### PR TITLE
fix: use BASE_URL for demo path in production

### DIFF
--- a/frontend/src/services/onboarding/config.ts
+++ b/frontend/src/services/onboarding/config.ts
@@ -21,8 +21,9 @@ export const ONBOARDING_CONFIG: OnboardingConfig = {
   /**
    * Path to bundled demo MusicXML file
    * File is copied to public/demo/ during build
+   * Uses Vite's BASE_URL to work with GitHub Pages deployment
    */
-  demoBundlePath: '/demo/CanonD.musicxml',
+  demoBundlePath: `${import.meta.env.BASE_URL}demo/CanonD.musicxml`,
   
   /**
    * Whether to show "Reload Demo" UI


### PR DESCRIPTION
Fixes "Demo not found" error on GitHub Pages deployment by using import.meta.env.BASE_URL to construct demo file path.

Local: /demo/CanonD.musicxml (BASE_URL = "/")
Production: /musicore/demo/CanonD.musicxml (BASE_URL = "/musicore/")

Resolves issue where absolute path /demo/CanonD.musicxml failed on GitHub Pages project deployment.