### PR TITLE
fix: use BASE_URL for AudioWorklet path to fix 'Failed to load audio …

### DIFF
--- a/frontend/src/services/recording/useAudioRecorder.ts
+++ b/frontend/src/services/recording/useAudioRecorder.ts
@@ -168,8 +168,11 @@ export function useAudioRecorder(
     const audioCtx = new AudioContext({ sampleRate: 44100 });
 
     // 3. Load AudioWorklet
+    // Use import.meta.env.BASE_URL so the path is correct on both local dev
+    // (base '/') and GitHub Pages (base '/musicore/'). A hardcoded leading '/'
+    // would skip the sub-path and produce a 404 on the deployed site.
     try {
-      await audioCtx.audioWorklet.addModule('/audio-processor.worklet.js');
+      await audioCtx.audioWorklet.addModule(`${import.meta.env.BASE_URL}audio-processor.worklet.js`);
     } catch {
       teardown();
       stream.getTracks().forEach((t) => t.stop());


### PR DESCRIPTION
…processor' on GitHub Pages

Hardcoded '/audio-processor.worklet.js' resolves relative to the origin root, so on GitHub Pages (base /musicore/) the browser requests /audio-processor.worklet.js (404) instead of /musicore/audio-processor.worklet.js.

Replace with import.meta.env.BASE_URL which Vite substitutes with the configured base path at build time: '/' locally, '/musicore/' on Pages.