### PR TITLE
fix: Use BASE_URL for service worker registration path

### DIFF
--- a/frontend/src/sw-registration.ts
+++ b/frontend/src/sw-registration.ts
@@ -20,7 +20,7 @@ export async function registerServiceWorker(
   callbacks: ServiceWorkerCallbacks = {}
 ): Promise<ServiceWorkerRegistration | undefined> {
   if ('serviceWorker' in navigator && import.meta.env.PROD) {
-    const wb = new Workbox('/sw.js');
+    const wb = new Workbox(`${import.meta.env.BASE_URL}sw.js`);
 
     // Service worker waiting (update available) - T019
     wb.addEventListener('waiting', () => {


### PR DESCRIPTION
The service worker was being registered at root (/sw.js) instead of respecting the base path (/musicore/sw.js for GitHub Pages). This caused registration failures on GitHub Pages project sites.

Changed from hardcoded /sw.js to ${import.meta.env.BASE_URL}sw.js to properly resolve the service worker path based on Vite base configuration.