### PR TITLE
feat: sticky playback controls bar in play view

### DIFF
--- a/frontend/src/components/LayoutRenderer.css
+++ b/frontend/src/components/LayoutRenderer.css
@@ -82,7 +82,7 @@ text.layout-glyph {
 }
 
 text.layout-glyph.highlighted {
-  transform: scale(1.3) !important;
+  transform: scale(1.2) !important;
 }
 
 /**
@@ -98,7 +98,7 @@ text.layout-glyph.highlighted {
 }
 
 text.layout-glyph.pinned {
-  transform: scale(1.3) !important;
+  transform: scale(1.2) !important;
 }
 
 /**

--- a/frontend/src/components/playback/PlaybackControls.css
+++ b/frontend/src/components/playback/PlaybackControls.css
@@ -169,6 +169,12 @@
   justify-content: flex-start;
   align-items: center;
   gap: 12px;
+  /* Stick to the top of the viewport during vertical scroll in play view */
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-radius: 0;           /* flat edges when pinned to viewport top */
+  border-bottom: 1px solid #ddd;
 }
 
 .playback-controls.compact .playback-buttons {


### PR DESCRIPTION
Add position:sticky; top:0 to .playback-controls.compact so the controls bar stays visible at the top of the viewport as the user scrolls down through the score.

- z-index:100 keeps it above SVG score elements
- border-radius:0 + border-bottom give a clean flat edge when pinned
- The existing OfflineBanner padding-top rule is unchanged and still works: the sticky bar sits at top:0 with padding-top:48px pushing buttons below the fixed banner