### PR TITLE
fix(load-score): enter fullscreen when loading score via dialog

### DIFF
--- a/frontend/src/components/ScoreViewer.tsx
+++ b/frontend/src/components/ScoreViewer.tsx
@@ -506,6 +506,7 @@ export function ScoreViewer({
           open={dialogOpen}
           onClose={() => setDialogOpen(false)}
           onImportComplete={handleDialogImportComplete}
+          onWillLoad={() => document.documentElement.requestFullscreen?.().catch(() => {})}
         />
       </div>
     );
@@ -650,6 +651,7 @@ export function ScoreViewer({
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}
         onImportComplete={handleDialogImportComplete}
+        onWillLoad={() => document.documentElement.requestFullscreen?.().catch(() => {})}
       />
     </div>
   );

--- a/frontend/src/components/load-score/LoadNewScoreButton.tsx
+++ b/frontend/src/components/load-score/LoadNewScoreButton.tsx
@@ -6,6 +6,9 @@ import type { ImportResult } from '../../services/import/MusicXMLImportService';
 interface LoadNewScoreButtonProps {
   onImportComplete: (result: ImportResult) => void;
   disabled?: boolean;
+  /** Called synchronously at the start of the file-change gesture, before any async work.
+   * Use this to call requestFullscreen() while still inside the user-gesture window. */
+  onWillLoad?: () => void;
 }
 
 /**
@@ -16,6 +19,7 @@ interface LoadNewScoreButtonProps {
 export function LoadNewScoreButton({
   onImportComplete,
   disabled = false,
+  onWillLoad,
 }: LoadNewScoreButtonProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -34,6 +38,9 @@ export function LoadNewScoreButton({
   const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
+      // Call before the first await so we're still inside the browser's user-gesture window.
+      // This allows requestFullscreen() to succeed (Safari/Firefox are strict about this).
+      onWillLoad?.();
       await importFile(file);
     }
     // reset so the same file can be re-selected

--- a/frontend/src/components/load-score/LoadScoreDialog.tsx
+++ b/frontend/src/components/load-score/LoadScoreDialog.tsx
@@ -11,6 +11,10 @@ interface LoadScoreDialogProps {
   open: boolean;
   onClose: () => void;
   onImportComplete: (result: ImportResult) => void;
+  /** Called synchronously at the very start of any load gesture (preset click or file select),
+   * before async work begins. Use this to call requestFullscreen() while still inside the
+   * browser's user-gesture window (Safari / Firefox require this). */
+  onWillLoad?: () => void;
 }
 
 /**
@@ -20,7 +24,7 @@ interface LoadScoreDialogProps {
  *
  * Feature 028: Load Score Dialog — User Stories 2–5.
  */
-export function LoadScoreDialog({ open, onClose, onImportComplete }: LoadScoreDialogProps) {
+export function LoadScoreDialog({ open, onClose, onImportComplete, onWillLoad }: LoadScoreDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
@@ -68,6 +72,9 @@ export function LoadScoreDialog({ open, onClose, onImportComplete }: LoadScoreDi
    * Feature 028, US3 (T017).
    */
   const loadPresetScore = async (score: PreloadedScore) => {
+    // Call before the first await so we're still inside the browser's user-gesture window.
+    // This allows requestFullscreen() to succeed (Safari / Firefox are strict about this).
+    onWillLoad?.();
     setSelectedId(score.id);
     setPresetError(null);
     setPresetLoading(true);
@@ -135,6 +142,7 @@ export function LoadScoreDialog({ open, onClose, onImportComplete }: LoadScoreDi
           <LoadNewScoreButton
             onImportComplete={handleLocalImportComplete}
             disabled={isBusy}
+            onWillLoad={onWillLoad}
           />
         </section>
       </div>


### PR DESCRIPTION
Browsers require requestFullscreen() to be called synchronously within the user-gesture event handler, before any awaits. The ViewModeSelector path was correct (called in onClick), but the Load Score dialog path called setViewMode('layout') only after async fetch + WASM parse completed - too late for Safari/Firefox.

Fix: add onWillLoad callback to LoadScoreDialog and LoadNewScoreButton. It fires synchronously at the very start of each gesture handler (before the first await), while still inside the user-gesture window. ScoreViewer passes requestFullscreen() as onWillLoad to both dialog instances, so loading a preset or a local file now reliably enters fullscreen in all browsers.