### PR TITLE
fix: Bass clef rendering and schema versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ See repository root for license information.
 
 ---
 
-**Version**: 1.0  
+**Version**: [1.0](https://github.com/aylabs/musicore)  
 **Last Updated**: 2026-02-11  
 **Status**: ✅ PWA deployed to GitHub Pages  
 **Test Coverage**: 596 tests (563 passing, 9 pre-existing failures, 24 skipped)

--- a/backend/src/adapters/api/handlers.rs
+++ b/backend/src/adapters/api/handlers.rs
@@ -7,6 +7,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use crate::adapters::dtos::{ScoreDto, InstrumentDto, StaffDto};
 use crate::domain::{
     errors::{DomainError, PersistenceError},
     events::{
@@ -42,74 +43,7 @@ pub struct ScoreListResponse {
     pub scores: Vec<String>, // UUIDs as strings
 }
 
-// ===== Response DTOs with computed fields (Feature 007) =====
-
-/// DTO for Staff with active_clef field derived from first ClefEvent
-#[derive(Debug, Serialize)]
-pub struct StaffDto {
-    pub id: String,
-    pub active_clef: Clef,  // NEW: Derived from first ClefEvent
-    pub staff_structural_events: Vec<StaffStructuralEvent>,
-    pub voices: Vec<Voice>,
-}
-
-impl From<&Staff> for StaffDto {
-    fn from(staff: &Staff) -> Self {
-        // Find first ClefEvent in staff_structural_events, default to Treble
-        let active_clef = staff.staff_structural_events
-            .iter()
-            .find_map(|event| match event {
-                StaffStructuralEvent::Clef(clef_event) => Some(clef_event.clef),
-                _ => None,
-            })
-            .unwrap_or(Clef::Treble);
-        
-        Self {
-            id: staff.id.to_string(),
-            active_clef,
-            staff_structural_events: staff.staff_structural_events.clone(),
-            voices: staff.voices.clone(),
-        }
-    }
-}
-
-/// DTO for Instrument containing StaffDtos
-#[derive(Debug, Serialize)]
-pub struct InstrumentDto {
-    pub id: String,
-    pub name: String,
-    pub instrument_type: String,
-    pub staves: Vec<StaffDto>,
-}
-
-impl From<&Instrument> for InstrumentDto {
-    fn from(instrument: &Instrument) -> Self {
-        Self {
-            id: instrument.id.to_string(),
-            name: instrument.name.clone(),
-            instrument_type: instrument.instrument_type.clone(),
-            staves: instrument.staves.iter().map(StaffDto::from).collect(),
-        }
-    }
-}
-
-/// DTO for Score containing InstrumentDtos
-#[derive(Debug, Serialize)]
-pub struct ScoreDto {
-    pub id: String,
-    pub global_structural_events: Vec<GlobalStructuralEvent>,
-    pub instruments: Vec<InstrumentDto>,
-}
-
-impl From<&Score> for ScoreDto {
-    fn from(score: &Score) -> Self {
-        Self {
-            id: score.id.to_string(),
-            global_structural_events: score.global_structural_events.clone(),
-            instruments: score.instruments.iter().map(InstrumentDto::from).collect(),
-        }
-    }
-}
+// Note: ScoreDto, InstrumentDto, and StaffDto are now imported from shared adapters::dtos module
 
 #[derive(Debug, Deserialize)]
 pub struct AddInstrumentRequest {

--- a/backend/src/adapters/dtos.rs
+++ b/backend/src/adapters/dtos.rs
@@ -1,0 +1,95 @@
+// Shared DTOs for API and WASM adapters
+// These DTOs add computed fields like active_clef to domain entities
+
+use serde::{Deserialize, Serialize};
+use crate::domain::{
+    score::Score,
+    instrument::Instrument,
+    staff::Staff,
+    voice::Voice,
+    value_objects::Clef,
+    events::{
+        global::GlobalStructuralEvent,
+        staff::StaffStructuralEvent,
+    },
+};
+
+// ===== Response DTOs with computed fields (Feature 007) =====
+
+/// DTO for Staff with active_clef field derived from first ClefEvent
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StaffDto {
+    pub id: String,
+    pub active_clef: Clef,  // NEW: Derived from first ClefEvent
+    pub staff_structural_events: Vec<StaffStructuralEvent>,
+    pub voices: Vec<Voice>,
+}
+
+impl From<&Staff> for StaffDto {
+    fn from(staff: &Staff) -> Self {
+        // Find first ClefEvent in staff_structural_events, default to Treble
+        let active_clef = staff.staff_structural_events
+            .iter()
+            .find_map(|event| match event {
+                StaffStructuralEvent::Clef(clef_event) => Some(clef_event.clef),
+                _ => None,
+            })
+            .unwrap_or(Clef::Treble);
+        
+        Self {
+            id: staff.id.to_string(),
+            active_clef,
+            staff_structural_events: staff.staff_structural_events.clone(),
+            voices: staff.voices.clone(),
+        }
+    }
+}
+
+/// DTO for Instrument containing StaffDtos
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InstrumentDto {
+    pub id: String,
+    pub name: String,
+    pub instrument_type: String,
+    pub staves: Vec<StaffDto>,
+}
+
+impl From<&Instrument> for InstrumentDto {
+    fn from(instrument: &Instrument) -> Self {
+        Self {
+            id: instrument.id.to_string(),
+            name: instrument.name.clone(),
+            instrument_type: instrument.instrument_type.clone(),
+            staves: instrument.staves.iter().map(StaffDto::from).collect(),
+        }
+    }
+}
+
+/// Schema version for the Score DTO structure
+/// Increment when adding/changing fields (e.g., active_clef added in v2)
+const SCORE_SCHEMA_VERSION: u32 = 2;
+
+/// DTO for Score containing InstrumentDtos with schema versioning
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ScoreDto {
+    pub id: String,
+    
+    /// Schema version for data structure evolution
+    /// v1: Original structure
+    /// v2: Added active_clef to StaffDto
+    pub schema_version: u32,
+    
+    pub global_structural_events: Vec<GlobalStructuralEvent>,
+    pub instruments: Vec<InstrumentDto>,
+}
+
+impl From<&Score> for ScoreDto {
+    fn from(score: &Score) -> Self {
+        Self {
+            id: score.id.to_string(),
+            schema_version: SCORE_SCHEMA_VERSION,
+            global_structural_events: score.global_structural_events.clone(),
+            instruments: score.instruments.iter().map(InstrumentDto::from).collect(),
+        }
+    }
+}

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -1,6 +1,9 @@
 // Adapters will be added as needed
 pub mod persistence;
 
+// Shared DTOs for both API and WASM adapters
+pub mod dtos;
+
 // API adapter only for native backend (uses axum, tower, not available in WASM)
 #[cfg(not(target_arch = "wasm32"))]
 pub mod api;

--- a/backend/src/adapters/wasm/bindings.rs
+++ b/backend/src/adapters/wasm/bindings.rs
@@ -3,6 +3,7 @@
 
 use wasm_bindgen::prelude::*;
 use crate::domain::importers::musicxml::{MusicXMLParser, MusicXMLConverter};
+use crate::adapters::dtos::ScoreDto;
 use super::error_handling::import_error_to_js;
 
 // ============================================================================
@@ -29,8 +30,11 @@ pub fn parse_musicxml(xml_content: &str) -> Result<JsValue, JsValue> {
     let score = MusicXMLConverter::convert(doc)
         .map_err(import_error_to_js)?;
     
-    // Serialize Score to JsValue for JavaScript
-    serde_wasm_bindgen::to_value(&score)
+    // Convert to DTO with active_clef field (same as API handlers)
+    let score_dto = ScoreDto::from(&score);
+    
+    // Serialize ScoreDto to JsValue for JavaScript
+    serde_wasm_bindgen::to_value(&score_dto)
         .map_err(|e| {
             JsValue::from_str(&format!("Serialization error: {}", e))
         })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,7 +61,22 @@ function App() {
     return (
       <div className="app">
         <header className="app-header">
-          <h1>🎵 Musicore</h1>
+          <h1>
+            🎵 Musicore{' '}
+            <a 
+              href="https://github.com/aylabs/musicore" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              style={{ 
+                fontSize: '0.5em', 
+                color: '#999', 
+                fontWeight: 'normal',
+                textDecoration: 'none'
+              }}
+            >
+              v{packageJson.version}
+            </a>
+          </h1>
         </header>
         <main style={{ 
           display: 'flex', 
@@ -83,7 +98,22 @@ function App() {
     return (
       <div className="app">
         <header className="app-header">
-          <h1>🎵 Musicore</h1>
+          <h1>
+            🎵 Musicore{' '}
+            <a 
+              href="https://github.com/aylabs/musicore" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              style={{ 
+                fontSize: '0.5em', 
+                color: '#999', 
+                fontWeight: 'normal',
+                textDecoration: 'none'
+              }}
+            >
+              v{packageJson.version}
+            </a>
+          </h1>
         </header>
         <main style={{ 
           display: 'flex', 
@@ -147,7 +177,22 @@ function App() {
             </div>
           )}
           <header className="app-header">
-            <h1>🎵 Musicore <span style={{ fontSize: '0.5em', color: '#999', fontWeight: 'normal' }}>v{packageJson.version}</span></h1>
+            <h1>
+              🎵 Musicore{' '}
+              <a 
+                href="https://github.com/aylabs/musicore" 
+                target="_blank" 
+                rel="noopener noreferrer"
+                style={{ 
+                  fontSize: '0.5em', 
+                  color: '#999', 
+                  fontWeight: 'normal',
+                  textDecoration: 'none'
+                }}
+              >
+                v{packageJson.version}
+              </a>
+            </h1>
           </header>
           <main>
             <ScoreViewer 

--- a/frontend/src/components/ScoreViewer.tsx
+++ b/frontend/src/components/ScoreViewer.tsx
@@ -153,7 +153,13 @@ export function ScoreViewer({
     setError(null);
     try {
       // Get demo score from IndexedDB
-      const demoScore = await demoLoaderService.getDemoScore();
+      let demoScore = await demoLoaderService.getDemoScore();
+      
+      if (!demoScore) {
+        // Demo might have outdated schema - reload it
+        console.log('[ScoreViewer] Demo not found or outdated, reloading...');
+        demoScore = await demoLoaderService.loadBundledDemo();
+      }
       
       if (!demoScore) {
         setError("Demo not found. Try refreshing the page.");

--- a/frontend/src/components/notation/NotationRenderer.tsx
+++ b/frontend/src/components/notation/NotationRenderer.tsx
@@ -28,7 +28,7 @@ export interface NotationRendererProps {
   /** Callback when note is clicked (User Story 3) */
   onNoteClick?: (noteId: string) => void;
   
-  /** Current horizontal scroll position (for fixed clef positioning) */
+  /** Current horizontal scroll position (deprecated - clef no longer sticky) */
   scrollX?: number;
   
   /** Whether to show the clef (Feature 009: hide during auto-scroll to prevent flickering) */
@@ -52,7 +52,7 @@ const NotationRendererComponent: React.FC<NotationRendererProps> = ({
   layout,
   selectedNoteId = null,
   onNoteClick,
-  scrollX = 0,
+  scrollX: _scrollX = 0, // Unused - clef no longer sticky
   showClef = true,
   notes = [],
   pixelsPerTick = 0.1,
@@ -107,23 +107,21 @@ const NotationRendererComponent: React.FC<NotationRendererProps> = ({
         />
       ))}
 
-      {/* Clef symbol - Feature 009: Hide during auto-scroll to prevent flickering */}
+      {/* Clef symbol - Shown only at start of staff (fixed position, not sticky) */}
       {showClef && (
-        <g style={{ transform: `translateX(${scrollX}px)`, willChange: 'transform' }}>
-          <text
-            data-testid={`clef-${layout.clef.type}`}
-            x={layout.clef.x}
-            y={layout.clef.y}
-            fontSize={layout.clef.fontSize}
-            fontFamily="Bravura"
-            fill="black"
-            textAnchor="middle"
-            dominantBaseline="central"
-            opacity={0.60}
-          >
-            {layout.clef.glyphCodepoint}
-          </text>
-        </g>
+        <text
+          data-testid={`clef-${layout.clef.type}`}
+          x={layout.clef.x}
+          y={layout.clef.y}
+          fontSize={layout.clef.fontSize}
+          fontFamily="Bravura"
+          fill="black"
+          textAnchor="middle"
+          dominantBaseline="central"
+          opacity={0.60}
+        >
+          {layout.clef.glyphCodepoint}
+        </text>
       )}
 
       {/* Note heads (positioned SMuFL glyphs) - T055: Virtual scrolling */}

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -135,6 +135,14 @@ export function useOnboarding(wasmReady: boolean = false): OnboardingHookResult 
         if (demoScore && mounted) {
           setDemoScoreId(demoScore.id);
           console.log(`[useOnboarding] Loaded demo score ID for returning user: ${demoScore.id}`);
+        } else if (!demoScore && mounted) {
+          // Demo might have outdated schema - reload it
+          console.log('[useOnboarding] Demo not found or outdated, reloading...');
+          const reloadedDemo = await demoLoaderService.loadBundledDemo();
+          if (reloadedDemo && mounted) {
+            setDemoScoreId(reloadedDemo.id);
+            console.log(`[useOnboarding] Reloaded demo with new schema: ${reloadedDemo.id}`);
+          }
         }
       } catch (error) {
         console.error('[useOnboarding] Failed to load demo score ID:', error);

--- a/frontend/src/services/file/FileService.ts
+++ b/frontend/src/services/file/FileService.ts
@@ -1,4 +1,5 @@
 import type { Score } from '../../types/score';
+import { CURRENT_SCHEMA_VERSION } from '../storage/local-storage';
 
 /**
  * Save a score to a JSON file using browser download
@@ -138,6 +139,7 @@ export function loadScore(file: File): Promise<Score> {
 export function createNewScore(): Score {
   return {
     id: crypto.randomUUID(),
+    schema_version: CURRENT_SCHEMA_VERSION,
     global_structural_events: [
       {
         Tempo: {

--- a/frontend/src/services/onboarding/config.ts
+++ b/frontend/src/services/onboarding/config.ts
@@ -26,6 +26,12 @@ export const ONBOARDING_CONFIG: OnboardingConfig = {
   demoBundlePath: `${import.meta.env.BASE_URL}demo/CanonD.musicxml`,
   
   /**
+   * Demo schema version - increment when data structure changes
+   * Forces reload of cached demo to pick up new fields (e.g., active_clef)
+   */
+  demoSchemaVersion: 2,
+  
+  /**
    * Whether to show "Reload Demo" UI
    * false for MVP/P1, true for P3 feature
    */

--- a/frontend/src/services/onboarding/types.ts
+++ b/frontend/src/services/onboarding/types.ts
@@ -89,6 +89,9 @@ export interface DemoScoreMetadata extends Score {
   
   /** ISO 8601 timestamp when score was loaded into library */
   loadedDate: string;
+  
+  /** Schema version of the demo data structure */
+  schemaVersion?: number;
 }
 
 // ============================================================================
@@ -105,6 +108,9 @@ export interface OnboardingConfig {
   
   /** Path to bundled demo MusicXML file */
   demoBundlePath: string;
+  
+  /** Demo schema version - increment when data structure changes */
+  demoSchemaVersion: number;
   
   /** Whether to show "Reload Demo" UI (false for MVP/P1, true for P3) */
   enableDemoReload: boolean;

--- a/frontend/src/types/score.ts
+++ b/frontend/src/types/score.ts
@@ -126,6 +126,10 @@ export interface Instrument {
 /** Score is the aggregate root containing all musical elements */
 export interface Score {
   id: string; // UUID
+  
+  /** Schema version for data structure evolution (v2 added active_clef) */
+  schema_version: number;
+  
   global_structural_events: GlobalStructuralEvent[];
   instruments: Instrument[];
 }


### PR DESCRIPTION
- Create shared adapters/dtos module for API and WASM consistency
- Add active_clef field calculation from ClefEvent in StaffDto
- Implement Score schema versioning (v2) across backend and frontend
- Add CURRENT_SCHEMA_VERSION constant and compatibility checking
- Auto-reload outdated demos with schema version mismatch
- Add getAllScoresFromIndexedDBUnfiltered for cleanup operations
- Export CURRENT_SCHEMA_VERSION for use in FileService
- Add schema_version field to createNewScore()
- Make clef symbols non-sticky (render only at staff start)
- Add GitHub link to version number in app banner

Fixes bass clef displaying as treble clef issue.
Implements comprehensive data evolution strategy for Score schema changes.