### PR TITLE
UI improvements and MusicXML import fix

### DIFF
--- a/frontend/src/components/ScoreViewer.css
+++ b/frontend/src/components/ScoreViewer.css
@@ -156,7 +156,27 @@
   border-radius: 4px;
 }
 
-/* Score page action buttons - matching initial screen styling */
+/* Score toolbar - Import (left) and View Mode Selector (right) on same line */
+.score-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  padding: 15px 0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.toolbar-left {
+  display: flex;
+  align-items: center;
+}
+
+.toolbar-right {
+  display: flex;
+  align-items: center;
+}
+
+/* Legacy score-actions styling - kept for backward compatibility */
 .score-actions {
   display: flex;
   gap: 10px;

--- a/frontend/src/components/import/ImportButton.tsx
+++ b/frontend/src/components/import/ImportButton.tsx
@@ -151,6 +151,13 @@ export function ImportButton({
       {/* Display success message with statistics */}
       {result && !error && (
         <div className="import-status import-success" role="status">
+          <button
+            className="close-button"
+            onClick={reset}
+            aria-label="Close success message"
+          >
+            ×
+          </button>
           <p className="success-message">
             <strong>✓ Import Successful!</strong>
           </p>

--- a/frontend/src/components/stacked/ViewModeSelector.css
+++ b/frontend/src/components/stacked/ViewModeSelector.css
@@ -4,8 +4,6 @@
 .view-mode-selector {
   display: flex;
   gap: 10px;
-  margin-bottom: 20px;
-  justify-content: center;
 }
 
 .view-mode-button {

--- a/frontend/src/components/stacked/ViewModeSelector.test.tsx
+++ b/frontend/src/components/stacked/ViewModeSelector.test.tsx
@@ -12,19 +12,19 @@ describe('ViewModeSelector', () => {
     const onChange = vi.fn();
     render(<ViewModeSelector currentMode="individual" onChange={onChange} />);
 
-    expect(screen.getByText('Individual View')).toBeDefined();
-    expect(screen.getByText('Stacked View')).toBeDefined();
+    expect(screen.getByText('Instruments View')).toBeDefined();
+    expect(screen.getByText('Play View')).toBeDefined();
   });
 
   it('should highlight the active button', () => {
     const onChange = vi.fn();
     const { rerender } = render(<ViewModeSelector currentMode="individual" onChange={onChange} />);
 
-    const individualButton = screen.getByText('Individual View');
+    const individualButton = screen.getByText('Instruments View');
     expect(individualButton.classList.contains('active')).toBe(true);
 
     rerender(<ViewModeSelector currentMode="stacked" onChange={onChange} />);
-    const stackedButton = screen.getByText('Stacked View');
+    const stackedButton = screen.getByText('Play View');
     expect(stackedButton.classList.contains('active')).toBe(true);
   });
 
@@ -32,7 +32,7 @@ describe('ViewModeSelector', () => {
     const onChange = vi.fn();
     render(<ViewModeSelector currentMode="individual" onChange={onChange} />);
 
-    const stackedButton = screen.getByText('Stacked View');
+    const stackedButton = screen.getByText('Play View');
     fireEvent.click(stackedButton);
 
     expect(onChange).toHaveBeenCalledWith('stacked');
@@ -42,7 +42,7 @@ describe('ViewModeSelector', () => {
     const onChange = vi.fn();
     render(<ViewModeSelector currentMode="individual" onChange={onChange} />);
 
-    const individualButton = screen.getByText('Individual View');
+    const individualButton = screen.getByText('Instruments View');
     fireEvent.click(individualButton);
 
     expect(onChange).toHaveBeenCalledWith('individual');

--- a/frontend/src/components/stacked/ViewModeSelector.tsx
+++ b/frontend/src/components/stacked/ViewModeSelector.tsx
@@ -1,5 +1,5 @@
 /**
- * ViewModeSelector - Toggle between Individual and Stacked view modes
+ * ViewModeSelector - Toggle between Instruments and Play view modes
  * Feature 010: Stacked Staves View - User Story 1
  */
 
@@ -18,16 +18,16 @@ export function ViewModeSelector({ currentMode, onChange }: ViewModeSelectorProp
       <button 
         className={`view-mode-button ${currentMode === 'individual' ? 'active' : ''}`}
         onClick={() => onChange('individual')}
-        aria-label="Switch to individual view"
+        aria-label="Switch to instruments view"
       >
-        Individual View
+        Instruments View
       </button>
       <button 
         className={`view-mode-button ${currentMode === 'stacked' ? 'active' : ''}`}
         onClick={() => onChange('stacked')}
-        aria-label="Switch to stacked view"
+        aria-label="Switch to play view"
       >
-        Stacked View
+        Play View
       </button>
     </div>
   );


### PR DESCRIPTION
- Remove Load button from Individual View (Feature 014)
- Add close button to Import success banner
- Reorganize toolbar: Import (left) and View Mode toggle (right)
- Rename view modes: Individual View → Instruments View, Stacked View → Play View
- Fix .mxl import: extract score.xml instead of container.xml
- Support container.xml parsing to find main MusicXML file
- Update ViewModeSelector tests for new button labels