### PR TITLE
fix(playback): Resolve mobile jitter and enable network testing

### DIFF
--- a/frontend/src/services/playback/MusicTimeline.ts
+++ b/frontend/src/services/playback/MusicTimeline.ts
@@ -68,10 +68,9 @@ export function usePlayback(notes: Note[], tempo: number): PlaybackState {
     status: 'stopped' as PlaybackStatus,
   });
 
-  // Keep tick source status in sync (after render)
-  useEffect(() => {
-    tickSourceRef.current = { ...tickSourceRef.current, status };
-  }, [status]);
+  // Keep tick source status in sync (must happen during render for immediate sync)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  tickSourceRef.current = { ...tickSourceRef.current, status };
   
   // Feature 022: Calculate total duration from all notes
   const totalDurationTicks = useMemo(() => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
   // For project pages: base: '/repository-name/'
   base: process.env.VITE_BASE || '/',
   
+  // Dev server configuration - listen on all interfaces for mobile testing
+  server: {
+    host: '0.0.0.0',  // Listen on all network interfaces
+    port: 5173,       // Default Vite port
+  },
+  
   plugins: [
     react(),
     // PWA plugin configuration


### PR DESCRIPTION
1. Revert tickSource status sync to synchronous (during render)
   - The useEffect approach introduced 1-frame delay where rAF could read stale status from tickSourceRef.current
   - For timing-critical playback sync, the ref must be updated synchronously during render, not after
   - Added eslint-disable-next-line with justification

2. Configure Vite dev server to listen on all network interfaces
   - Added server.host: '0.0.0.0' to enable mobile device testing
   - Allows accessing dev server from phones on same network
   - Critical for testing mobile jitter fixes in real conditions

These changes address mobile playback jitter regression introduced by ESLint fixes and enable proper mobile testing workflow.