### PR TITLE
fix: Remove mobile tap highlight flicker in stacked view

### DIFF
--- a/frontend/src/components/stacked/StackedStaffView.css
+++ b/frontend/src/components/stacked/StackedStaffView.css
@@ -10,7 +10,10 @@
   /* Tablet: Tapping background toggles playback */
   cursor: pointer;
   user-select: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.05);
+  /* Remove tap highlight on mobile devices */
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  touch-action: manipulation;
 }
 
 .stacked-staff-scroll-container {


### PR DESCRIPTION
- Change -webkit-tap-highlight-color from rgba(0,0,0,0.05) to transparent
- Add -webkit-touch-callout: none to prevent iOS callout menu
- Add touch-action: manipulation to disable double-tap zoom delay

Improves tablet/phone UX by removing visual flash when tapping to play/pause.