### PR TITLE
feat(030): Plugin Architecture - versioned Plugin API with Virtual Keyboard and audio playback

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -59,6 +59,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-06
 - TypeScript (strict), React 18, Vite + `computeLayout` / `GlobalLayout` (`wasm/layout.ts`), `LayoutRenderer` (`components/LayoutRenderer.tsx`), `buildSourceToNoteIdMap` pattern from `services/highlight/sourceMapping.ts` (001-practice-rust-layout)
 - N/A — all data is in-memory per practice session (001-practice-rust-layout)
 - TypeScript 5.9 / React 19.2 / Vite 7.x + Web MIDI API (`navigator.requestMIDIAccess` — no npm library), existing `useAudioRecorder` hook pattern (029-midi-input)
+- TypeScript 5.x, React 18, Vite + React 18 (error boundary API), `fflate` (ZIP extraction, ~8 KB gz), `idb` v8 (IndexedDB, ~1.7 KB gz), ESLint flat config (`no-restricted-imports`) (030-plugin-architecture)
+- IndexedDB (plugin registry — manifests + asset blobs; persists across PWA sessions) (030-plugin-architecture)
 
 - Rust (latest stable 1.75+) + serde 1.0+, serde_json 1.0+ (serialization), thiserror 1.0+ (errors); web framework TBD in contracts phase (axum or actix-web) (001-score-model)
 
@@ -79,9 +81,9 @@ cargo test [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECH
 Rust (latest stable 1.75+): Follow standard conventions
 
 ## Recent Changes
+- 030-plugin-architecture: Added TypeScript 5.x, React 18, Vite + React 18 (error boundary API), `fflate` (ZIP extraction, ~8 KB gz), `idb` v8 (IndexedDB, ~1.7 KB gz), ESLint flat config (`no-restricted-imports`)
 - 029-midi-input: Added TypeScript 5.9 / React 19.2 / Vite 7.x + Web MIDI API (`navigator.requestMIDIAccess` — no npm library), existing `useAudioRecorder` hook pattern
 - 001-practice-rust-layout: Added TypeScript (strict), React 18, Vite + `computeLayout` / `GlobalLayout` (`wasm/layout.ts`), `LayoutRenderer` (`components/LayoutRenderer.tsx`), `buildSourceToNoteIdMap` pattern from `services/highlight/sourceMapping.ts`
-- 001-piano-practice: Added TypeScript 5 / React 18, Node 22 + Vite 6, Vitest 2, @testing-library/react, pitchy (already installed), existing `NotationLayoutEngine` + `NotationRenderer` WASM modules
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1,0 +1,376 @@
+# Musicore Plugin Development Guide
+
+Plugins extend Musicore with new UI views and interactive musical tools. They run inside the application as trusted React components and communicate with the host through a versioned Plugin API.
+
+---
+
+## Table of Contents
+
+1. [Concepts](#concepts)
+2. [Plugin API reference](#plugin-api-reference)
+3. [Creating a builtin plugin](#creating-a-builtin-plugin)
+4. [Creating an importable plugin (ZIP package)](#creating-an-importable-plugin-zip-package)
+5. [API constraints and ESLint boundary](#api-constraints-and-eslint-boundary)
+6. [Testing your plugin](#testing-your-plugin)
+7. [Reference: Virtual Keyboard plugin](#reference-virtual-keyboard-plugin)
+
+---
+
+## Concepts
+
+| Term | Meaning |
+|---|---|
+| **Plugin** | A self-contained feature that adds a new view to the Musicore navigation bar |
+| **Builtin plugin** | Bundled with the repository; always available without installation |
+| **Imported plugin** | Packaged as a ZIP file by a third-party developer and installed by the user at runtime |
+| **Plugin API** | The only public surface a plugin may import — `frontend/src/plugin-api/index.ts` |
+| **PluginContext** | Host-provided object injected into `init()`: the only channel from plugin → host |
+
+---
+
+## Plugin API reference
+
+All public types are exported from `frontend/src/plugin-api/index.ts`. This is the **only** file a plugin is permitted to import from the host.
+
+### `MusicorePlugin`
+
+The interface your plugin's default export must satisfy.
+
+```typescript
+import type { MusicorePlugin, PluginContext } from '../../src/plugin-api/index';
+
+const plugin: MusicorePlugin = {
+  /** Called once on app startup. Store context for use inside Component. */
+  init(context: PluginContext): void { ... },
+
+  /** Optional. Called when the plugin is unregistered. Release resources here. */
+  dispose?(): void { ... },
+
+  /** Root React component rendered when the plugin's nav entry is active. */
+  Component: () => <div>My Plugin</div>,
+};
+
+export default plugin;
+```
+
+### `PluginContext`
+
+Injected by the host into `init()`. Store it in a module-level variable and pass it to your component.
+
+```typescript
+interface PluginContext {
+  /**
+   * Send a note event to the host WASM layout pipeline.
+   * Use this to record notes the user plays on the musical staff.
+   */
+  emitNote(event: PluginNoteEvent): void;
+
+  /**
+   * Play a note through the host audio engine (Salamander Grand Piano samples).
+   * This is the only authorised route for audio — do NOT import Tone.js directly.
+   *
+   *   type: 'attack'   — note-on  (default when omitted)
+   *   type: 'release'  — note-off (release a sustained note)
+   */
+  playNote(event: PluginNoteEvent): void;
+
+  /** Read-only descriptor for this plugin instance. */
+  readonly manifest: Readonly<PluginManifest>;
+}
+```
+
+### `PluginNoteEvent`
+
+The event type used by both `emitNote` and `playNote`.
+
+```typescript
+interface PluginNoteEvent {
+  readonly midiNote: number;       // MIDI note number 0–127. Middle C = 60.
+  readonly timestamp: number;      // Date.now() at the moment of input.
+  readonly velocity?: number;      // 1–127. Defaults to 64 (mezzo-forte).
+  readonly type?: 'attack' | 'release'; // Defaults to 'attack'.
+}
+```
+
+### `PluginManifest`
+
+Read-only descriptor available via `context.manifest`. Populated from `plugin.json` plus `origin` set by the host.
+
+```typescript
+interface PluginManifest {
+  readonly id: string;
+  readonly name: string;
+  readonly version: string;
+  readonly pluginApiVersion: string;
+  readonly entryPoint: string;
+  readonly description?: string;
+  readonly origin: 'builtin' | 'imported';
+}
+```
+
+### `PLUGIN_API_VERSION`
+
+```typescript
+const PLUGIN_API_VERSION = '1';   // current version
+```
+
+---
+
+## Creating a builtin plugin
+
+Builtin plugins live in `frontend/plugins/<plugin-id>/` and are bundled at build time.
+
+### Step 1 — Create the folder structure
+
+```
+frontend/plugins/my-plugin/
+  plugin.json        # manifest
+  index.tsx          # MusicorePlugin default export (entry point)
+  MyPlugin.tsx       # React component(s)
+  MyPlugin.css       # styles (optional)
+  MyPlugin.test.tsx  # Vitest tests
+```
+
+### Step 2 — Write `plugin.json`
+
+```json
+{
+  "id": "my-plugin",
+  "name": "My Plugin",
+  "version": "1.0.0",
+  "pluginApiVersion": "1",
+  "entryPoint": "index.js",
+  "description": "What this plugin does."
+}
+```
+
+`id` must be unique across all plugins. `pluginApiVersion` must match `PLUGIN_API_VERSION` (`"1"`).  
+Do **not** include an `origin` field — the host sets it automatically.
+
+### Step 3 — Write `index.tsx`
+
+```tsx
+/* eslint-disable react-refresh/only-export-components */
+import type { MusicorePlugin, PluginContext } from '../../src/plugin-api/index';
+import { MyPlugin } from './MyPlugin';
+
+// Store context at module scope so the Component closure can access it.
+let _context: PluginContext | null = null;
+
+function MyPluginWithContext() {
+  if (!_context) return null;
+  return <MyPlugin context={_context} />;
+}
+
+const plugin: MusicorePlugin = {
+  init(context) {
+    _context = context;
+  },
+  dispose() {
+    _context = null;
+  },
+  Component: MyPluginWithContext,
+};
+
+export default plugin;
+```
+
+### Step 4 — Write your component
+
+```tsx
+import { useCallback } from 'react';
+import type { PluginContext } from '../../src/plugin-api/index';
+
+export function MyPlugin({ context }: { context: PluginContext }) {
+  const handlePlay = useCallback(() => {
+    // Play middle C via the host audio engine
+    context.playNote({ midiNote: 60, timestamp: Date.now(), type: 'attack' });
+    // Also record it on the score staff
+    context.emitNote({ midiNote: 60, timestamp: Date.now() });
+  }, [context]);
+
+  const handleRelease = useCallback(() => {
+    context.playNote({ midiNote: 60, timestamp: Date.now(), type: 'release' });
+  }, [context]);
+
+  return (
+    <button onMouseDown={handlePlay} onMouseUp={handleRelease}>
+      Play C4
+    </button>
+  );
+}
+```
+
+### Step 5 — Register in `builtinPlugins.ts`
+
+Edit `frontend/src/services/plugins/builtinPlugins.ts`:
+
+```typescript
+import myPlugin from '../../../plugins/my-plugin/index';
+import myPluginManifest from '../../../plugins/my-plugin/plugin.json';
+
+export const BUILTIN_PLUGINS: BuiltinPluginEntry[] = [
+  // ... existing plugins ...
+  {
+    manifest: {
+      ...(myPluginManifest as Omit<PluginManifest, 'origin'>),
+      origin: 'builtin' as const,
+    },
+    plugin: myPlugin,
+  },
+];
+```
+
+That's it — the plugin now appears in the navigation bar on the next `npm run dev`.
+
+---
+
+## Creating an importable plugin (ZIP package)
+
+Imported plugins are distributed as `.zip` files and installed by the user via the **Import Plugin** button in the Musicore UI. They are persisted in IndexedDB and survive reloads.
+
+> **Note**: Because importable plugins are loaded at runtime without a bundler, they must be pre-compiled to a single JavaScript file. This packaging step is the responsibility of the plugin developer.
+
+### ZIP structure
+
+```
+my-plugin.zip
+├── plugin.json     # required — manifest (same schema as above)
+└── index.js        # required — compiled/bundled ES module, default-exports MusicorePlugin
+```
+
+Both files must be at the **root** of the ZIP (no subdirectory nesting). The `entryPoint` field in `plugin.json` must match the JS filename exactly.
+
+### Validation rules
+
+The importer rejects ZIPs that fail any of the following checks:
+
+| Rule | Requirement |
+|---|---|
+| `plugin.json` present | ZIP must contain `plugin.json` at root |
+| Valid JSON | `plugin.json` must parse without errors |
+| Required fields | `id`, `name`, `version`, `pluginApiVersion`, `entryPoint` must all be present strings |
+| API version | `pluginApiVersion` must equal `"1"` |
+| Entry point present | The file named by `entryPoint` must exist in the ZIP |
+| No duplicate ID | If a plugin with the same `id` is already installed, the user is prompted to replace or cancel |
+
+### Building a plugin for distribution
+
+You can use any bundler. Here is a minimal example using `esbuild`:
+
+```bash
+# Install dependencies
+npm install --save-dev esbuild
+
+# Bundle to a single file (React must be available in the Musicore host — use externals)
+npx esbuild index.tsx \
+  --bundle \
+  --format=esm \
+  --external:react \
+  --external:react-dom \
+  --outfile=dist/index.js
+
+# Package
+zip my-plugin.zip plugin.json dist/index.js --junk-paths
+```
+
+> React is provided by the Musicore host. Mark it external in your bundler config to avoid shipping a duplicate copy.
+
+---
+
+## API constraints and ESLint boundary
+
+These rules are enforced automatically by ESLint (`frontend/eslint.config.js`).
+
+### Permitted imports
+
+```typescript
+// ✅ Allowed — only the public API barrel
+import type { MusicorePlugin, PluginContext, PluginNoteEvent } from '../../src/plugin-api/index';
+```
+
+### Forbidden imports
+
+```typescript
+// ❌ Forbidden — direct access to host internals
+import { ToneAdapter } from '../../src/services/playback/ToneAdapter';
+import { ScoreViewer }  from '../../src/components/ScoreViewer';
+import { someUtil }     from '../../src/utils/someUtil';
+```
+
+### Forbidden direct audio access
+
+```typescript
+// ❌ Forbidden — plugins must not use Tone.js or Web Audio API directly
+import * as Tone from 'tone';
+const ctx = new AudioContext();
+```
+
+Use `context.playNote()` instead. The host manages the audio engine (Tone.js + Salamander Grand Piano samples) and enforces a single, shared AudioContext.
+
+### Constitution Principle VI
+
+`PluginNoteEvent` carries **musical data only** (`midiNote`, `timestamp`, `velocity`). Never add coordinate or layout fields — the WASM engine is the sole authority over all spatial layout.
+
+---
+
+## Testing your plugin
+
+Write Vitest tests alongside your component. Mock `PluginContext` to keep tests fast and isolated:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { MyPlugin } from './MyPlugin';
+import type { PluginContext, PluginManifest } from '../../src/plugin-api/index';
+
+function makeContext(
+  emitNote = vi.fn(),
+  playNote = vi.fn(),
+): PluginContext {
+  const manifest: PluginManifest = {
+    id: 'my-plugin',
+    name: 'My Plugin',
+    version: '1.0.0',
+    pluginApiVersion: '1',
+    entryPoint: 'index.js',
+    origin: 'builtin',
+  };
+  return { emitNote, playNote, manifest };
+}
+
+describe('MyPlugin', () => {
+  let context: PluginContext;
+
+  beforeEach(() => {
+    context = makeContext();
+  });
+
+  it('calls playNote with type:attack when button is pressed', () => {
+    render(<MyPlugin context={context} />);
+    fireEvent.mouseDown(document.querySelector('button')!);
+    expect(context.playNote).toHaveBeenCalledWith(
+      expect.objectContaining({ midiNote: 60, type: 'attack' }),
+    );
+  });
+});
+```
+
+Run the plugin tests:
+
+```bash
+cd frontend
+npx vitest run plugins/my-plugin/
+```
+
+---
+
+## Reference: Virtual Keyboard plugin
+
+The Virtual Keyboard (`frontend/plugins/virtual-keyboard/`) is the canonical reference implementation. It demonstrates:
+
+- Module-level `PluginContext` storage and injection into the React tree
+- `context.playNote()` for attack/release audio via the host engine
+- `context.emitNote()` to send note data to the WASM layout pipeline
+- `useEffect` unmount cleanup to release held notes when navigating away
+- A full Vitest test suite covering layout, MIDI mapping, and API calls

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -7,6 +7,10 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
   globalIgnores(['dist']),
+  // Feature 030: lint-test/ is an intentional ESLint boundary violation fixture.
+  // Exclude it from the global lint run (verify it manually with:
+  //   npx eslint plugins/lint-test/ — expected: 1 no-restricted-imports error).
+  globalIgnores(['plugins/lint-test/**']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -30,6 +34,21 @@ export default defineConfig([
       'react-hooks/exhaustive-deps': 'off',
       'react-hooks/set-state-in-effect': 'off',
       'react-hooks/globals': 'off',
+    },
+  },
+  // Feature 030: Plugin API boundary enforcement (T003 / FR-001 / SC-004 / SC-008)
+  // Plugin code may ONLY import from ../../src/plugin-api — all other host internals are forbidden.
+  // Enforcement is static (lint-time); see specs/030-plugin-architecture/research.md R-003.
+  //
+  // NOTE: ESLint 9 flat config requires the simple string-array "patterns" form for
+  // no-restricted-imports. The object form {group, message} is handled by
+  // @typescript-eslint/no-restricted-imports if needed in future.
+  {
+    files: ['plugins/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: ['../../src/components/*', '../../src/services/*', '../../src/pages/*', '../../src/data/*', '../../src/utils/*', '../../src/hooks/*'],
+      }],
     },
   },
 ])

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.1.37",
       "dependencies": {
+        "fflate": "^0.8.2",
+        "idb": "^8.0.3",
         "jszip": "^3.10.1",
         "pitchy": "^4.1.0",
         "react": "^19.2.0",
@@ -36,6 +38,7 @@
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^16.5.0",
         "happy-dom": "^20.5.0",
         "husky": "^9.1.7",
@@ -4727,6 +4730,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4781,7 +4794,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/fft.js": {
       "version": "4.0.4",
@@ -5357,9 +5370,10 @@
       }
     },
     "node_modules/idb": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
-      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -8568,6 +8582,13 @@
         "workbox-core": "7.4.0"
       }
     },
+    "node_modules/workbox-background-sync/node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/workbox-broadcast-update": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.0.tgz",
@@ -8799,6 +8820,12 @@
         "idb": "^7.0.1",
         "workbox-core": "7.4.0"
       }
+    },
+    "node_modules/workbox-expiration/node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/workbox-google-analytics": {
       "version": "7.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,8 @@
     "ci-check": "npm run build && npm test -- --run --reporter=verbose"
   },
   "dependencies": {
+    "fflate": "^0.8.2",
+    "idb": "^8.0.3",
     "jszip": "^3.10.1",
     "pitchy": "^4.1.0",
     "react": "^19.2.0",
@@ -48,6 +50,7 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^16.5.0",
     "happy-dom": "^20.5.0",
     "husky": "^9.1.7",

--- a/frontend/plugins/lint-test/bad-import.ts
+++ b/frontend/plugins/lint-test/bad-import.ts
@@ -1,0 +1,22 @@
+/**
+ * Lint boundary regression fixture — T029
+ * Feature 030: Plugin Architecture
+ *
+ * THIS FILE MUST NEVER BE MODIFIED TO FIX THE LINT ERROR.
+ * It exists to prove that ESLint catches illegal imports from plugins/.
+ *
+ * Run: npx eslint plugins/lint-test/bad-import.ts
+ * Expected: no-restricted-imports error on the import below.
+ *
+ * @see frontend/eslint.config.js — scoped rule for plugins/**
+ * @see specs/030-plugin-architecture/contracts/plugin-api.ts
+ */
+
+// This import intentionally violates the plugin API boundary.
+// Plugins must ONLY import from ../../src/plugin-api and nothing else in src/.
+import { pluginRegistry } from '../../src/services/plugins/PluginRegistry';
+
+// Suppress "unused variable" — the lint error is the only thing that matters here.
+void pluginRegistry;
+
+export {};

--- a/frontend/plugins/virtual-keyboard/VirtualKeyboard.css
+++ b/frontend/plugins/virtual-keyboard/VirtualKeyboard.css
@@ -1,0 +1,174 @@
+/**
+ * VirtualKeyboard.css — Feature 030: Plugin Architecture (US1)
+ *
+ * Piano keyboard layout for the Virtual Keyboard plugin.
+ * Supports two octaves (C3–B4) with tablet-first design.
+ * Touch targets: white keys ≥44×160 px, black keys ≥26×100 px in height.
+ *
+ * Constitution §III: tablet-first, touch-friendly, 44×44 px minimum targets.
+ */
+
+/* ── Outer container ───────────────────────────────────────────────── */
+
+.virtual-keyboard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px;
+  background: #1a1a2e;
+  min-height: 100%;
+  box-sizing: border-box;
+}
+
+.virtual-keyboard__title {
+  color: #e0e0e0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 12px 0;
+  letter-spacing: 0.05em;
+}
+
+/* Staff placeholder shown above the keyboard */
+.virtual-keyboard__staff-area {
+  width: 100%;
+  max-width: 640px;
+  min-height: 80px;
+  background: #ffffff;
+  border-radius: 4px;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  color: #888;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+}
+
+/* ── Keyboard wrapper (scrollable on narrow screens) ───────────────── */
+
+.virtual-keyboard__scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-width: 100%;
+  padding-bottom: 8px;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* ── Key container ─────────────────────────────────────────────────── */
+
+.keyboard {
+  position: relative;
+  display: inline-flex;
+  flex-direction: row;
+  height: 160px;
+  /* Width is determined by the number of white keys (set inline per instance) */
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+}
+
+/* ── White keys ────────────────────────────────────────────────────── */
+
+.key {
+  position: relative;
+  box-sizing: border-box;
+  border-radius: 0 0 4px 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+  /* Prevents context menu on long-press (touch) */
+  -webkit-tap-highlight-color: transparent;
+}
+
+.key--white {
+  width: 44px;
+  min-width: 44px;  /* 44 px touch target */
+  height: 160px;
+  background: #f8f8f8;
+  border: 1px solid #bbb;
+  z-index: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 6px;
+  font-size: 0.6rem;
+  color: #bbb;
+  font-family: monospace;
+}
+
+.key--white:active,
+.key--white.key--pressed {
+  background: #b8d4ff;
+  border-color: #5599ee;
+}
+
+/* ── Black keys ────────────────────────────────────────────────────── */
+
+.key--black {
+  position: absolute;
+  top: 0;
+  width: 26px;
+  height: 100px;
+  background: #222;
+  border: 1px solid #111;
+  border-radius: 0 0 4px 4px;
+  z-index: 2;
+  /* Centre the black key over its calculated left position */
+  transform: translateX(-50%);
+}
+
+.key--black:active,
+.key--black.key--pressed {
+  background: #1a4fcf;
+  border-color: #0033aa;
+}
+
+/* ── Note display in staff area ────────────────────────────────────── */
+
+.virtual-keyboard__note-display {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 4px;
+  padding: 8px 12px;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.virtual-keyboard__note-display--empty {
+  color: #bbb;
+  font-size: 0.85rem;
+  pointer-events: none;
+}
+
+.virtual-keyboard__note-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #667eea;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  font-family: monospace;
+}
+
+/* ── Responsive adjustments ────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .key--white {
+    width: 38px;
+    min-width: 38px;
+    height: 140px;
+  }
+  .key--black {
+    width: 22px;
+    height: 88px;
+  }
+}

--- a/frontend/plugins/virtual-keyboard/VirtualKeyboard.test.tsx
+++ b/frontend/plugins/virtual-keyboard/VirtualKeyboard.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * VirtualKeyboard component tests — T010
+ * Feature 030: Plugin Architecture (US1 — Play Virtual Keyboard)
+ *
+ * Constitution Principle V: tests written and verified failing before
+ * VirtualKeyboard.tsx implementation is committed.
+ *
+ * Covers (per tasks.md T010):
+ * - Renders 14+ white keys and 10 black keys per octave
+ * - Key press applies .key--pressed CSS class
+ * - Key press calls context.emitNote() and context.playNote() with correct midiNote
+ * - White key C4 emits midiNote: 60
+ * - Black key C#4 emits midiNote: 61
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VirtualKeyboard } from './VirtualKeyboard';
+import type { PluginContext, PluginManifest } from '../../src/plugin-api/index';
+
+const makeManifest = (): PluginManifest => ({
+  id: 'virtual-keyboard',
+  name: 'Virtual Keyboard',
+  version: '1.0.0',
+  pluginApiVersion: '1',
+  entryPoint: 'index.js',
+  origin: 'builtin',
+});
+
+function makeContext(emitNote = vi.fn(), playNote = vi.fn()): PluginContext {
+  return {
+    emitNote,
+    playNote,
+    manifest: makeManifest(),
+  };
+}
+
+describe('VirtualKeyboard', () => {
+  let emitNote: ReturnType<typeof vi.fn>;
+  let playNote: ReturnType<typeof vi.fn>;
+  let context: PluginContext;
+
+  beforeEach(() => {
+    emitNote = vi.fn();
+    playNote = vi.fn();
+    context = makeContext(emitNote, playNote);
+  });
+
+  describe('keyboard layout', () => {
+    it('renders at least 14 white keys', () => {
+      render(<VirtualKeyboard context={context} />);
+      const whiteKeys = document.querySelectorAll('.key--white');
+      expect(whiteKeys.length).toBeGreaterThanOrEqual(14);
+    });
+
+    it('renders at least 10 black keys', () => {
+      render(<VirtualKeyboard context={context} />);
+      const blackKeys = document.querySelectorAll('.key--black');
+      expect(blackKeys.length).toBeGreaterThanOrEqual(10);
+    });
+  });
+
+  describe('key interactions', () => {
+    it('calls context.emitNote when a white key is pressed', () => {
+      render(<VirtualKeyboard context={context} />);
+      const whiteKeys = document.querySelectorAll('.key--white');
+      fireEvent.mouseDown(whiteKeys[0]);
+      expect(emitNote).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls context.emitNote when a black key is pressed', () => {
+      render(<VirtualKeyboard context={context} />);
+      const blackKeys = document.querySelectorAll('.key--black');
+      fireEvent.mouseDown(blackKeys[0]);
+      expect(emitNote).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls context.playNote with type:attack on mousedown', () => {
+      render(<VirtualKeyboard context={context} />);
+      const c4 = document.querySelector('[data-midi="60"]');
+      fireEvent.mouseDown(c4!);
+      expect(playNote).toHaveBeenCalledWith(
+        expect.objectContaining({ midiNote: 60, type: 'attack' })
+      );
+    });
+
+    it('calls context.playNote with type:release on mouseup', () => {
+      render(<VirtualKeyboard context={context} />);
+      const c4 = document.querySelector('[data-midi="60"]');
+      fireEvent.mouseDown(c4!);
+      fireEvent.mouseUp(c4!);
+      expect(playNote).toHaveBeenCalledWith(
+        expect.objectContaining({ midiNote: 60, type: 'release' })
+      );
+    });
+
+    it('emits a PluginNoteEvent with midiNote and timestamp', () => {
+      render(<VirtualKeyboard context={context} />);
+      const before = Date.now();
+      const whiteKeys = document.querySelectorAll('.key--white');
+      fireEvent.mouseDown(whiteKeys[0]);
+      const after = Date.now();
+
+      const event = emitNote.mock.calls[0][0];
+      expect(typeof event.midiNote).toBe('number');
+      expect(event.timestamp).toBeGreaterThanOrEqual(before);
+      expect(event.timestamp).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('MIDI note mapping', () => {
+    it('middle C (C4) emits midiNote: 60', () => {
+      render(<VirtualKeyboard context={context} />);
+      // C4 is middle C — find the key with data-midi="60"
+      const c4 = document.querySelector('[data-midi="60"]');
+      expect(c4).not.toBeNull();
+      fireEvent.mouseDown(c4!);
+      expect(emitNote).toHaveBeenCalledWith(
+        expect.objectContaining({ midiNote: 60 })
+      );
+    });
+
+    it('C#4 (black key) emits midiNote: 61', () => {
+      render(<VirtualKeyboard context={context} />);
+      const cSharp4 = document.querySelector('[data-midi="61"]');
+      expect(cSharp4).not.toBeNull();
+      fireEvent.mouseDown(cSharp4!);
+      expect(emitNote).toHaveBeenCalledWith(
+        expect.objectContaining({ midiNote: 61 })
+      );
+    });
+  });
+
+  describe('visual pressed state', () => {
+    it('adds key--pressed class on mousedown', () => {
+      render(<VirtualKeyboard context={context} />);
+      const c4 = document.querySelector('[data-midi="60"]') as HTMLElement;
+      expect(c4.classList.contains('key--pressed')).toBe(false);
+      fireEvent.mouseDown(c4);
+      expect(c4.classList.contains('key--pressed')).toBe(true);
+    });
+
+    it('removes key--pressed class on mouseup', () => {
+      render(<VirtualKeyboard context={context} />);
+      const c4 = document.querySelector('[data-midi="60"]') as HTMLElement;
+      fireEvent.mouseDown(c4);
+      fireEvent.mouseUp(c4);
+      expect(c4.classList.contains('key--pressed')).toBe(false);
+    });
+
+    it('removes key--pressed class on mouseleave', () => {
+      render(<VirtualKeyboard context={context} />);
+      const c4 = document.querySelector('[data-midi="60"]') as HTMLElement;
+      fireEvent.mouseDown(c4);
+      fireEvent.mouseLeave(c4);
+      expect(c4.classList.contains('key--pressed')).toBe(false);
+    });
+  });
+});

--- a/frontend/plugins/virtual-keyboard/VirtualKeyboard.tsx
+++ b/frontend/plugins/virtual-keyboard/VirtualKeyboard.tsx
@@ -1,0 +1,211 @@
+/**
+ * VirtualKeyboard component — Feature 030: Plugin Architecture (US1)
+ *
+ * Renders an interactive two-octave piano keyboard (C3–B4).
+ * On key press: calls context.playNote() (audio via host ToneAdapter) and
+ * context.emitNote() (note data for the WASM layout pipeline), and records
+ * the played note for on-screen display above the keyboard.
+ *
+ * Audio is intentionally routed through the Plugin API (context.playNote /
+ * context.emitNote) — this component must NOT import Tone.js or the Web Audio
+ * API directly. The host owns the audio engine.
+ *
+ * Constitution Principle VI: this component emits ONLY midiNote integers via
+ * the Plugin API. It does NOT perform any coordinate or layout calculations;
+ * those are delegated to the WASM engine through the host's note pipeline.
+ *
+ * Accessibility: ARIA roles + keyboard navigation are out of scope for US1.
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { PluginContext } from '../../src/plugin-api/index';
+import './VirtualKeyboard.css';
+
+// ---------------------------------------------------------------------------
+// Note definitions
+// ---------------------------------------------------------------------------
+
+interface NoteDefinition {
+  midi: number;
+  isBlack: boolean;
+  /** Only set for black keys: the 0-based index of the white key it follows */
+  whiteKeyBefore?: number;
+  /** Short label, e.g. "C4", "C#4" */
+  label: string;
+}
+
+const WHITE_KEY_WIDTH = 44; // px — meets 44px touch target requirement
+
+/**
+ * Two octaves: C3 (MIDI 48) → B4 (MIDI 71)
+ * White keys: 14 total (7 per octave)
+ * Black keys: 10 total (5 per octave)
+ */
+const NOTES: NoteDefinition[] = [
+  // Octave 3
+  { midi: 48, isBlack: false, label: 'C3' },
+  { midi: 49, isBlack: true,  whiteKeyBefore: 0,  label: 'C#3' },
+  { midi: 50, isBlack: false, label: 'D3' },
+  { midi: 51, isBlack: true,  whiteKeyBefore: 1,  label: 'D#3' },
+  { midi: 52, isBlack: false, label: 'E3' },
+  { midi: 53, isBlack: false, label: 'F3' },
+  { midi: 54, isBlack: true,  whiteKeyBefore: 3,  label: 'F#3' },
+  { midi: 55, isBlack: false, label: 'G3' },
+  { midi: 56, isBlack: true,  whiteKeyBefore: 4,  label: 'G#3' },
+  { midi: 57, isBlack: false, label: 'A3' },
+  { midi: 58, isBlack: true,  whiteKeyBefore: 5,  label: 'A#3' },
+  { midi: 59, isBlack: false, label: 'B3' },
+  // Octave 4
+  { midi: 60, isBlack: false, label: 'C4' },
+  { midi: 61, isBlack: true,  whiteKeyBefore: 7,  label: 'C#4' },
+  { midi: 62, isBlack: false, label: 'D4' },
+  { midi: 63, isBlack: true,  whiteKeyBefore: 8,  label: 'D#4' },
+  { midi: 64, isBlack: false, label: 'E4' },
+  { midi: 65, isBlack: false, label: 'F4' },
+  { midi: 66, isBlack: true,  whiteKeyBefore: 10, label: 'F#4' },
+  { midi: 67, isBlack: false, label: 'G4' },
+  { midi: 68, isBlack: true,  whiteKeyBefore: 11, label: 'G#4' },
+  { midi: 69, isBlack: false, label: 'A4' },
+  { midi: 70, isBlack: true,  whiteKeyBefore: 12, label: 'A#4' },
+  { midi: 71, isBlack: false, label: 'B4' },
+];
+
+const WHITE_NOTES = NOTES.filter(n => !n.isBlack);
+const BLACK_NOTES = NOTES.filter(n => n.isBlack);
+
+/** Calculate the absolute left position for a black key (in px). */
+function blackKeyLeft(note: NoteDefinition): number {
+  // Centre the black key at 65% from the left edge of its preceding white key.
+  // (whiteKeyBefore * whiteKeyWidth) = left edge of the white key
+  // + 0.65 * whiteKeyWidth = the centre point
+  return (note.whiteKeyBefore! * WHITE_KEY_WIDTH) + (0.65 * WHITE_KEY_WIDTH);
+}
+
+// Maximum displayed notes before oldest are dropped from the on-screen list
+const MAX_DISPLAYED_NOTES = 20;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface VirtualKeyboardProps {
+  context: PluginContext;
+}
+
+export function VirtualKeyboard({ context }: VirtualKeyboardProps) {
+  const [pressedKeys, setPressedKeys] = useState<Set<number>>(new Set());
+  const [playedNotes, setPlayedNotes] = useState<{ midi: number; label: string }[]>([]);
+
+  // Mirror pressedKeys into a ref so the unmount cleanup can read the latest
+  // value without capturing a stale closure.
+  const pressedKeysRef = useRef<Set<number>>(new Set());
+  useEffect(() => { pressedKeysRef.current = pressedKeys; }, [pressedKeys]);
+
+  // On unmount (e.g. Back button): release any notes that are still held down.
+  // Without this a sustained note keeps playing after the component is gone.
+  useEffect(() => {
+    return () => {
+      for (const midi of pressedKeysRef.current) {
+        context.playNote({ midiNote: midi, timestamp: Date.now(), type: 'release' });
+      }
+    };
+  // context is stable (created once in App loadPlugins), intentional empty-dep.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (note: NoteDefinition) => {
+      // Audio playback via Plugin API — host routes through ToneAdapter (Salamander piano)
+      context.playNote({ midiNote: note.midi, timestamp: Date.now(), type: 'attack' });
+      // Note data to WASM layout pipeline
+      context.emitNote({ midiNote: note.midi, timestamp: Date.now() });
+
+      setPressedKeys(prev => {
+        const next = new Set(prev);
+        next.add(note.midi);
+        return next;
+      });
+
+      setPlayedNotes(prev => {
+        const next = [...prev, { midi: note.midi, label: note.label }];
+        return next.length > MAX_DISPLAYED_NOTES ? next.slice(-MAX_DISPLAYED_NOTES) : next;
+      });
+    },
+    [context]
+  );
+
+  const handleKeyUp = useCallback((midi: number) => {
+    // Release the sustained note through the Plugin API
+    context.playNote({ midiNote: midi, timestamp: Date.now(), type: 'release' });
+    setPressedKeys(prev => {
+      const next = new Set(prev);
+      next.delete(midi);
+      return next;
+    });
+  }, [context]);
+
+  const totalWidth = WHITE_NOTES.length * WHITE_KEY_WIDTH;
+
+  return (
+    <div className="virtual-keyboard">
+      <h2 className="virtual-keyboard__title">Virtual Keyboard</h2>
+
+      {/* Note display area — shows chips for each played note */}
+      <div className="virtual-keyboard__staff-area">
+        {playedNotes.length === 0 ? (
+          <span className="virtual-keyboard__note-display--empty">
+            Play a key to see notes here
+          </span>
+        ) : (
+          <div className="virtual-keyboard__note-display">
+            {playedNotes.map((n, i) => (
+              <span key={i} className="virtual-keyboard__note-chip">
+                {n.label}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Keyboard (scrollable on narrow screens) */}
+      <div className="virtual-keyboard__scroll">
+        <div className="keyboard" style={{ width: `${totalWidth}px` }}>
+          {/* White keys first (z-index 1) */}
+          {WHITE_NOTES.map(note => (
+            <div
+              key={note.midi}
+              className={`key key--white${pressedKeys.has(note.midi) ? ' key--pressed' : ''}`}
+              data-midi={note.midi}
+              onMouseDown={() => handleKeyDown(note)}
+              onMouseUp={() => handleKeyUp(note.midi)}
+              onMouseLeave={() => handleKeyUp(note.midi)}
+              onTouchStart={e => { e.preventDefault(); handleKeyDown(note); }}
+              onTouchEnd={() => handleKeyUp(note.midi)}
+              role="button"
+              aria-label={note.label}
+            >
+              {note.label.startsWith('C') ? note.label : ''}
+            </div>
+          ))}
+
+          {/* Black keys last (z-index 2, absolutely positioned) */}
+          {BLACK_NOTES.map(note => (
+            <div
+              key={note.midi}
+              className={`key key--black${pressedKeys.has(note.midi) ? ' key--pressed' : ''}`}
+              data-midi={note.midi}
+              style={{ left: `${blackKeyLeft(note)}px` }}
+              onMouseDown={() => handleKeyDown(note)}
+              onMouseUp={() => handleKeyUp(note.midi)}
+              onMouseLeave={() => handleKeyUp(note.midi)}
+              onTouchStart={e => { e.preventDefault(); handleKeyDown(note); }}
+              onTouchEnd={() => handleKeyUp(note.midi)}
+              role="button"
+              aria-label={note.label}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/plugins/virtual-keyboard/index.tsx
+++ b/frontend/plugins/virtual-keyboard/index.tsx
@@ -1,0 +1,46 @@
+/**
+ * Virtual Keyboard plugin — entry point (T015)
+ * Feature 030: Plugin Architecture
+ *
+ * Default export must satisfy the MusicorePlugin interface.
+ * Only imports from ../../src/plugin-api are permitted (enforced by ESLint).
+ *
+ * This plugin is registered as a built-in in builtinPlugins.ts (T016).
+ *
+ * Note: react-refresh/only-export-components is silenced here because plugin
+ * entry points export a MusicorePlugin object (not a React component) by design.
+ * HMR for plugins is not required — see R-006 in research.md.
+ */
+/* eslint-disable react-refresh/only-export-components */
+
+import type { MusicorePlugin, PluginContext } from '../../src/plugin-api/index';
+import { VirtualKeyboard } from './VirtualKeyboard';
+
+let _context: PluginContext | null = null;
+
+/**
+ * Wrapper component that provides the stored PluginContext to VirtualKeyboard.
+ * Context is injected via init() before the component is first rendered.
+ */
+function VirtualKeyboardWithContext() {
+  if (!_context) {
+    // Should never happen in practice — init() is called before Component renders.
+    return <div>Virtual Keyboard: context not initialised</div>;
+  }
+  return <VirtualKeyboard context={_context} />;
+}
+
+const virtualKeyboardPlugin: MusicorePlugin = {
+  init(context: PluginContext) {
+    _context = context;
+    console.log('[VirtualKeyboard] init', context.manifest.version);
+  },
+
+  dispose() {
+    _context = null;
+  },
+
+  Component: VirtualKeyboardWithContext,
+};
+
+export default virtualKeyboardPlugin;

--- a/frontend/plugins/virtual-keyboard/plugin.json
+++ b/frontend/plugins/virtual-keyboard/plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "virtual-keyboard",
+  "name": "Virtual Keyboard",
+  "version": "1.0.0",
+  "pluginApiVersion": "1",
+  "entryPoint": "index.js",
+  "description": "An interactive piano keyboard that shows played notes on a music staff in real time."
+}

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * App.tsx navigation integration tests — T026
+ * Feature 030: Plugin Architecture (US3 — Navigate Between Installed Plugins)
+ *
+ * Constitution Principle V: written before T027/T028 hardening.
+ *
+ * Mocks:
+ * - initWasm: avoids WASM loading in unit tests
+ * - builtinPlugins: injects two synthetic plugins for navigation testing
+ * - PluginRegistry: avoids IndexedDB in unit tests
+ * - PluginImporter: avoids file system in unit tests
+ *
+ * Covers:
+ * - Each installed plugin produces exactly one nav entry
+ * - Clicking a plugin nav entry renders its view (aria-pressed = true)
+ * - Clicking a second plugin nav entry switches to it (first becomes inactive)
+ * - Clicking the score/home area (or a non-plugin handler) dismisses plugin view
+ * - Rapid switching between plugin entries does not throw
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any imports that depend on them
+// ---------------------------------------------------------------------------
+
+vi.mock('./services/wasm/loader', () => ({
+  initWasm: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./services/plugins/PluginImporter', () => ({
+  importPlugin: vi.fn(),
+}));
+
+// Declare fake plugins in vi.hoisted so they are available when the mock factory runs
+const { fakePlugin1, fakePlugin2 } = vi.hoisted(() => {
+  function makeFakePlugin() {
+    return {
+      init: vi.fn(),
+      dispose: vi.fn(),
+      // Component will be replaced in beforeEach with JSX (JSX transform not available in vi.hoisted)
+      Component: (() => null) as unknown as () => JSX.Element,
+    };
+  }
+  return { fakePlugin1: makeFakePlugin(), fakePlugin2: makeFakePlugin() };
+});
+
+vi.mock('./services/plugins/builtinPlugins', () => ({
+  BUILTIN_PLUGINS: [
+    {
+      manifest: {
+        id: 'alpha-plugin',
+        name: 'Alpha Plugin',
+        version: '1.0.0',
+        pluginApiVersion: '1',
+        entryPoint: 'index.js',
+        origin: 'builtin',
+      },
+      plugin: fakePlugin1,
+    },
+    {
+      manifest: {
+        id: 'beta-plugin',
+        name: 'Beta Plugin',
+        version: '1.0.0',
+        pluginApiVersion: '1',
+        entryPoint: 'index.js',
+        origin: 'builtin',
+      },
+      plugin: fakePlugin2,
+    },
+  ],
+}));
+
+vi.mock('./services/plugins/PluginRegistry', () => ({
+  pluginRegistry: {
+    list: vi.fn().mockResolvedValue([]),
+    get: vi.fn().mockResolvedValue(null),
+    register: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+  },
+  PluginRegistry: class MockPluginRegistry {},
+}));
+
+// Silence console noise from WASM + plugin context
+beforeEach(() => {
+  // Replace Components with JSX-capable functions (JSX transform available here)
+  fakePlugin1.Component = () => <div data-testid="plugin-view-alpha">Alpha View</div>;
+  fakePlugin2.Component = () => <div data-testid="plugin-view-beta">Beta View</div>;
+
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Import App AFTER mocks are declared (vi.mock is hoisted by Vite)
+import App from './App';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('App plugin navigation (US3)', () => {
+  // ── One nav entry per plugin ────────────────────────────────────────────
+
+  it('renders exactly one nav entry for each installed plugin', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Open Alpha Plugin plugin/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Open Beta Plugin plugin/i })).toBeInTheDocument();
+    });
+
+    // Only two plugin buttons (not counting import "+" button or other controls)
+    const pluginNavButtons = screen.getAllByRole('button', { name: /Open .* plugin/i });
+    expect(pluginNavButtons).toHaveLength(2);
+  });
+
+  // ── Selecting a plugin activates it ────────────────────────────────────
+
+  it('marks a plugin nav entry as active when clicked', async () => {
+    render(<App />);
+
+    await waitFor(() => screen.getByRole('button', { name: /Open Alpha Plugin plugin/i }));
+
+    const alphaBtn = screen.getByRole('button', { name: /Open Alpha Plugin plugin/i });
+    expect(alphaBtn).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(alphaBtn);
+
+    expect(alphaBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('renders the plugin view component when its nav entry is clicked', async () => {
+    render(<App />);
+
+    await waitFor(() => screen.getByRole('button', { name: /Open Alpha Plugin plugin/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /Open Alpha Plugin plugin/i }));
+
+    expect(screen.getByTestId('plugin-view-alpha')).toBeInTheDocument();
+  });
+
+  // ── Switching between plugins ────────────────────────────────────────────
+
+  it('deactivates the first plugin when user selects the second', async () => {
+    render(<App />);
+
+    await waitFor(() => screen.getByRole('button', { name: /Open Alpha Plugin plugin/i }));
+
+    const alphaBtn = screen.getByRole('button', { name: /Open Alpha Plugin plugin/i });
+    const betaBtn = screen.getByRole('button', { name: /Open Beta Plugin plugin/i });
+
+    fireEvent.click(alphaBtn);
+    expect(alphaBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(betaBtn).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(betaBtn);
+    expect(betaBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(alphaBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('shows the second plugin view when switching from first to second', async () => {
+    render(<App />);
+
+    await waitFor(() => screen.getByRole('button', { name: /Open Alpha Plugin plugin/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /Open Alpha Plugin plugin/i }));
+    expect(screen.getByTestId('plugin-view-alpha')).toBeInTheDocument();
+    expect(screen.queryByTestId('plugin-view-beta')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Open Beta Plugin plugin/i }));
+    expect(screen.getByTestId('plugin-view-beta')).toBeInTheDocument();
+    expect(screen.queryByTestId('plugin-view-alpha')).not.toBeInTheDocument();
+  });
+
+  // ── Rapid switching ────────────────────────────────────────────────────
+
+  it('handles rapid switching between plugins without throwing', async () => {
+    render(<App />);
+
+    await waitFor(() => screen.getByRole('button', { name: /Open Alpha Plugin plugin/i }));
+
+    const alphaBtn = screen.getByRole('button', { name: /Open Alpha Plugin plugin/i });
+    const betaBtn = screen.getByRole('button', { name: /Open Beta Plugin plugin/i });
+
+    // 10 rapid alternating clicks
+    await act(async () => {
+      for (let i = 0; i < 10; i++) {
+        fireEvent.click(i % 2 === 0 ? alphaBtn : betaBtn);
+      }
+    });
+
+    // Should end on alpha (10 clicks, 0-indexed: last click is at i=9 on betaBtn, but
+    // i=9 is odd so betaBtn is clicked last)
+    expect(betaBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/frontend/src/components/plugins/PluginImporterDialog.test.tsx
+++ b/frontend/src/components/plugins/PluginImporterDialog.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * PluginImporterDialog tests — T021
+ * Feature 030: Plugin Architecture (US2 — Import a Third-Party Plugin)
+ *
+ * Constitution Principle V: written before PluginImporterDialog.tsx
+ * implementation.
+ *
+ * Uses vi.mock to stub out importPlugin so these tests exercise the dialog
+ * UI in isolation (no real ZIP / IndexedDB required).
+ *
+ * Covers:
+ * - File picker input is rendered
+ * - Selecting a valid ZIP shows success state and calls onImportComplete
+ * - Selecting an invalid ZIP shows an error message
+ * - A duplicate triggers a confirmation prompt
+ * - Cancelling duplicate leaves existing plugin and does NOT call onImportComplete
+ * - Confirming duplicate calls importPlugin with overwrite: true and onImportComplete
+ * - Close button / onClose prop is triggered
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { PluginManifest } from '../../plugin-api/index';
+import type { ImportResult } from '../../services/plugins/PluginImporter';
+
+// ---------------------------------------------------------------------------
+// Mock PluginImporter — must be declared before the component import
+// ---------------------------------------------------------------------------
+const mockImportPlugin = vi.fn<(file: File, _registry: unknown, _opts?: unknown) => Promise<ImportResult>>();
+
+vi.mock('../../services/plugins/PluginImporter', () => ({
+  importPlugin: (...args: Parameters<typeof mockImportPlugin>) => mockImportPlugin(...args),
+}));
+
+// Static import — vi.mock above is hoisted so the stub is applied first
+import { PluginImporterDialog } from './PluginImporterDialog';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fakeManifest: PluginManifest = {
+  id: 'my-plugin',
+  name: 'My Plugin',
+  version: '1.0.0',
+  pluginApiVersion: '1',
+  entryPoint: 'index.js',
+  origin: 'imported',
+};
+
+function makeZipFile(name = 'plugin.zip') {
+  return new File(['fake zip bytes'], name, { type: 'application/zip' });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PluginImporterDialog', () => {
+  let onImportComplete: ReturnType<typeof vi.fn>;
+  let onClose: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onImportComplete = vi.fn();
+    onClose = vi.fn();
+    mockImportPlugin.mockReset();
+  });
+
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
+  it('renders a file input that accepts .zip files', () => {
+    render(<PluginImporterDialog onImportComplete={onImportComplete} onClose={onClose} />);
+    const input = screen.getByTestId('plugin-file-input') as HTMLInputElement;
+    expect(input.accept).toContain('.zip');
+  });
+
+  it('renders a close button that calls onClose', () => {
+    render(<PluginImporterDialog onImportComplete={onImportComplete} onClose={onClose} />);
+    const btn = screen.getByRole('button', { name: /close/i });
+    fireEvent.click(btn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Success path ──────────────────────────────────────────────────────────
+
+  it('calls onImportComplete with manifest on successful import', async () => {
+    mockImportPlugin.mockResolvedValue({ success: true, manifest: fakeManifest });
+
+    render(<PluginImporterDialog onImportComplete={onImportComplete} onClose={onClose} />);
+    const input = screen.getByTestId('plugin-file-input');
+    fireEvent.change(input, { target: { files: [makeZipFile()] } });
+
+    await waitFor(() => {
+      expect(onImportComplete).toHaveBeenCalledWith(fakeManifest);
+    });
+  });
+
+  it('shows a success confirmation message after import', async () => {
+    mockImportPlugin.mockResolvedValue({ success: true, manifest: fakeManifest });
+
+    render(<PluginImporterDialog onImportComplete={onImportComplete} onClose={onClose} />);
+    fireEvent.change(screen.getByTestId('plugin-file-input'), { target: { files: [makeZipFile()] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/imported successfully|installed/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── Error path ────────────────────────────────────────────────────────────
+
+  it('shows error message when importPlugin returns success: false', async () => {
+    mockImportPlugin.mockResolvedValue({ success: false, error: 'invalid plugin.json' });
+
+    render(<PluginImporterDialog onImportComplete={onImportComplete} onClose={onClose} />);
+    fireEvent.change(screen.getByTestId('plugin-file-input'), { target: { files: [makeZipFile()] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid plugin\.json/i)).toBeInTheDocument();
+    });
+    expect(onImportComplete).not.toHaveBeenCalled();
+  });
+
+  // ── Duplicate path ────────────────────────────────────────────────────────
+
+  it('shows a duplicate-confirmation dialog when a duplicate is detected', async () => {
+    mockImportPlugin.mockResolvedValue({
+      success: false,
+      duplicate: true,
+      manifest: fakeManifest,
+    });
+
+    render(<PluginImporterDialog onImportComplete={onImportComplete} onClose={onClose} />);
+    fireEvent.change(screen.getByTestId('plugin-file-input'), { target: { files: [makeZipFile()] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    // Confirm the duplicate prompt mentions the plugin name
+    expect(screen.getByRole('alert').textContent).toMatch(/My Plugin/);
+    expect(onImportComplete).not.toHaveBeenCalled();
+  });
+
+  it('does NOT overwrite when user cancels the duplicate confirm', async () => {
+    mockImportPlugin.mockResolvedValue({
+      success: false,
+      duplicate: true,
+      manifest: fakeManifest,
+    });
+
+    render(<PluginImporterDialog onImportComplete={onImportComplete} onClose={onClose} />);
+    fireEvent.change(screen.getByTestId('plugin-file-input'), { target: { files: [makeZipFile()] } });
+
+    // Wait for the duplicate confirmation prompt
+    await waitFor(() => screen.getByRole('alert'));
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onImportComplete).not.toHaveBeenCalled();
+  });
+
+  it('overwrites and calls onImportComplete when user confirms duplicate replace', async () => {
+    // First call → duplicate; second call (with overwrite) → success
+    mockImportPlugin
+      .mockResolvedValueOnce({ success: false, duplicate: true, manifest: fakeManifest })
+      .mockResolvedValueOnce({ success: true, manifest: fakeManifest });
+
+    render(<PluginImporterDialog onImportComplete={onImportComplete} onClose={onClose} />);
+    fireEvent.change(screen.getByTestId('plugin-file-input'), { target: { files: [makeZipFile()] } });
+
+    await waitFor(() => screen.getByRole('alert'));
+
+    fireEvent.click(screen.getByRole('button', { name: /replace|overwrite|yes/i }));
+
+    await waitFor(() => {
+      expect(onImportComplete).toHaveBeenCalledWith(fakeManifest);
+    });
+    // The second call must pass overwrite: true
+    expect(mockImportPlugin).toHaveBeenCalledTimes(2);
+    expect(mockImportPlugin.mock.calls[1][2]).toMatchObject({ overwrite: true });
+  });
+});

--- a/frontend/src/components/plugins/PluginImporterDialog.tsx
+++ b/frontend/src/components/plugins/PluginImporterDialog.tsx
@@ -1,0 +1,263 @@
+/**
+ * PluginImporterDialog — T023
+ * Feature 030: Plugin Architecture (US2 — Import a Third-Party Plugin)
+ *
+ * Modal dialog for importing a third-party plugin from a ZIP file.
+ *
+ * States:
+ *  idle     — waiting for the user to choose a file
+ *  loading  — ZIP is being processed
+ *  success  — plugin imported successfully
+ *  error    — import rejected (validation, size, etc.)
+ *  duplicate — plugin id already installed; waits for user confirmation
+ */
+
+import React, { useRef, useState } from 'react';
+import type { PluginManifest } from '../../plugin-api/index';
+import { importPlugin } from '../../services/plugins/PluginImporter';
+import { pluginRegistry } from '../../services/plugins/PluginRegistry';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type DialogState =
+  | { phase: 'idle' }
+  | { phase: 'loading' }
+  | { phase: 'success'; manifest: PluginManifest }
+  | { phase: 'error'; message: string }
+  | { phase: 'duplicate'; manifest: PluginManifest; pendingFile: File };
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface PluginImporterDialogProps {
+  onImportComplete: (manifest: PluginManifest) => void;
+  onClose: () => void;
+}
+
+export function PluginImporterDialog({
+  onImportComplete,
+  onClose,
+}: PluginImporterDialogProps) {
+  const [state, setState] = useState<DialogState>({ phase: 'idle' });
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // ── File selection ─────────────────────────────────────────────────────
+
+  async function handleFile(file: File) {
+    setState({ phase: 'loading' });
+
+    const result = await importPlugin(file, pluginRegistry);
+
+    if (result.success) {
+      setState({ phase: 'success', manifest: result.manifest });
+      onImportComplete(result.manifest);
+    } else if ((result as { duplicate?: boolean }).duplicate) {
+      const dup = result as { duplicate: true; manifest: PluginManifest };
+      setState({ phase: 'duplicate', manifest: dup.manifest, pendingFile: file });
+    } else {
+      setState({ phase: 'error', message: (result as { error?: string }).error ?? 'Unknown error.' });
+    }
+  }
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+  }
+
+  // ── Duplicate confirmation ─────────────────────────────────────────────
+
+  async function handleReplace() {
+    if (state.phase !== 'duplicate') return;
+    const { pendingFile } = state;
+    setState({ phase: 'loading' });
+
+    const result = await importPlugin(pendingFile, pluginRegistry, { overwrite: true });
+    if (result.success) {
+      setState({ phase: 'success', manifest: result.manifest });
+      onImportComplete(result.manifest);
+    } else {
+      setState({ phase: 'error', message: (result as { error?: string }).error ?? 'Unknown error.' });
+    }
+  }
+
+  function handleCancelDuplicate() {
+    setState({ phase: 'idle' });
+    // Reset file input so the same file can be re-selected
+    if (inputRef.current) inputRef.current.value = '';
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Import Plugin"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.55)',
+        backdropFilter: 'blur(2px)',
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        style={{
+          background: '#fff',
+          color: '#222',
+          borderRadius: '10px',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.25)',
+          width: 'min(420px, 92vw)',
+          padding: '24px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+        }}
+      >
+        <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '8px' }}>
+          <h2 style={{ margin: 0, fontSize: '1.1rem', fontWeight: 700, color: '#1a1a1a' }}>
+            Import Plugin
+          </h2>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            style={{
+              background: 'none',
+              border: 'none',
+              fontSize: '1.4rem',
+              lineHeight: 1,
+              cursor: 'pointer',
+              color: '#666',
+              padding: '2px 6px',
+              borderRadius: '4px',
+            }}
+          >
+            ×
+          </button>
+        </header>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          {/* ── File picker ─────────────────────────────────────────────── */}
+          {(state.phase === 'idle' || state.phase === 'error') && (
+            <>
+              <label
+                htmlFor="plugin-file-input"
+                style={{ fontSize: '0.9rem', color: '#444', fontWeight: 500 }}
+              >
+                Select a plugin ZIP package:
+              </label>
+              <input
+                ref={inputRef}
+                id="plugin-file-input"
+                data-testid="plugin-file-input"
+                type="file"
+                accept=".zip"
+                onChange={handleInputChange}
+                style={{ fontSize: '0.875rem', cursor: 'pointer' }}
+              />
+              {state.phase === 'error' && (
+                <p
+                  role="alert"
+                  style={{
+                    margin: 0,
+                    padding: '10px 12px',
+                    background: '#fff0f0',
+                    border: '1px solid #f5c6c6',
+                    borderRadius: '6px',
+                    color: '#c0392b',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  {state.message}
+                </p>
+              )}
+            </>
+          )}
+
+          {/* ── Loading ─────────────────────────────────────────────────── */}
+          {state.phase === 'loading' && (
+            <p aria-live="polite" style={{ margin: 0, color: '#555', fontSize: '0.9rem' }}>
+              Installing plugin…
+            </p>
+          )}
+
+          {/* ── Success ─────────────────────────────────────────────────── */}
+          {state.phase === 'success' && (
+            <p
+              role="status"
+              style={{
+                margin: 0,
+                padding: '10px 12px',
+                background: '#f0fff4',
+                border: '1px solid #a8e6c3',
+                borderRadius: '6px',
+                color: '#27ae60',
+                fontSize: '0.875rem',
+              }}
+            >
+              ✓ "{state.manifest.name}" imported successfully!
+            </p>
+          )}
+
+          {/* ── Duplicate confirm ────────────────────────────────────────── */}
+          {state.phase === 'duplicate' && (
+            <div
+              role="alert"
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '14px',
+              }}
+            >
+              <p style={{ margin: 0, color: '#333', fontSize: '0.9rem' }}>
+                A plugin named <strong>"{state.manifest.name}"</strong> is already installed.
+                Replace it?
+              </p>
+              <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+                <button
+                  type="button"
+                  onClick={handleCancelDuplicate}
+                  style={{
+                    padding: '7px 16px',
+                    border: '1px solid #ccc',
+                    borderRadius: '6px',
+                    background: '#fff',
+                    color: '#444',
+                    cursor: 'pointer',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleReplace}
+                  style={{
+                    padding: '7px 16px',
+                    border: 'none',
+                    borderRadius: '6px',
+                    background: '#e74c3c',
+                    color: '#fff',
+                    cursor: 'pointer',
+                    fontWeight: 600,
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  Replace
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/plugins/PluginNavEntry.tsx
+++ b/frontend/src/components/plugins/PluginNavEntry.tsx
@@ -1,0 +1,62 @@
+/**
+ * PluginNavEntry — navigation entry per installed plugin (T018)
+ * Feature 030: Plugin Architecture
+ *
+ * Renders a nav button for a single plugin. Active state styling applied
+ * when isActive is true. 44×44 px minimum touch target (Constitution §III).
+ */
+
+import type { PluginManifest } from '../../plugin-api/index';
+
+export interface PluginNavEntryProps {
+  plugin: PluginManifest;
+  isActive: boolean;
+  onSelect: () => void;
+}
+
+export function PluginNavEntry({ plugin, isActive, onSelect }: PluginNavEntryProps) {
+  return (
+    <button
+      className={`plugin-nav-entry${isActive ? ' plugin-nav-entry--active' : ''}`}
+      onClick={onSelect}
+      aria-pressed={isActive}
+      aria-label={`Open ${plugin.name} plugin`}
+      style={isActive ? { ...styles.base, ...styles.active } : styles.base}
+    >
+      {plugin.name}
+      {plugin.origin === 'imported' && (
+        <span style={styles.badge} aria-label="user-installed">↑</span>
+      )}
+    </button>
+  );
+}
+
+const styles = {
+  base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+    minWidth: '44px',
+    minHeight: '44px',
+    padding: '8px 16px',
+    fontSize: '0.875rem',
+    fontWeight: '500',
+    color: '#e0e0ff',
+    background: 'rgba(255,255,255,0.1)',
+    border: '1px solid rgba(255,255,255,0.2)',
+    borderRadius: '6px',
+    cursor: 'pointer',
+    whiteSpace: 'nowrap' as const,
+    transition: 'background 0.15s, color 0.15s',
+  },
+  active: {
+    background: 'rgba(255,255,255,0.9)',
+    color: '#4a0080',
+    fontWeight: '700' as const,
+    borderColor: 'rgba(255,255,255,0.9)',
+  },
+  badge: {
+    fontSize: '0.7rem',
+    opacity: 0.7,
+  },
+};

--- a/frontend/src/components/plugins/PluginView.test.tsx
+++ b/frontend/src/components/plugins/PluginView.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * PluginView error boundary tests — T011
+ * Feature 030: Plugin Architecture (US1 — Play Virtual Keyboard)
+ *
+ * Constitution Principle V: tests written before PluginView.tsx implementation.
+ *
+ * Covers (per tasks.md T011):
+ * - Renders children normally when no error occurs
+ * - Catches thrown error and shows plugin name + error message
+ * - "Reload plugin" button resets boundary and remounts children
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PluginView } from './PluginView';
+import type { PluginManifest } from '../plugin-api/index';
+
+const makeManifest = (overrides: Partial<PluginManifest> = {}): PluginManifest => ({
+  id: 'test-plugin',
+  name: 'Test Plugin',
+  version: '1.0.0',
+  pluginApiVersion: '1',
+  entryPoint: 'index.js',
+  origin: 'builtin',
+  ...overrides,
+});
+
+/** Component that renders normally. */
+const SafeChild = () => <div>Safe content</div>;
+
+/** Component that throws immediately during render. */
+const CrashingChild = ({ shouldCrash }: { shouldCrash: boolean }) => {
+  if (shouldCrash) throw new Error('Test error from plugin');
+  return <div>Recovered content</div>;
+};
+
+describe('PluginView', () => {
+  // Suppress React's console.error output for expected error boundary tests
+  const originalConsoleError = console.error;
+  beforeEach(() => {
+    console.error = vi.fn();
+  });
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  describe('normal rendering', () => {
+    it('renders children when no error occurs', () => {
+      render(
+        <PluginView plugin={makeManifest()}>
+          <SafeChild />
+        </PluginView>
+      );
+      expect(screen.getByText('Safe content')).toBeInTheDocument();
+    });
+
+    it('does not show the error UI when no error occurs', () => {
+      render(
+        <PluginView plugin={makeManifest()}>
+          <SafeChild />
+        </PluginView>
+      );
+      expect(screen.queryByText(/encountered an error/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('error boundary', () => {
+    it('catches a render error and shows the plugin name in the error message', () => {
+      render(
+        <PluginView plugin={makeManifest({ name: 'Test Plugin' })}>
+          <CrashingChild shouldCrash={true} />
+        </PluginView>
+      );
+      expect(screen.getByText(/Test Plugin/)).toBeInTheDocument();
+      expect(screen.getByText(/encountered an error/i)).toBeInTheDocument();
+    });
+
+    it('shows the error message from the thrown error', () => {
+      render(
+        <PluginView plugin={makeManifest()}>
+          <CrashingChild shouldCrash={true} />
+        </PluginView>
+      );
+      expect(screen.getByText(/Test error from plugin/)).toBeInTheDocument();
+    });
+
+    it('shows a "Reload plugin" button when in error state', () => {
+      render(
+        <PluginView plugin={makeManifest()}>
+          <CrashingChild shouldCrash={true} />
+        </PluginView>
+      );
+      expect(screen.getByRole('button', { name: /reload plugin/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('reload behaviour', () => {
+    it('resets error state and remounts children when Reload plugin is clicked', () => {
+      // Use a mutable flag so we can stop crashing BEFORE clicking reload.
+      // This simulates: user "fixes" the issue, then clicks Reload.
+      let shouldCrash = true;
+      const ControlledCrash = () => {
+        if (shouldCrash) throw new Error('Test error from plugin');
+        return <div>Recovered content</div>;
+      };
+
+      render(
+        <PluginView plugin={makeManifest()}>
+          <ControlledCrash />
+        </PluginView>
+      );
+
+      // Verify error state is active
+      expect(screen.getByRole('button', { name: /reload plugin/i })).toBeInTheDocument();
+
+      // Resolve the crash condition, then click Reload —
+      // boundary resets, same component re-renders without crashing.
+      shouldCrash = false;
+      fireEvent.click(screen.getByRole('button', { name: /reload plugin/i }));
+
+      expect(screen.getByText('Recovered content')).toBeInTheDocument();
+      expect(screen.queryByText(/encountered an error/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/plugins/PluginView.tsx
+++ b/frontend/src/components/plugins/PluginView.tsx
@@ -1,0 +1,103 @@
+/**
+ * PluginView — per-plugin error boundary (T017)
+ * Feature 030: Plugin Architecture
+ *
+ * Wraps any plugin component in a React class-based error boundary.
+ * On crash: displays plugin name + error message + "Reload plugin" button.
+ * "Reload plugin" resets boundary state so the plugin's component is remounted.
+ *
+ * This is intentionally a separate class from ErrorBoundary.tsx so it can
+ * render the plugin name + caught error in its fallback without modifying
+ * the existing ErrorBoundary API. (FR-020 / research.md R-005)
+ */
+
+import { Component, type ReactNode } from 'react';
+import type { PluginManifest } from '../../plugin-api/index';
+
+export interface PluginViewProps {
+  /** Manifest of the plugin whose Component is being wrapped. */
+  plugin: PluginManifest;
+  children: ReactNode;
+}
+
+interface PluginViewState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class PluginView extends Component<PluginViewProps, PluginViewState> {
+  constructor(props: PluginViewProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): PluginViewState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error): void {
+    console.error(`[PluginView] Plugin "${this.props.plugin.name}" crashed:`, error);
+  }
+
+  private handleReset = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    const { hasError, error } = this.state;
+    const { plugin, children } = this.props;
+
+    if (hasError) {
+      return (
+        <div className="plugin-error" style={styles.container}>
+          <div style={styles.card}>
+            <p style={styles.message}>
+              Plugin &ldquo;{plugin.name}&rdquo; encountered an error:{' '}
+              {error?.message ?? 'Unknown error'}
+            </p>
+            <button onClick={this.handleReset} style={styles.button}>
+              Reload plugin
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}
+
+const styles = {
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '200px',
+    padding: '20px',
+    background: '#f9f9f9',
+  },
+  card: {
+    maxWidth: '480px',
+    padding: '20px',
+    background: '#fff',
+    borderRadius: '8px',
+    boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+    textAlign: 'center' as const,
+  },
+  message: {
+    margin: '0 0 16px',
+    fontSize: '0.95rem',
+    color: '#555',
+    lineHeight: '1.5',
+  },
+  button: {
+    padding: '8px 20px',
+    fontSize: '0.875rem',
+    fontWeight: 'bold' as const,
+    color: '#fff',
+    background: '#1976D2',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+  },
+};

--- a/frontend/src/plugin-api/index.ts
+++ b/frontend/src/plugin-api/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Musicore Plugin API — public barrel (v1)
+ * Feature 030: Plugin Architecture
+ *
+ * THIS IS THE ONLY MODULE plugin code is permitted to import from the host.
+ * ESLint enforces this boundary via `no-restricted-imports` scoped to plugins/**.
+ *
+ * Re-exports the complete public API surface from types.ts.
+ * Nothing from src/ other than this barrel may be imported by plugins.
+ */
+
+export type {
+  PluginNoteEvent,
+  PluginManifest,
+  PluginContext,
+  MusicorePlugin,
+} from './types';
+
+export { PLUGIN_API_VERSION } from './types';

--- a/frontend/src/plugin-api/plugin-api.test.ts
+++ b/frontend/src/plugin-api/plugin-api.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Plugin API contract tests — T006
+ * Feature 030: Plugin Architecture
+ *
+ * Verifies the public surface exported from src/plugin-api/index.ts
+ * matches the contract defined in specs/030-plugin-architecture/contracts/plugin-api.ts.
+ *
+ * Constitution Principle V: these tests must exist and be green before
+ * any code that consumes the Plugin API is merged.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  PLUGIN_API_VERSION,
+  type PluginManifest,
+  type PluginNoteEvent,
+  type PluginContext,
+  type MusicorePlugin,
+} from './index';
+
+describe('Plugin API contract', () => {
+  describe('PLUGIN_API_VERSION', () => {
+    it('is the string "1"', () => {
+      expect(PLUGIN_API_VERSION).toBe('1');
+    });
+
+    it('is a string (not a number)', () => {
+      expect(typeof PLUGIN_API_VERSION).toBe('string');
+    });
+  });
+
+  describe('PluginNoteEvent shape', () => {
+    it('accepts an object with midiNote and timestamp', () => {
+      const event: PluginNoteEvent = { midiNote: 60, timestamp: Date.now() };
+      expect(event.midiNote).toBe(60);
+      expect(typeof event.timestamp).toBe('number');
+    });
+
+    it('accepts optional velocity', () => {
+      const event: PluginNoteEvent = { midiNote: 60, timestamp: 0, velocity: 64 };
+      expect(event.velocity).toBe(64);
+    });
+
+    it('does not include coordinate fields (Constitution Principle VI)', () => {
+      const event: PluginNoteEvent = { midiNote: 60, timestamp: 0 };
+      // Compile-time guard: 'x', 'y', 'position', 'bbox' must NOT exist on PluginNoteEvent.
+      // If they were added, TypeScript would surface an error here via @ts-expect-error reversal.
+      expect('x' in event).toBe(false);
+      expect('y' in event).toBe(false);
+      expect('position' in event).toBe(false);
+      expect('bbox' in event).toBe(false);
+    });
+  });
+
+  describe('PluginManifest shape', () => {
+    it('can be constructed with required fields', () => {
+      const manifest: PluginManifest = {
+        id: 'virtual-keyboard',
+        name: 'Virtual Keyboard',
+        version: '1.0.0',
+        pluginApiVersion: '1',
+        entryPoint: 'index.js',
+        origin: 'builtin',
+      };
+      expect(manifest.id).toBe('virtual-keyboard');
+      expect(manifest.origin).toBe('builtin');
+    });
+
+    it('accepts optional description', () => {
+      const manifest: PluginManifest = {
+        id: 'test',
+        name: 'Test',
+        version: '0.1.0',
+        pluginApiVersion: '1',
+        entryPoint: 'index.js',
+        origin: 'imported',
+        description: 'A test plugin',
+      };
+      expect(manifest.description).toBe('A test plugin');
+    });
+  });
+
+  describe('MusicorePlugin interface contract', () => {
+    it('an object satisfying MusicorePlugin compiles and has init + Component', () => {
+      // Runtime check: confirm the shape is as expected by constructing a minimal mock
+      const mockPlugin: MusicorePlugin = {
+        init: (_ctx: PluginContext) => { /* no-op */ },
+        Component: () => null,
+      };
+      expect(typeof mockPlugin.init).toBe('function');
+      expect(typeof mockPlugin.Component).toBe('function');
+    });
+
+    it('dispose is optional', () => {
+      const withoutDispose: MusicorePlugin = {
+        init: () => { /* no-op */ },
+        Component: () => null,
+      };
+      expect(withoutDispose.dispose).toBeUndefined();
+
+      const withDispose: MusicorePlugin = {
+        init: () => { /* no-op */ },
+        dispose: () => { /* no-op */ },
+        Component: () => null,
+      };
+      expect(typeof withDispose.dispose).toBe('function');
+    });
+  });
+
+  describe('PluginContext interface contract', () => {
+    it('context mock satisfies the contract', () => {
+      const manifst: PluginManifest = {
+        id: 'x',
+        name: 'X',
+        version: '1.0.0',
+        pluginApiVersion: '1',
+        entryPoint: 'index.js',
+        origin: 'builtin',
+      };
+      const ctx: PluginContext = {
+        emitNote: (_event: PluginNoteEvent) => { /* no-op */ },
+        playNote: (_event: PluginNoteEvent) => { /* no-op */ },
+        manifest: manifst,
+      };
+      expect(typeof ctx.emitNote).toBe('function');
+      expect(typeof ctx.playNote).toBe('function');
+      expect(ctx.manifest.id).toBe('x');
+    });
+  });
+});

--- a/frontend/src/plugin-api/types.ts
+++ b/frontend/src/plugin-api/types.ts
@@ -1,0 +1,118 @@
+/**
+ * Musicore Plugin API — Types (v1)
+ * Feature 030: Plugin Architecture
+ *
+ * Defines all public types for the Musicore Plugin API.
+ * See specs/030-plugin-architecture/contracts/plugin-api.ts for the canonical contract.
+ *
+ * Constitution Principle VI: PluginNoteEvent carries ONLY musical data (midiNote,
+ * timestamp, velocity). No coordinate or layout geometry is permitted here — the
+ * WASM engine is the sole authority over all spatial layout.
+ */
+
+import type { ComponentType } from 'react';
+
+// ---------------------------------------------------------------------------
+// Domain events
+// ---------------------------------------------------------------------------
+
+/**
+ * Emitted by a plugin when a note input event occurs (e.g. virtual key press).
+ * Plugins produce this event; the host consumes it and passes it to the WASM
+ * layout engine. Must NOT include coordinate or layout data.
+ */
+export interface PluginNoteEvent {
+  /** MIDI note number (0–127). Middle C = 60. */
+  readonly midiNote: number;
+  /** Millisecond timestamp (Date.now()) at the moment of input. */
+  readonly timestamp: number;
+  /** MIDI velocity (1–127). Defaults to 64 (mezzo-forte) if omitted. */
+  readonly velocity?: number;
+  /**
+   * Whether this is a key attack (note-on) or release (note-off).
+   * Defaults to 'attack' when omitted.
+   */
+  readonly type?: 'attack' | 'release';
+}
+
+// ---------------------------------------------------------------------------
+// Manifest
+// ---------------------------------------------------------------------------
+
+/**
+ * Read-only plugin descriptor. Available to plugins at runtime via PluginContext.
+ * The `origin` field is set by the host — it is NOT present in plugin.json.
+ */
+export interface PluginManifest {
+  readonly id: string;
+  readonly name: string;
+  readonly version: string;
+  readonly pluginApiVersion: string;
+  readonly entryPoint: string;
+  readonly description?: string;
+  /** Set by the host: 'builtin' for repo plugins, 'imported' for user-installed. */
+  readonly origin: 'builtin' | 'imported';
+}
+
+// ---------------------------------------------------------------------------
+// Plugin context
+// ---------------------------------------------------------------------------
+
+/**
+ * Host-provided context injected into a plugin's `init()` call.
+ * The only communication channel from plugin → host.
+ */
+export interface PluginContext {
+  /**
+   * Emit a note event to the host. The host forwards it to the
+   * WASM layout pipeline which renders the note on the staff.
+   */
+  emitNote(event: PluginNoteEvent): void;
+  /**
+   * Play a note through the host audio engine (Salamander Grand Piano samples).
+   * The host resolves the MIDI note number to sample playback via ToneAdapter.
+   *
+   * - `event.type === 'attack'` (default): triggers note-on immediately.
+   * - `event.type === 'release'`: releases a sustained note.
+   *
+   * This is the only authorised route for plugins to produce audio — plugins
+   * must NOT import Tone.js or Web Audio API directly.
+   */
+  playNote(event: PluginNoteEvent): void;
+  /** Read-only manifest for this plugin instance. */
+  readonly manifest: Readonly<PluginManifest>;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry-point contract
+// ---------------------------------------------------------------------------
+
+/**
+ * The interface every plugin's default export must satisfy.
+ *
+ * @example
+ * ```ts
+ * import type { MusicorePlugin } from '../../src/plugin-api';
+ *
+ * const plugin: MusicorePlugin = {
+ *   init(context) { ctx = context; },
+ *   Component: () => <div>My Plugin</div>,
+ * };
+ * export default plugin;
+ * ```
+ */
+export interface MusicorePlugin {
+  /** Called once when the plugin is first activated. Store context for later use. */
+  init(context: PluginContext): void;
+  /** Optional cleanup: remove listeners and release resources. */
+  dispose?(): void;
+  /** Root React component rendered when this plugin's nav entry is active. */
+  Component: ComponentType;
+}
+
+// ---------------------------------------------------------------------------
+// Current API version
+// ---------------------------------------------------------------------------
+
+/** Major version of the currently running Musicore Plugin API. */
+export const PLUGIN_API_VERSION = '1' as const;

--- a/frontend/src/services/plugins/PluginImporter.test.ts
+++ b/frontend/src/services/plugins/PluginImporter.test.ts
@@ -1,0 +1,223 @@
+/**
+ * PluginImporter tests — T020
+ * Feature 030: Plugin Architecture (US2 — Import a Third-Party Plugin)
+ *
+ * Constitution Principle V: written before PluginImporter.ts implementation.
+ *
+ * Uses fflate.zipSync to create in-memory ZIPs, and fake-indexeddb via
+ * PluginRegistry for persistence testing.
+ *
+ * Covers (per tasks.md T020):
+ * - Rejects ZIP > 5 MB file size (FR-021)
+ * - Rejects package whose pluginApiVersion > "1" (FR-019)
+ * - Rejects missing/invalid plugin.json (FR-009)
+ * - Rejects when entryPoint file is absent from ZIP
+ * - Accepts valid package and calls PluginRegistry.register
+ * - Returns { duplicate: true } when plugin id already exists
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { strToU8, zipSync } from 'fflate';
+import { importPlugin } from './PluginImporter';
+import { PluginRegistry } from './PluginRegistry';
+import type { PluginManifest } from '../../plugin-api/index';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeValidManifest(overrides: Partial<PluginManifest> = {}): Omit<PluginManifest, 'origin'> {
+  return {
+    id: 'test-plugin',
+    name: 'Test Plugin',
+    version: '1.0.0',
+    pluginApiVersion: '1',
+    entryPoint: 'index.js',
+    ...overrides,
+  };
+}
+
+/** Build a valid ZIP File containing plugin.json + index.js. */
+function makeValidZipFile(manifest = makeValidManifest()): File {
+  const data = zipSync({
+    'plugin.json': strToU8(JSON.stringify(manifest)),
+    'index.js': strToU8('export default {};'),
+  });
+  return new File([data], `${manifest.id}.zip`, { type: 'application/zip' });
+}
+
+/** Build a ZIP File missing a specific file. */
+function makeZipMissingEntry(
+  manifest = makeValidManifest(),
+  includeEntryPoint = true
+): File {
+  const files: Record<string, Uint8Array> = {
+    'plugin.json': strToU8(JSON.stringify(manifest)),
+  };
+  if (includeEntryPoint) {
+    files['index.js'] = strToU8('export default {};');
+  }
+  const data = zipSync(files);
+  return new File([data], 'plugin.zip', { type: 'application/zip' });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('importPlugin()', () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = new PluginRegistry(`plugin-registry-importer-test-${Math.random()}`);
+  });
+
+  // ── Size guard (FR-021) ─────────────────────────────────────────────────
+
+  describe('size validation (FR-021)', () => {
+    it('rejects a file whose size exceeds 5 MB', async () => {
+      // 6 MB of data — clearly over the limit even as compressed
+      const bigFile = new File(
+        [new Uint8Array(6 * 1024 * 1024)],
+        'big-plugin.zip',
+        { type: 'application/zip' }
+      );
+
+      const result = await importPlugin(bigFile, registry);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toMatch(/5 MB|size/i);
+      }
+    });
+
+    it('accepts a file small enough (< 5 MB)', async () => {
+      const file = makeValidZipFile();
+      const result = await importPlugin(file, registry);
+      // Should not fail on size (may fail for other reasons in this test)
+      if (!result.success) {
+        expect(result.error).not.toMatch(/5 MB|size/i);
+      }
+    });
+  });
+
+  // ── Manifest validation (FR-009) ────────────────────────────────────────
+
+  describe('manifest validation (FR-009)', () => {
+    it('rejects a ZIP with no plugin.json', async () => {
+      const data = zipSync({ 'index.js': strToU8('export default {};') });
+      const file = new File([data], 'plugin.zip', { type: 'application/zip' });
+
+      const result = await importPlugin(file, registry);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toMatch(/plugin\.json/i);
+      }
+    });
+
+    it('rejects a ZIP with invalid JSON in plugin.json', async () => {
+      const data = zipSync({ 'plugin.json': strToU8('{ not valid json') });
+      const file = new File([data], 'plugin.zip', { type: 'application/zip' });
+
+      const result = await importPlugin(file, registry);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a manifest missing required field "id"', async () => {
+      const badManifest = { name: 'No Id', version: '1.0.0', pluginApiVersion: '1', entryPoint: 'index.js' };
+      const data = zipSync({
+        'plugin.json': strToU8(JSON.stringify(badManifest)),
+        'index.js': strToU8(''),
+      });
+      const file = new File([data], 'plugin.zip', { type: 'application/zip' });
+
+      const result = await importPlugin(file, registry);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toMatch(/id/i);
+      }
+    });
+
+    it('rejects a manifest with invalid id pattern (uppercase)', async () => {
+      const file = makeValidZipFile(makeValidManifest({ id: 'BadId' }));
+      const result = await importPlugin(file, registry);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects when the entryPoint file is absent from the ZIP (FR-009)', async () => {
+      const file = makeZipMissingEntry(makeValidManifest(), false);
+      const result = await importPlugin(file, registry);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toMatch(/entryPoint|entry point|index\.js/i);
+      }
+    });
+  });
+
+  // ── API version check (FR-019) ───────────────────────────────────────────
+
+  describe('Plugin API version check (FR-019)', () => {
+    it('rejects a package requiring a newer Plugin API version', async () => {
+      const file = makeValidZipFile(makeValidManifest({ pluginApiVersion: '99' }));
+      const result = await importPlugin(file, registry);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toMatch(/API version|pluginApiVersion/i);
+      }
+    });
+
+    it('accepts a package with matching Plugin API version "1"', async () => {
+      const file = makeValidZipFile(makeValidManifest({ pluginApiVersion: '1' }));
+      const result = await importPlugin(file, registry);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ── Successful import ────────────────────────────────────────────────────
+
+  describe('successful import', () => {
+    it('registers the manifest in the PluginRegistry on success', async () => {
+      const file = makeValidZipFile();
+      const result = await importPlugin(file, registry);
+
+      expect(result.success).toBe(true);
+      const stored = await registry.get('test-plugin');
+      expect(stored).toBeDefined();
+      expect(stored!.manifest.id).toBe('test-plugin');
+    });
+
+    it('returns the manifest in the success result', async () => {
+      const file = makeValidZipFile();
+      const result = await importPlugin(file, registry);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.manifest.id).toBe('test-plugin');
+        expect(result.manifest.origin).toBe('imported');
+      }
+    });
+  });
+
+  // ── Duplicate detection (FR-018) ─────────────────────────────────────────
+
+  describe('duplicate detection (FR-018)', () => {
+    it('returns { success: false, duplicate: true } when id already exists', async () => {
+      // Register first
+      await importPlugin(makeValidZipFile(), registry);
+
+      // Try again
+      const result = await importPlugin(makeValidZipFile(), registry);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect((result as { duplicate?: boolean }).duplicate).toBe(true);
+      }
+    });
+
+    it('overwrites when overwrite option is true', async () => {
+      await importPlugin(makeValidZipFile(), registry);
+      const result = await importPlugin(makeValidZipFile(), registry, { overwrite: true });
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/frontend/src/services/plugins/PluginImporter.ts
+++ b/frontend/src/services/plugins/PluginImporter.ts
@@ -1,0 +1,170 @@
+/**
+ * PluginImporter — T022
+ * Feature 030: Plugin Architecture (US2 — Import a Third-Party Plugin)
+ *
+ * Validates a ZIP package, enforces all FR-009 / FR-018 / FR-019 / FR-021
+ * rules, then delegates persistence to the provided PluginRegistry instance.
+ *
+ * Constitution Principle VI: PluginNoteEvent carries no coordinate data;
+ * this module never touches note events.
+ */
+
+import { unzipSync } from 'fflate';
+import { PLUGIN_API_VERSION, type PluginManifest } from '../../plugin-api/index';
+import { type PluginRegistry, type PluginAsset } from './PluginRegistry';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ImportResult =
+  | { success: true; manifest: PluginManifest }
+  | { success: false; error: string; duplicate?: false }
+  | { success: false; duplicate: true; manifest: PluginManifest; error?: string };
+
+export interface ImportOptions {
+  /** When true, overwrite an already-installed plugin with the same id. */
+  overwrite?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+
+/** Plugin ids must be lowercase alphanumeric + hyphens only (FR-009). */
+const VALID_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function err(error: string): ImportResult {
+  return { success: false, error };
+}
+
+/** Assert that a raw JSON object has all required PluginManifest fields. */
+function validateManifestShape(
+  raw: unknown
+): raw is Omit<PluginManifest, 'origin'> {
+  if (typeof raw !== 'object' || raw === null) return false;
+  const r = raw as Record<string, unknown>;
+  return (
+    typeof r['id'] === 'string' &&
+    typeof r['name'] === 'string' &&
+    typeof r['version'] === 'string' &&
+    typeof r['pluginApiVersion'] === 'string' &&
+    typeof r['entryPoint'] === 'string'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate and import a plugin ZIP package.
+ *
+ * @param file     The ZIP file selected by the user.
+ * @param registry The PluginRegistry instance to persist into (injected for testability).
+ * @param options  Optional overwrite flag for duplicate handling.
+ */
+export async function importPlugin(
+  file: File,
+  registry: PluginRegistry,
+  options: ImportOptions = {}
+): Promise<ImportResult> {
+  // ── FR-021: Size guard (before any extraction) ───────────────────────────
+  if (file.size > MAX_BYTES) {
+    return err(`Plugin package exceeds the 5 MB size limit (file is ${(file.size / 1024 / 1024).toFixed(1)} MB).`);
+  }
+
+  // ── Extract ZIP ──────────────────────────────────────────────────────────
+  let files: Record<string, Uint8Array>;
+  try {
+    const buf = await file.arrayBuffer();
+    files = unzipSync(new Uint8Array(buf));
+  } catch {
+    return err('Failed to read ZIP package. The file may be corrupt or is not a valid ZIP.');
+  }
+
+  // ── Also enforce 5 MB uncompressed total (FR-021, belt + suspenders) ────
+  const totalUncompressed = Object.values(files).reduce(
+    (sum, bytes) => sum + bytes.byteLength,
+    0
+  );
+  if (totalUncompressed > MAX_BYTES) {
+    return err(`Plugin package uncompressed size exceeds the 5 MB limit.`);
+  }
+
+  // ── FR-009: Require plugin.json ──────────────────────────────────────────
+  if (!('plugin.json' in files)) {
+    return err('The package does not contain a plugin.json manifest.');
+  }
+
+  // ── FR-009: Parse + validate plugin.json ────────────────────────────────
+  let rawManifest: unknown;
+  try {
+    const json = new TextDecoder().decode(files['plugin.json']);
+    rawManifest = JSON.parse(json);
+  } catch {
+    return err('plugin.json is not valid JSON.');
+  }
+
+  if (!validateManifestShape(rawManifest)) {
+    const raw = rawManifest as Record<string, unknown>;
+    if (!raw || typeof raw['id'] !== 'string') {
+      return err('plugin.json is missing the required "id" field.');
+    }
+    return err('plugin.json is missing one or more required fields (id, name, version, pluginApiVersion, entryPoint).');
+  }
+
+  // ── FR-009: Validate id pattern ──────────────────────────────────────────
+  if (!VALID_ID_RE.test(rawManifest.id)) {
+    return err(
+      `Invalid plugin id "${rawManifest.id}". Plugin ids must be lowercase alphanumeric characters and hyphens only (e.g. "my-plugin").`
+    );
+  }
+
+  // ── FR-019: API version check ────────────────────────────────────────────
+  const apiVer = parseInt(rawManifest.pluginApiVersion, 10);
+  const hostVer = parseInt(PLUGIN_API_VERSION, 10);
+  if (Number.isNaN(apiVer) || apiVer > hostVer) {
+    return err(
+      `Plugin requires pluginApiVersion "${rawManifest.pluginApiVersion}" but this host only supports up to version "${PLUGIN_API_VERSION}".`
+    );
+  }
+
+  // ── FR-009: entryPoint must exist in ZIP ─────────────────────────────────
+  if (!(rawManifest.entryPoint in files)) {
+    return err(
+      `The plugin manifest specifies entryPoint "${rawManifest.entryPoint}" but that file is not present in the package.`
+    );
+  }
+
+  // Build full manifest (origin = 'imported') ──────────────────────────────
+  const manifest: PluginManifest = {
+    ...rawManifest,
+    origin: 'imported' as const,
+  };
+
+  // ── FR-018: Duplicate detection ──────────────────────────────────────────
+  const existing = await registry.get(manifest.id);
+  if (existing && !options.overwrite) {
+    return { success: false, duplicate: true, manifest };
+  }
+
+  // ── Register in IndexedDB ─────────────────────────────────────────────────
+  await registry.register(
+    manifest,
+    // Persist each file as an asset keyed by filename
+    Object.entries(files).map<PluginAsset>(([name, bytes]) => ({
+      pluginId: manifest.id,
+      name,
+      data: bytes.buffer as ArrayBuffer,
+    }))
+  );
+
+  return { success: true, manifest };
+}

--- a/frontend/src/services/plugins/PluginRegistry.test.ts
+++ b/frontend/src/services/plugins/PluginRegistry.test.ts
@@ -1,0 +1,146 @@
+/**
+ * PluginRegistry tests — T008
+ * Feature 030: Plugin Architecture
+ *
+ * Tests for the PluginRegistry IndexedDB persistence layer.
+ * Uses fake-indexeddb to run in happy-dom / Vitest without a real browser.
+ *
+ * Constitution Principle V: written before PluginRegistry.ts implementation.
+ * Constitution Principle VII: any regression must yield a failing test.
+ *
+ * Covers (per tasks.md T008):
+ * - register() persists manifest + assets atomically
+ * - list() returns all entries
+ * - get(id) returns stored entry
+ * - duplicate id overwrites existing entry
+ * - removed entry is absent from list()
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { PluginRegistry } from './PluginRegistry';
+import type { PluginManifest } from '../plugin-api/index';
+
+/** Helper: build a minimal valid PluginManifest */
+function makeManifest(overrides: Partial<PluginManifest> = {}): PluginManifest {
+  return {
+    id: 'test-plugin',
+    name: 'Test Plugin',
+    version: '1.0.0',
+    pluginApiVersion: '1',
+    entryPoint: 'index.js',
+    origin: 'imported',
+    ...overrides,
+  };
+}
+
+describe('PluginRegistry', () => {
+  let registry: PluginRegistry;
+
+  beforeEach(async () => {
+    // Create a fresh registry instance using a unique DB name per test
+    // fake-indexeddb/auto patches global indexedDB, IDBKeyRange etc.
+    registry = new PluginRegistry(`plugin-registry-test-${Math.random()}`);
+  });
+
+  describe('register()', () => {
+    it('stores a manifest and makes it retrievable via get()', async () => {
+      const manifest = makeManifest();
+      await registry.register(manifest, []);
+
+      const result = await registry.get('test-plugin');
+      expect(result).toBeDefined();
+      expect(result!.manifest.id).toBe('test-plugin');
+      expect(result!.manifest.name).toBe('Test Plugin');
+    });
+
+    it('stores assets alongside the manifest', async () => {
+      const manifest = makeManifest();
+      const asset = { pluginId: 'test-plugin', name: 'bundle.js', data: new ArrayBuffer(8) };
+      await registry.register(manifest, [asset]);
+
+      const assets = await registry.getAssets('test-plugin');
+      expect(assets).toHaveLength(1);
+      expect(assets[0].name).toBe('bundle.js');
+    });
+
+    it('overwrites an existing plugin with the same id without error', async () => {
+      const v1 = makeManifest({ version: '1.0.0' });
+      const v2 = makeManifest({ version: '2.0.0' });
+
+      await registry.register(v1, []);
+      await registry.register(v2, []);
+
+      const result = await registry.get('test-plugin');
+      expect(result!.manifest.version).toBe('2.0.0');
+    });
+  });
+
+  describe('list()', () => {
+    it('returns an empty array when no plugins are registered', async () => {
+      const plugins = await registry.list();
+      expect(plugins).toEqual([]);
+    });
+
+    it('returns all registered plugins', async () => {
+      await registry.register(makeManifest({ id: 'plugin-a', name: 'A' }), []);
+      await registry.register(makeManifest({ id: 'plugin-b', name: 'B' }), []);
+
+      const plugins = await registry.list();
+      expect(plugins).toHaveLength(2);
+      const ids = plugins.map(p => p.manifest.id).sort();
+      expect(ids).toEqual(['plugin-a', 'plugin-b']);
+    });
+  });
+
+  describe('get()', () => {
+    it('returns undefined for an unknown plugin id', async () => {
+      const result = await registry.get('nonexistent');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns the exact manifest that was registered', async () => {
+      const manifest = makeManifest({ description: 'A test plugin' });
+      await registry.register(manifest, []);
+
+      const result = await registry.get('test-plugin');
+      expect(result!.manifest.description).toBe('A test plugin');
+      expect(result!.manifest.origin).toBe('imported');
+    });
+
+    it('includes an installedAt date', async () => {
+      const before = new Date();
+      await registry.register(makeManifest(), []);
+      const after = new Date();
+
+      const result = await registry.get('test-plugin');
+      expect(result!.installedAt).toBeInstanceOf(Date);
+      expect(result!.installedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(result!.installedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+  });
+
+  describe('remove()', () => {
+    it('removes a registered plugin so it no longer appears in list()', async () => {
+      await registry.register(makeManifest(), []);
+      await registry.remove('test-plugin');
+
+      const plugins = await registry.list();
+      expect(plugins).toHaveLength(0);
+    });
+
+    it('removes associated assets', async () => {
+      const asset = { pluginId: 'test-plugin', name: 'index.js', data: new ArrayBuffer(4) };
+      await registry.register(makeManifest(), [asset]);
+      await registry.remove('test-plugin');
+
+      const assets = await registry.getAssets('test-plugin');
+      expect(assets).toHaveLength(0);
+    });
+
+    it('is a no-op for an unregistered id', async () => {
+      // Should not throw
+      await expect(registry.remove('never-existed')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/services/plugins/PluginRegistry.ts
+++ b/frontend/src/services/plugins/PluginRegistry.ts
@@ -1,0 +1,175 @@
+/**
+ * PluginRegistry — IndexedDB persistence for installed plugins
+ * Feature 030: Plugin Architecture
+ *
+ * The aggregate root for all plugin lifecycle operations.
+ * Built-in plugins (origin: 'builtin') should not be registered here —
+ * they are held in-memory via builtinPlugins.ts.
+ *
+ * IndexedDB schema (see data-model.md):
+ *   DB name:  plugin-registry       (configurable for testing)
+ *   Version:  1
+ *
+ *   Object store 'manifests'  — keyPath: 'id'
+ *     Stores: StoredManifestEntry (PluginManifest + installedAt)
+ *
+ *   Object store 'assets'     — keyPath: 'key'
+ *     Stores: StoredAsset, keyed by '{pluginId}/{filename}'
+ *     Query by pluginId: IDBKeyRange.bound('{id}/', '{id}/\uffff')
+ *
+ * Invariants (spec FR-018, data-model.md):
+ *   - duplicate id → overwrite (caller is responsible for showing confirmation)
+ *   - manifest + assets written in a single atomic transaction
+ */
+
+import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
+import type { PluginManifest } from '../../plugin-api/index';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Asset stored in indexedDB (key = '{pluginId}/{name}'). */
+export interface PluginAsset {
+  pluginId: string;
+  name: string;
+  data: ArrayBuffer;
+}
+
+/** Single row stored in the 'manifests' object store. */
+interface StoredManifestEntry {
+  id: string;      // matches manifest.id, used as keyPath
+  manifest: PluginManifest;
+  installedAt: Date;
+}
+
+/** Single row stored in the 'assets' object store. */
+interface StoredAsset extends PluginAsset {
+  /** Compound key: '{pluginId}/{name}' */
+  key: string;
+}
+
+/** What callers receive from get() and list(). */
+export interface PluginRegistryEntry {
+  manifest: PluginManifest;
+  installedAt: Date;
+}
+
+interface PluginDBSchema extends DBSchema {
+  manifests: {
+    key: string;
+    value: StoredManifestEntry;
+  };
+  assets: {
+    key: string;
+    value: StoredAsset;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PluginRegistry
+// ---------------------------------------------------------------------------
+
+export class PluginRegistry {
+  private readonly dbName: string;
+  private dbPromise: Promise<IDBPDatabase<PluginDBSchema>> | null = null;
+
+  constructor(dbName = 'plugin-registry') {
+    this.dbName = dbName;
+  }
+
+  private getDb(): Promise<IDBPDatabase<PluginDBSchema>> {
+    if (!this.dbPromise) {
+      this.dbPromise = openDB<PluginDBSchema>(this.dbName, 1, {
+        upgrade(db) {
+          db.createObjectStore('manifests', { keyPath: 'id' });
+          db.createObjectStore('assets', { keyPath: 'key' });
+        },
+      });
+    }
+    return this.dbPromise;
+  }
+
+  /**
+   * Register (or overwrite) a plugin. Writes manifest + assets atomically.
+   * Caller must ensure duplicate confirmation has occurred (FR-018).
+   */
+  async register(manifest: PluginManifest, assets: PluginAsset[]): Promise<void> {
+    const db = await this.getDb();
+    const tx = db.transaction(['manifests', 'assets'], 'readwrite');
+
+    // Remove existing assets for this plugin before writing new ones
+    const assetStore = tx.objectStore('assets');
+    const existingKeys = await assetStore.getAllKeys(
+      IDBKeyRange.bound(`${manifest.id}/`, `${manifest.id}/\uffff`)
+    );
+    await Promise.all(existingKeys.map(k => assetStore.delete(k)));
+
+    // Write new manifest
+    await tx.objectStore('manifests').put({
+      id: manifest.id,
+      manifest,
+      installedAt: new Date(),
+    });
+
+    // Write new assets
+    await Promise.all(
+      assets.map(asset =>
+        assetStore.put({
+          key: `${asset.pluginId}/${asset.name}`,
+          pluginId: asset.pluginId,
+          name: asset.name,
+          data: asset.data,
+        })
+      )
+    );
+
+    await tx.done;
+  }
+
+  /** Return all registered plugins (imported only; builtins are held in-memory). */
+  async list(): Promise<PluginRegistryEntry[]> {
+    const db = await this.getDb();
+    const entries = await db.getAll('manifests');
+    return entries.map(e => ({ manifest: e.manifest, installedAt: e.installedAt }));
+  }
+
+  /** Retrieve a single plugin by id. Returns undefined if not found. */
+  async get(id: string): Promise<PluginRegistryEntry | undefined> {
+    const db = await this.getDb();
+    const entry = await db.get('manifests', id);
+    if (!entry) return undefined;
+    return { manifest: entry.manifest, installedAt: entry.installedAt };
+  }
+
+  /** Retrieve all stored assets for a given plugin id. */
+  async getAssets(pluginId: string): Promise<PluginAsset[]> {
+    const db = await this.getDb();
+    const stored = await db.getAll(
+      'assets',
+      IDBKeyRange.bound(`${pluginId}/`, `${pluginId}/\uffff`)
+    );
+    return stored.map(s => ({ pluginId: s.pluginId, name: s.name, data: s.data }));
+  }
+
+  /**
+   * Remove a plugin and all its assets. No-op if plugin not registered.
+   */
+  async remove(id: string): Promise<void> {
+    const db = await this.getDb();
+    const tx = db.transaction(['manifests', 'assets'], 'readwrite');
+
+    await tx.objectStore('manifests').delete(id);
+
+    const assetStore = tx.objectStore('assets');
+    const keys = await assetStore.getAllKeys(
+      IDBKeyRange.bound(`${id}/`, `${id}/\uffff`)
+    );
+    await Promise.all(keys.map(k => assetStore.delete(k)));
+
+    await tx.done;
+  }
+}
+
+/** Singleton instance used by the application. */
+export const pluginRegistry = new PluginRegistry();

--- a/frontend/src/services/plugins/builtinPlugins.ts
+++ b/frontend/src/services/plugins/builtinPlugins.ts
@@ -1,0 +1,32 @@
+/**
+ * Built-in plugin registry — T016
+ * Feature 030: Plugin Architecture
+ *
+ * Built-in plugins are bundled at build time and registered in-memory on app
+ * startup. They are NOT written to IndexedDB (see research.md R-006).
+ *
+ * The Virtual Keyboard plugin manifests here as the first built-in.
+ */
+
+import type { PluginManifest, MusicorePlugin } from '../../plugin-api/index';
+import virtualKeyboardPlugin from '../../../plugins/virtual-keyboard/index';
+import virtualKeyboardManifestJson from '../../../plugins/virtual-keyboard/plugin.json';
+
+export interface BuiltinPluginEntry {
+  manifest: PluginManifest;
+  plugin: MusicorePlugin;
+}
+
+/**
+ * All built-in plugins bundled with the repository.
+ * origin is set to 'builtin' here — it is NOT present in plugin.json.
+ */
+export const BUILTIN_PLUGINS: BuiltinPluginEntry[] = [
+  {
+    manifest: {
+      ...(virtualKeyboardManifestJson as Omit<PluginManifest, 'origin'>),
+      origin: 'builtin' as const,
+    },
+    plugin: virtualKeyboardPlugin,
+  },
+];

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -25,6 +25,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "tests/**/*"]
+  "include": ["src", "plugins"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "tests/**/*", "plugins/**/*.test.ts", "plugins/**/*.test.tsx", "plugins/lint-test/**"]
 }

--- a/specs/001-plugin-architecture/spec.md
+++ b/specs/001-plugin-architecture/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: Plugin Architecture with Virtual Keyboard Sample Plugin
+
+**Feature Branch**: `001-plugin-architecture`
+**Created**: 2026-02-25
+**Status**: Draft
+**Input**: User description: "plugin architecture with virtual keyboard sample plugin — virtual keyboard view where touching keys shows notes on a staff; plugin assets in frontend/plugins/virtual-keyboard; same internal architecture as the rest of the project; plugins added via plugin importer controller; built-in repo plugins available by default; new navigation entry per installed plugin; plugins restricted to the Musicore Plugin API"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Play Virtual Keyboard (Priority: P1)
+
+A user opens the Musicore app and finds the Virtual Keyboard plugin already available in the navigation. They tap individual piano keys and see the played notes rendered on a music staff in real time, giving them an interactive way to explore music notation while playing by ear.
+
+**Why this priority**: This is the core visible value of the entire feature. It proves the plugin architecture works end-to-end and delivers immediate musical utility without any setup required from the user.
+
+**Independent Test**: Can be fully tested by opening the app, navigating to the Virtual Keyboard plugin view, clicking piano keys, and verifying notes appear on the staff — no imports or configuration required.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has opened the app for the first time, **When** they look at the navigation, **Then** the Virtual Keyboard plugin is listed as a default navigation entry.
+2. **Given** the Virtual Keyboard view is open, **When** the user taps a white key (e.g., middle C), **Then** the corresponding note appears on the staff within 100 ms of the tap.
+3. **Given** the Virtual Keyboard view is open, **When** the user taps a black key (sharp/flat), **Then** the note with its correct accidental symbol appears on the staff.
+4. **Given** the user has played several notes in sequence, **When** they look at the staff, **Then** all played notes are shown in the order they were played.
+5. **Given** the Virtual Keyboard view is open on a touch device, **When** the user touches a key, **Then** the key shows a pressed visual state and the note appears on the staff.
+
+---
+
+### User Story 2 - Import a Third-Party Plugin (Priority: P2)
+
+A user who wants to extend Musicore beyond its defaults opens the plugin importer, selects a plugin package from their device, and adds it to the app. The new plugin immediately appears as a navigation entry they can access.
+
+**Why this priority**: This validates the extensibility mechanism. Without it, the plugin architecture is a build-time concept only — the importer is what makes it a live platform.
+
+**Independent Test**: Can be fully tested by accessing the plugin importer, uploading a valid plugin package, and confirming a new navigation entry appears — independently of the virtual keyboard plugin.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the plugin importer screen, **When** they select a valid plugin package from their device, **Then** the plugin is installed and a confirmation message is shown.
+2. **Given** a plugin has been successfully imported, **When** the user returns to the main navigation, **Then** a new entry for the imported plugin is visible.
+3. **Given** the user taps the new navigation entry, **When** the plugin view loads, **Then** the plugin's interface is displayed correctly.
+4. **Given** the user uploads an invalid or malformed plugin package, **When** the import is attempted, **Then** the system rejects it with a clear error message and no partial installation occurs.
+5. **Given** a previously imported plugin exists, **When** the user closes and reopens the app (PWA reload), **Then** the plugin is still present in the navigation and functional.
+
+---
+
+### User Story 3 - Navigate Between Installed Plugins (Priority: P3)
+
+A user who has the default Virtual Keyboard plugin plus one imported plugin can navigate freely between both plugin views and the rest of the app. Each plugin is reachable from a consistent place in the app UI.
+
+**Why this priority**: Navigation cohesion ensures plugins feel like first-class citizens rather than bolted-on extras. Depends on P1 and P2 being functional.
+
+**Independent Test**: Can be tested with only the built-in virtual keyboard plugin in navigation, confirming it can be accessed and the user can return to other app views without issues.
+
+**Acceptance Scenarios**:
+
+1. **Given** one or more plugins are installed, **When** the user opens the navigation, **Then** each installed plugin has exactly one entry listed.
+2. **Given** the user is in a plugin view, **When** they tap a non-plugin navigation entry, **Then** the plugin view is dismissed and the selected view loads correctly.
+3. **Given** multiple plugins are installed, **When** the user switches between plugin views, **Then** each plugin view renders its own independent state without interference from others.
+
+---
+
+### User Story 4 - Plugin Developer Builds with the Plugin API (Priority: P4)
+
+A plugin developer writes a new Musicore plugin using only the documented Plugin API. They can complete the plugin from scratch using the API reference and the virtual keyboard plugin as an example, without needing access to Musicore's internal source code.
+
+**Why this priority**: This ensures the Plugin API contract is robust and documented. It is the lowest priority as it serves developers rather than end users and depends on all prior stories being complete.
+
+**Independent Test**: Can be validated by confirming the Plugin API documentation covers all capabilities used by the virtual keyboard plugin, and that no undocumented internal APIs are referenced within `frontend/plugins/virtual-keyboard`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads the Plugin API documentation, **When** they build a plugin using only documented API methods, **Then** the plugin installs and runs correctly without errors.
+2. **Given** the virtual keyboard plugin codebase, **When** a developer reviews it, **Then** every Musicore-specific call goes through the Plugin API with no direct access to app internals.
+3. **Given** a plugin that attempts to call a non-Plugin-API internal, **When** the plugin is loaded, **Then** the call fails with a descriptive error rather than silently accessing private state.
+
+---
+
+### Edge Cases
+
+- What happens when the user imports a plugin with the same name as an already-installed plugin?
+- What happens if a plugin package exceeds a maximum size threshold?
+- What happens when the app is offline and the user tries to use the plugin importer?
+- How does the system behave if a plugin crashes or throws an unhandled error during use?
+- What happens if the user plays keys faster than the staff can render (rapid sequential tapping)?
+- What happens on small screens that cannot fit a full piano keyboard?
+- How does the Virtual Keyboard layout adapt when the device orientation changes?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Plugin System**
+
+- **FR-001**: The app MUST define a Plugin API that is the exclusive interface through which plugins interact with Musicore functionality; plugins MUST NOT access any other internal application interfaces directly.
+- **FR-002**: The Plugin API MUST be documented in human-readable form within the repository, covering all available operations a plugin may invoke.
+- **FR-003**: Each plugin MUST be self-contained within a dedicated folder following the naming convention `frontend/plugins/[plugin-name]`; no plugin assets may reside outside its designated folder.
+- **FR-004**: Plugins MUST follow the same internal architectural patterns applied throughout the rest of the Musicore frontend project (component structure, state management approach, testing conventions).
+- **FR-005**: All plugins shipped within the Musicore repository MUST be available to the PWA by default without any user action; users MUST NOT need to manually import built-in plugins.
+- **FR-006**: When a plugin becomes available (built-in or imported), the app navigation MUST gain exactly one new entry pointing to that plugin's view.
+- **FR-007**: The app MUST provide a Plugin Importer that allows users to add external plugins to the PWA.
+- **FR-008**: The Plugin Importer MUST accept a plugin package in the form of a ZIP archive containing a plugin manifest file and the plugin's assets.
+- **FR-009**: The Plugin Importer MUST validate the uploaded package before activating it; packages that fail validation MUST be rejected with a descriptive error and leave the app state unchanged.
+- **FR-010**: Imported plugins MUST persist across app reloads (PWA sessions); a plugin installed in one session MUST still be available in subsequent sessions without re-importing.
+- **FR-011**: Users MUST be able to view a list of all currently installed plugins (both built-in and imported).
+
+**Virtual Keyboard Plugin**
+
+- **FR-012**: The Virtual Keyboard plugin MUST render a visual piano keyboard spanning at least two full octaves.
+- **FR-013**: When a user presses a key on the virtual keyboard, the corresponding musical note MUST be displayed on a music staff within the plugin view.
+- **FR-014**: All notes played during a session MUST accumulate on the staff in the order they were played, forming a growing notation sequence.
+- **FR-015**: The virtual keyboard MUST visually indicate the pressed state of a key during a tap or click interaction.
+- **FR-016**: The Virtual Keyboard plugin MUST display each played note on the staff within 100 ms of the key press.
+- **FR-017**: All assets for the Virtual Keyboard plugin MUST reside within `frontend/plugins/virtual-keyboard`; the plugin MUST use only the Musicore Plugin API to render notation and access any app capability.
+
+### Key Entities
+
+- **Plugin**: A self-contained module with a manifest, a view component, and a defined set of declared capabilities, accessible exclusively through the Plugin API. Identified by a unique name and version.
+- **Plugin Manifest**: A descriptor file bundled with a plugin that declares its name, version, entry point, and optionally the Plugin API operations it uses.
+- **Plugin Registry**: The in-app record of all installed plugins (built-in and imported), persisted across sessions.
+- **Musicore Plugin API**: The documented, versioned interface through which plugins access notation rendering and other Musicore capabilities without touching app internals.
+- **Plugin Importer**: The UI controller that orchestrates package upload, validation, registration, and navigation entry creation.
+- **Virtual Keyboard Plugin**: The reference plugin bundled with the repository, demonstrating the plugin architecture by displaying a piano keyboard that feeds played notes into a staff notation view.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A first-time user can access and play the Virtual Keyboard plugin within 30 seconds of opening the app, with no setup steps required.
+- **SC-002**: Every note played on the virtual keyboard appears on the staff in under 100 ms of the key press, ensuring the interaction feels instantaneous.
+- **SC-003**: A user can successfully import a valid third-party plugin in under 2 minutes from opening the plugin importer to seeing the new navigation entry.
+- **SC-004**: 100% of the Virtual Keyboard plugin's Musicore-facing calls go through the documented Plugin API — zero direct internal API calls, verifiable by code review and static analysis.
+- **SC-005**: An invalid plugin package is rejected with a descriptive error message in under 3 seconds of upload completion; the app remains fully functional after rejection.
+- **SC-006**: All installed plugins (built-in and imported) remain available across PWA reloads with no data loss and no re-import required.
+- **SC-007**: The Plugin API documentation covers every method used by the Virtual Keyboard plugin, enabling a developer to replicate the plugin from documentation alone without reading Musicore's internal source code.
+- **SC-008**: Plugin API compliance is enforced by documentation and code review; all plugins, including the virtual keyboard reference, are verified to contain zero direct calls to app internals. No runtime sandboxing is required for this phase; the Plugin API boundary is a documented contract upheld by repository policy.
+
+## Assumptions
+
+- Plugin packages are distributed as ZIP archives containing a `plugin.json` manifest and the plugin's assets; this is the format the importer accepts.
+- Notes played on the Virtual Keyboard accumulate onto the staff for the duration of the session; there is no note-by-note replacement or automatic scroll-off.
+- The Plugin API will initially expose notation rendering (display a note on a staff) and key-event handling; audio playback and score export capabilities may be added in future iterations.
+- Imported plugins are stored in the browser's local persistent storage after import, enabling offline access in subsequent sessions.
+- The virtual keyboard layout presents a fixed set of keys; the number of visible octaves may adapt to available screen width, but individual key dimensions do not resize.
+- Removing a plugin and its navigation entry is out of scope for this initial feature.
+- The Plugin Importer is accessible from the app's settings or a dedicated management area; exact placement in the navigation is determined during planning.
+
+

--- a/specs/030-plugin-architecture/checklists/requirements.md
+++ b/specs/030-plugin-architecture/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Plugin Architecture with Virtual Keyboard Sample Plugin
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-25
+**Feature**: [spec.md](../spec.md)
+**Branch**: `030-plugin-architecture`
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — resolved: SC-008 uses documentation + code review enforcement (Option A)
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. SC-008 resolved: plugin API compliance is enforced by documentation and code review only — plugins run in the same JS context as the app; no runtime sandboxing in this phase.
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/030-plugin-architecture/contracts/plugin-api.ts
+++ b/specs/030-plugin-architecture/contracts/plugin-api.ts
@@ -1,0 +1,127 @@
+/**
+ * Musicore Plugin API — v1
+ *
+ * This is the ONLY module that plugin code may import from the host application.
+ * ESLint enforces this boundary via `no-restricted-imports` scoped to `plugins/**`.
+ *
+ * @module plugin-api
+ */
+
+// ---------------------------------------------------------------------------
+// Domain events
+// ---------------------------------------------------------------------------
+
+/**
+ * Emitted by a plugin when a note input event occurs (e.g. virtual key press).
+ * Plugins produce this event; the host consumes it and passes it to the WASM
+ * layout engine. Plugins must NOT include any coordinate or layout data here —
+ * all spatial geometry is the exclusive domain of the WASM engine.
+ */
+export interface PluginNoteEvent {
+  /** MIDI note number (0–127). Middle C = 60. */
+  readonly midiNote: number;
+  /** Millisecond timestamp (Date.now()) at the moment of input. */
+  readonly timestamp: number;
+  /**
+   * MIDI velocity (1–127). Defaults to 64 (mezzo-forte) if not provided by
+   * the plugin.
+   */
+  readonly velocity?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Manifest (read-only view available to plugins at runtime)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read-only descriptor provided to a plugin's `init()` call.
+ * Plugins must not mutate this object.
+ */
+export interface PluginManifest {
+  /** Unique plugin identifier (URL-safe lowercase string). */
+  readonly id: string;
+  /** Human-readable display name. */
+  readonly name: string;
+  /** Plugin version (SemVer). */
+  readonly version: string;
+  /** Minimum Musicore Plugin API major version this plugin requires. */
+  readonly pluginApiVersion: string;
+  /** Entry point path (informational; already resolved by the time init() runs). */
+  readonly entryPoint: string;
+  /** Optional display description. */
+  readonly description?: string;
+  /** Set by the host; not present in plugin.json. */
+  readonly origin: 'builtin' | 'imported';
+}
+
+// ---------------------------------------------------------------------------
+// Plugin context
+// ---------------------------------------------------------------------------
+
+/**
+ * Host-provided context object injected into a plugin's `init()` call.
+ * Provides the only communication channel from plugin to host.
+ */
+export interface PluginContext {
+  /**
+   * Emit a note event to the host. The host forwards it to the WASM layout
+   * engine which renders the note on the staff.
+   *
+   * @param event - The note event to emit.
+   */
+  emitNote(event: PluginNoteEvent): void;
+
+  /**
+   * The read-only manifest for this plugin instance.
+   * Useful for plugins that display their own name/version.
+   */
+  readonly manifest: Readonly<PluginManifest>;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry-point contract
+// ---------------------------------------------------------------------------
+
+/**
+ * The interface every plugin's default export must satisfy.
+ *
+ * @example
+ * ```ts
+ * // frontend/plugins/my-plugin/index.ts
+ * import type { MusicorePlugin } from '../../src/plugin-api';
+ *
+ * const plugin: MusicorePlugin = {
+ *   init(context) { ... },
+ *   Component: () => <div>My Plugin</div>,
+ * };
+ * export default plugin;
+ * ```
+ */
+export interface MusicorePlugin {
+  /**
+   * Called once by the host when the plugin is activated for the first time.
+   * Plugins should register any listeners and store the `context` reference.
+   *
+   * @param context - Host-provided context for emitting events.
+   */
+  init(context: PluginContext): void;
+
+  /**
+   * Optional cleanup hook called when the plugin is deactivated or unloaded.
+   * Plugins should remove event listeners and release resources.
+   */
+  dispose?(): void;
+
+  /**
+   * The root React component the host renders when the plugin's navigation
+   * entry is active.
+   */
+  Component: React.ComponentType;
+}
+
+// ---------------------------------------------------------------------------
+// Current API version (exported as const for import-time checks)
+// ---------------------------------------------------------------------------
+
+/** Major version of the currently running Musicore Plugin API. */
+export const PLUGIN_API_VERSION = '1' as const;

--- a/specs/030-plugin-architecture/contracts/plugin-manifest.schema.json
+++ b/specs/030-plugin-architecture/contracts/plugin-manifest.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://musicore.app/schemas/plugin-manifest.schema.json",
+  "title": "PluginManifest",
+  "description": "Descriptor file (plugin.json) required in every Musicore plugin package.",
+  "type": "object",
+  "required": ["id", "name", "version", "pluginApiVersion", "entryPoint"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique, URL-safe plugin identifier. Used as primary key in the plugin registry.",
+      "pattern": "^[a-z0-9-]+$",
+      "minLength": 1,
+      "maxLength": 64,
+      "examples": ["virtual-keyboard", "chord-trainer"]
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable display name shown in navigation and plugin list.",
+      "minLength": 1,
+      "maxLength": 128,
+      "examples": ["Virtual Keyboard", "Chord Trainer"]
+    },
+    "version": {
+      "type": "string",
+      "description": "Plugin version as a SemVer string.",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "examples": ["1.0.0", "2.3.1-beta.1"]
+    },
+    "pluginApiVersion": {
+      "type": "string",
+      "description": "Minimum Musicore Plugin API major version required. The importer rejects the plugin if the app's current API version is lower.",
+      "pattern": "^[1-9][0-9]*$",
+      "examples": ["1", "2"]
+    },
+    "entryPoint": {
+      "type": "string",
+      "description": "Relative path inside the ZIP to the plugin's compiled JavaScript entry module.",
+      "minLength": 1,
+      "examples": ["index.js", "dist/plugin.js"]
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional short description shown in the plugin list.",
+      "maxLength": 256,
+      "examples": ["A virtual piano keyboard that shows notes on the score in real-time."]
+    }
+  }
+}

--- a/specs/030-plugin-architecture/data-model.md
+++ b/specs/030-plugin-architecture/data-model.md
@@ -1,0 +1,122 @@
+# Data Model: Plugin Architecture
+
+**Branch**: `030-plugin-architecture` | **Date**: 2026-02-25
+
+---
+
+## Entities
+
+### PluginManifest
+
+The descriptor bundled with every plugin. Stored in IndexedDB (`manifests` object store) for imported plugins; loaded directly at build time for built-in plugins.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | ✅ | Unique plugin identifier, URL-safe (e.g. `virtual-keyboard`). Serves as the primary key. |
+| `name` | `string` | ✅ | Human-readable display name (e.g. `"Virtual Keyboard"`). Shown in navigation and plugin list. |
+| `version` | `string` | ✅ | SemVer string (e.g. `"1.0.0"`). Displayed in the plugin list; used in overwrite confirmation prompt (FR-018). |
+| `pluginApiVersion` | `string` | ✅ | Minimum Musicore Plugin API version required (e.g. `"1"`). Validated against current app API version during import (FR-019). |
+| `entryPoint` | `string` | ✅ | Path to the plugin's main JS/TS entry file within the ZIP package (e.g. `"index.js"`). |
+| `description` | `string` | ❌ | Optional short description for display in the plugin list. |
+| `origin` | `"builtin" \| "imported"` | — | Set by the registry (not present in the ZIP manifest); `"builtin"` for repo plugins, `"imported"` for user-installed. |
+
+**Validation rules** (FR-009):
+- `id` must match pattern `/^[a-z0-9-]+$/` (lowercase alphanumeric + hyphens)
+- `version` must be a valid SemVer string
+- `pluginApiVersion` must be a non-empty string parseable as a positive integer
+- `entryPoint` file must exist within the ZIP (`files[entryPoint]` is defined)
+- Package ZIP uncompressed size must not exceed 5 MB (FR-021)
+
+---
+
+### PluginRegistryEntry
+
+The runtime record in the Plugin Registry. Combines the manifest with runtime metadata.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `manifest` | `PluginManifest` | The plugin's descriptor. |
+| `component` | `React.ComponentType` | The plugin's root view component (resolved at build time for builtins; dynamically loaded for imported plugins). |
+| `installedAt` | `Date` | ISO timestamp of installation. Stored in IndexedDB for imported plugins. |
+
+---
+
+### PluginAsset
+
+Auxiliary files bundled with an imported plugin (JS bundles, CSS, images). Stored in IndexedDB (`assets` object store) keyed by `{pluginId}/{filename}`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pluginId` | `string` | Foreign key → `PluginManifest.id` |
+| `name` | `string` | Relative path within the ZIP (e.g. `"bundle.js"`, `"styles.css"`). Combined with `pluginId` as the storage key. |
+| `data` | `ArrayBuffer` | Raw file bytes. |
+
+---
+
+### PluginNoteEvent
+
+The domain event emitted by a plugin (e.g. Virtual Keyboard key press) and passed to the Plugin API for notation rendering.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `midiNote` | `number` | Integer MIDI note number (0–127). Middle C = 60. |
+| `timestamp` | `number` | Millisecond timestamp (`Date.now()`) at the moment of the key press. |
+| `velocity` | `number` | Optional MIDI velocity (1–127). Defaults to 64 if not provided. |
+
+---
+
+## Plugin Registry — Aggregate
+
+`PluginRegistry` is the aggregate root for all plugin lifecycle operations.
+
+**Invariants**:
+- No two plugins may share the same `id` (overwrite requires confirmation, FR-018).
+- Built-in plugins (origin `"builtin"`) cannot be overwritten or removed through the importer.
+- A plugin with a `pluginApiVersion` greater than the current app's Plugin API version is never registered (FR-019).
+- All imported plugin writes are atomic: manifest + assets committed together or not at all.
+
+**State transitions**:
+
+```
+[package uploaded]
+      │
+      ▼
+[validation] ─── fail ──► [rejected with error] ─► end
+      │
+     pass
+      │
+      ▼
+[duplicate check] ─── found ──► [confirmation prompt]
+      │                               │ cancel ──► end
+     none                             │ confirm ──►
+      │                               │
+      └──────────────────────────────►│
+                                      ▼
+                              [write to IndexedDB]
+                                      │
+                                      ▼
+                              [navigation entry added]
+                                      │
+                                      ▼
+                                    [done]
+```
+
+---
+
+## IndexedDB Schema
+
+**Database name**: `plugin-registry`  
+**Version**: `1`
+
+| Object Store | Key Path | Description |
+|---|---|---|
+| `manifests` | `id` | One entry per installed imported plugin (PluginManifest + `installedAt`). |
+| `assets` | `name` | One entry per asset file (`{pluginId}/{filename}`). |
+
+Built-in plugins are held in-memory only (not written to IndexedDB).
+
+---
+
+## Post-Design Constitution Check (Principle VI)
+
+`PluginNoteEvent` carries only `midiNote` (integer), `timestamp`, and `velocity`. It contains **no coordinate data** (no `x`, `y`, bounding boxes, or layout geometry). The Plugin API method `renderNote(event)` passes the note to the existing WASM `computeLayout` pipeline — the WASM engine is the sole authority over all spatial geometry. This satisfies Constitution Principle VI.

--- a/specs/030-plugin-architecture/plan.md
+++ b/specs/030-plugin-architecture/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: Plugin Architecture with Virtual Keyboard Sample Plugin
+
+**Branch**: `030-plugin-architecture` | **Date**: 2026-02-25 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/030-plugin-architecture/spec.md`
+
+## Summary
+
+Introduce a plugin architecture for the Musicore PWA. Plugins are self-contained React views that interact with the app exclusively through a documented Musicore Plugin API. A built-in Virtual Keyboard plugin (assets in `frontend/plugins/virtual-keyboard`) demonstrates the architecture: tapping piano keys displays the played notes on a music staff using the WASM layout engine via the Plugin API. A Plugin Importer controller allows users to add external plugins (ZIP packages) at runtime; each installed plugin gains a dedicated navigation entry. Plugin API compliance is enforced by ESLint static analysis and code review.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18, Vite  
+**Primary Dependencies**: React 18 (error boundary API), `fflate` (ZIP extraction, ~8 KB gz), `idb` v8 (IndexedDB, ~1.7 KB gz), ESLint flat config (`no-restricted-imports`)  
+**Storage**: IndexedDB (plugin registry — manifests + asset blobs; persists across PWA sessions)  
+**Testing**: Vitest + React Testing Library (existing setup)  
+**Target Platform**: Tablet-first PWA — Chrome, Safari, Firefox, Edge (see constitution §III)  
+**Project Type**: Web application (frontend-only; no Rust/WASM changes needed for plugin infrastructure; Plugin API delegates notation rendering to existing WASM pipeline)  
+**Performance Goals**: Note-to-staff display ≤100 ms (FR-016/SC-002); plugin import end-to-end ≤2 min (SC-003); invalid package rejection ≤3 s (SC-005)  
+**Constraints**: Plugin packages ≤5 MB (FR-021); offline-capable (plugins stored in IndexedDB, no network required after install); 44×44 px touch targets  
+**Scale/Scope**: Initial scope — 1 built-in plugin (Virtual Keyboard); runtime-installed plugins limited only by IndexedDB storage quota
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Domain-Driven Design | ✅ PASS | Plugin, PluginManifest, PluginRegistry are first-class domain entities with ubiquitous language. PluginRegistry is the aggregate root for plugin lifecycle. |
+| II. Hexagonal Architecture | ✅ PASS | Plugin API is a port (defines what plugins can request). PluginImporter and IndexedDB adapter are adapters implementing persistence and package-ingestion ports. Plugin views are pure UI adapters. |
+| III. PWA — Offline-First | ✅ PASS | Built-in plugins bundled at build time; imported plugins stored in IndexedDB. All plugin views functional without network after first load. |
+| IV. Precision & Fidelity | ✅ PASS | Virtual Keyboard key events use integer MIDI note numbers. Note display delegated to WASM layout engine via Plugin API, preserving engine authority. |
+| V. Test-First Development | ✅ REQUIRED | All Plugin API methods, PluginRegistry operations, PluginImporter validation, Virtual Keyboard interactions, and error boundary behaviour must be TDD. No implementation PR without tests. |
+| VI. Layout Engine Authority | ✅ PASS | Plugin API's `renderNote` delegates directly to existing WASM `computeLayout` pipeline. Virtual Keyboard plugin MUST NOT perform coordinate calculations; it emits note events, the Plugin API and WASM engine handle geometry. TypeScript-side layout in plugin code is explicitly prohibited. |
+| VII. Regression Prevention | ✅ REQUIRED | Any error discovered during implementation (validation edge cases, IndexedDB failures, ESLint false negatives) must yield a failing test before the fix. |
+
+**Post-Design Re-Check**: Re-evaluate Principle VI after data-model is finalised — confirm `renderNote` in Plugin API contract does not expose or accept coordinate parameters.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-plugin-architecture/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── plugin-manifest.schema.json   # Plugin manifest JSON Schema
+│   └── plugin-api.ts                 # Plugin API TypeScript interface
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+├── plugins/
+│   └── virtual-keyboard/         # Virtual Keyboard plugin (FR-003, FR-017)
+│       ├── plugin.json           # Plugin manifest
+│       ├── index.tsx             # Plugin view entry point
+│       ├── VirtualKeyboard.tsx   # Piano keyboard component
+│       ├── VirtualKeyboard.css
+│       └── VirtualKeyboard.test.tsx
+│
+└── src/
+    ├── plugin-api/               # Musicore Plugin API (the only import plugins may use)
+    │   ├── index.ts              # Public API surface (sole export from plugin-api)
+    │   ├── types.ts              # PluginManifest, PluginNoteEvent, PluginContext types
+    │   └── plugin-api.test.ts
+    │
+    ├── services/
+    │   └── plugins/
+    │       ├── PluginRegistry.ts        # CRUD + persistence via idb
+    │       ├── PluginRegistry.test.ts
+    │       ├── PluginImporter.ts        # ZIP extraction, validation, registration
+    │       ├── PluginImporter.test.ts
+    │       └── builtinPlugins.ts        # Registers frontend/plugins/* at startup
+    │
+    ├── components/
+    │   └── plugins/
+    │       ├── PluginView.tsx           # Error boundary wrapper for any plugin view
+    │       ├── PluginView.test.tsx
+    │       ├── PluginImporterDialog.tsx # Upload UI + confirmation dialogs
+    │       ├── PluginImporterDialog.test.tsx
+    │       └── PluginNavEntry.tsx       # Navigation entry component per plugin
+    │
+    └── App.tsx                   # Extended: plugin navigation entries added dynamically
+```
+
+**Structure Decision**: Frontend-only feature (Option 2 web, frontend subtree only). No Rust backend changes. The `frontend/plugins/` directory is the plugin home per FR-003; `frontend/src/plugin-api/` is the enforced API boundary; `frontend/src/services/plugins/` contains domain logic following the existing `services/` hexagonal pattern.
+
+## Complexity Tracking
+
+> No constitution violations. No complexity justification required.

--- a/specs/030-plugin-architecture/quickstart.md
+++ b/specs/030-plugin-architecture/quickstart.md
@@ -1,0 +1,210 @@
+# Plugin Architecture — Developer Quickstart
+
+**Branch**: `030-plugin-architecture`
+
+This guide covers:
+1. Running the app and seeing the Virtual Keyboard plugin
+2. Creating a new plugin from scratch
+3. Packaging and testing a plugin ZIP import
+4. Understanding the ESLint API-boundary enforcement
+
+---
+
+## 1. Running the App and Seeing the Virtual Keyboard
+
+```bash
+# From the repo root:
+cd frontend
+npm install
+npm run dev
+```
+
+Open `http://localhost:5173`. The **Virtual Keyboard** entry appears in the navigation bar (it is a built-in plugin, always present).
+
+Click **Virtual Keyboard** → the keyboard view renders. Tap or click a key → the corresponding note appears on the staff above the keyboard.
+
+---
+
+## 2. Creating a New Plugin
+
+### Folder structure
+
+All plugins live under `frontend/plugins/<plugin-id>/`.
+
+```
+frontend/plugins/
+└── my-plugin/
+    ├── plugin.json         ← manifest (required)
+    ├── index.tsx           ← plugin entry point (must export default MusicorePlugin)
+    ├── MyPlugin.tsx        ← root React component (imported by index.tsx)
+    ├── MyPlugin.css        ← optional styles
+    └── MyPlugin.test.tsx   ← optional Vitest tests
+```
+
+### plugin.json reference
+
+```json
+{
+  "id": "my-plugin",
+  "name": "My Plugin",
+  "version": "1.0.0",
+  "pluginApiVersion": "1",
+  "entryPoint": "index.js",
+  "description": "A short description for the plugin list."
+}
+```
+
+| Field | Notes |
+|-------|-------|
+| `id` | Lowercase, alphanumeric + hyphens only. Must be unique across all installed plugins. |
+| `version` | SemVer (`MAJOR.MINOR.PATCH`). Shown in the duplicate-name confirmation dialog. |
+| `pluginApiVersion` | Integer string. The importer rejects the plugin if this exceeds the app's current Plugin API version (`"1"`). |
+| `entryPoint` | The compiled JS file *inside* the ZIP (not the source path). For built-in plugins, this field is informational. |
+
+### index.tsx skeleton
+
+```tsx
+// frontend/plugins/my-plugin/index.tsx
+import type { MusicorePlugin } from '../../src/plugin-api';
+import MyPlugin from './MyPlugin';
+
+const plugin: MusicorePlugin = {
+  init(context) {
+    // Store context if needed to call context.emitNote() later.
+    console.log('my-plugin initialised', context.manifest.version);
+  },
+
+  dispose() {
+    // Clean up listeners / timers here.
+  },
+
+  Component: MyPlugin,
+};
+
+export default plugin;
+```
+
+### Emitting a note event
+
+```tsx
+// Inside a component or event handler:
+context.emitNote({ midiNote: 60, timestamp: Date.now() }); // Middle C
+```
+
+The host forwards the event to the WASM layout engine. **Do not compute note coordinates in plugin code** — that violates Constitution Principle VI.
+
+### Registering as a built-in plugin
+
+Open `frontend/src/services/plugins/builtinPlugins.ts` and add an import:
+
+```ts
+import myPlugin from '../../../plugins/my-plugin';
+import myPluginManifest from '../../../plugins/my-plugin/plugin.json';
+
+export const BUILTIN_PLUGINS: BuiltinPluginEntry[] = [
+  // ... existing entries
+  { manifest: { ...myPluginManifest, origin: 'builtin' }, plugin: myPlugin },
+];
+```
+
+Built-in plugins appear in the nav bar immediately on app start, without any IndexedDB writes.
+
+---
+
+## 3. Packaging and Testing a Plugin ZIP Import
+
+### Package your plugin
+
+A plugin ZIP must have `plugin.json` at the root and all referenced assets (your compiled entry-point JS, CSS, etc.) at the corresponding relative paths.
+
+```bash
+# From your plugin's build output directory:
+zip -r my-plugin-1.0.0.zip plugin.json index.js styles.css
+```
+
+Constraints enforced by the importer:
+- Total uncompressed size: ≤ 5 MB (FR-021)
+- `plugin.json` must be present and valid against [plugin-manifest.schema.json](contracts/plugin-manifest.schema.json)
+- `entryPoint` file must exist inside the ZIP
+- `pluginApiVersion` must be `"1"` (current app API version)
+
+### Import via the UI
+
+1. Click the **+** button in the navigation bar (or the "Import Plugin" action).
+2. Select your ZIP file.
+3. The importer validates, then:
+   - If a plugin with the same `id` is already installed, a confirmation dialog asks whether to overwrite it.
+   - On success, the new plugin's navigation entry appears immediately.
+
+### Testing import in isolation (Vitest)
+
+```ts
+// frontend/src/services/plugins/PluginImporter.test.ts
+import { importPlugin } from './PluginImporter';
+import { strToU8, zip } from 'fflate';
+
+it('rejects package over 5 MB', async () => {
+  const bigData = new Uint8Array(6 * 1024 * 1024);
+  // ... build a ZIP and assert rejection
+});
+```
+
+---
+
+## 4. ESLint API-Boundary Enforcement
+
+The ESLint configuration in `frontend/eslint.config.js` contains a scoped block:
+
+```js
+{
+  files: ['plugins/**/*.{ts,tsx}'],
+  rules: {
+    'no-restricted-imports': ['error', {
+      patterns: [{
+        group: ['../src/*', '../../src/*', '!**/src/plugin-api', '!**/src/plugin-api/**'],
+        message: 'Plugins may only import from src/plugin-api. All other host internals are forbidden.',
+      }],
+    }],
+  },
+},
+```
+
+**What it enforces**: any file under `frontend/plugins/` that imports from a `src/` path other than `src/plugin-api` gets an ESLint error.
+
+**What plugins may import**:
+- `../../src/plugin-api` (the official Plugin API)
+- npm packages (React, etc.)
+- Files within their own plugin folder
+
+**How to verify**:
+
+```bash
+cd frontend
+npx eslint plugins/
+```
+
+A violation looks like:
+```
+plugins/bad-plugin/index.tsx
+  3:1  error  Plugins may only import from src/plugin-api.  no-restricted-imports
+```
+
+**Known limitation** (see research.md R-003): ESLint only prevents *static* import violations at lint time. Runtime dynamic imports (`await import(url)`) are not covered — avoid dynamic host imports in plugin code.
+
+---
+
+## 5. Useful Commands
+
+```bash
+# Run all frontend tests (includes plugin service unit tests)
+cd frontend && npm test
+
+# Run just plugin-related tests
+cd frontend && npx vitest run --reporter=verbose src/services/plugins src/components/plugins plugins/
+
+# Type-check (includes plugin API types)
+cd frontend && npx tsc --noEmit
+
+# Lint plugins for API-boundary violations
+cd frontend && npx eslint plugins/
+```

--- a/specs/030-plugin-architecture/research.md
+++ b/specs/030-plugin-architecture/research.md
@@ -1,0 +1,160 @@
+# Research: Plugin Architecture with Virtual Keyboard Sample Plugin
+
+**Branch**: `030-plugin-architecture` | **Date**: 2026-02-25
+**Input**: [spec.md](spec.md) — FR-001 through FR-021; 4 user stories
+
+---
+
+## R-001: Plugin Registry Persistence — IndexedDB Library Choice
+
+**Decision**: Use the `idb` npm package (v8, Jake Archibald) for IndexedDB access.
+
+**Rationale**: The plugin registry must persist two data shapes — small manifest objects and large binary blobs (up to 5 MB per plugin). Raw IndexedDB satisfies browser support requirements but wraps every operation in `IDBRequest` callbacks, making the atomic manifest+assets write required by FR-010 brittle and verbose. `localforage` abstracts storage but silently falls back to localStorage (which cannot hold blobs of this size), has no TypeScript generics on values, and omits multi-store transaction APIs. `idb` costs ~1.7 kB gzipped, wraps every request in a Promise, exposes the full IndexedDB primitive (stores, indexes, transactions, cursors), and ships first-party TypeScript types via `DBSchema`. Maintenance is active (v8, 2024).
+
+**Key pattern**:
+```ts
+import { openDB, DBSchema } from 'idb';
+interface PluginDB extends DBSchema {
+  manifests: { key: string; value: PluginManifest };
+  assets:    { key: string; value: { pluginId: string; name: string; data: ArrayBuffer } };
+}
+const db = await openDB<PluginDB>('plugin-registry', 1, {
+  upgrade(db) {
+    db.createObjectStore('manifests', { keyPath: 'id' });
+    db.createObjectStore('assets',    { keyPath: 'name' });
+  },
+});
+const tx = db.transaction(['manifests', 'assets'], 'readwrite');
+await tx.objectStore('manifests').put(manifest);
+await tx.objectStore('assets').put({ pluginId: manifest.id, name: 'bundle.js', data: buffer });
+await tx.done;
+```
+
+**Alternatives considered**:
+- **Raw IndexedDB**: Zero dependencies, full control. Rejected — doubles boilerplate, no typed generics.
+- **localforage**: Simpler API. Rejected — opaque backend, no multi-store transactions, no generic types.
+
+---
+
+## R-002: ZIP Package Extraction — Library Choice
+
+**Decision**: Use `fflate` for in-browser ZIP extraction.
+
+**Rationale**: The Plugin Importer accepts plugin packages as ZIP archives (FR-008). `fflate` provides a `unzip()` function that accepts a `Uint8Array` (from `File.arrayBuffer()`) and returns all entries by path with raw bytes. Bundle size is ~8 kB gzipped — significantly lighter than JSZip (~30 kB gzipped). `fflate` ships first-party TypeScript types, is actively maintained (v0.8.x, ~2 M weekly downloads), and covers all modern browsers.
+
+**Key pattern**:
+```ts
+import { unzip } from 'fflate';
+const buffer = await file.arrayBuffer();
+const files = await new Promise<Record<string, Uint8Array>>((res, rej) =>
+  unzip(new Uint8Array(buffer), (err, data) => err ? rej(err) : res(data))
+);
+const manifestRaw = files['plugin.json'];
+const manifest = JSON.parse(new TextDecoder().decode(manifestRaw));
+```
+
+**Alternatives considered**:
+- **JSZip**: Familiar API, but ~30 kB gzipped, no releases since 2023, requires `@types/jszip`.
+- **Native `DecompressionStream`**: Handles raw deflate/gzip only — has no ZIP container (local file headers, central directory) support. Manual parsing would be ~500 LOC.
+
+---
+
+## R-003: Plugin API Boundary Enforcement — Static Analysis
+
+**Decision**: Use ESLint `no-restricted-imports` in a scoped flat-config block targeting `plugins/**/*` to enforce that plugin code imports only from `src/plugin-api/`.
+
+**Rationale**: SC-008 resolved to documentation + code review only (no runtime sandboxing). `no-restricted-imports` is a built-in ESLint rule (zero extra dependencies) that supports glob patterns. Flat config (`eslint.config.js`) makes per-directory scoping straightforward — a separate config block with `files: ['plugins/**/*.{ts,tsx}']` applies the restriction only to plugin files. The alternative `eslint-plugin-import` rule `import/no-restricted-paths` solves the same problem but requires installing the `import` plugin and configuring its resolver.
+
+**Key config snippet** (`frontend/eslint.config.js`):
+```js
+{
+  files: ['plugins/**/*.{ts,tsx}'],
+  rules: {
+    'no-restricted-imports': ['error', {
+      patterns: [{
+        group: ['**/src/!(plugin-api)/**', '../!(src)/**', './*'],
+        message: 'Plugin code must only import from src/plugin-api/.',
+      }],
+    }],
+  },
+},
+```
+
+**Known limitations**:
+- Matches literal import strings, not resolved module paths. Path aliases (e.g. `@/components/`) must also be listed in `patterns`.
+- Dynamic `import()` with computed strings is not caught.
+- Re-exports that inadvertently expose non-API internals from the `plugin-api/index.ts` barrel are not detected by this rule — the barrel's own exports must be carefully curated.
+
+---
+
+## R-004: Plugin Navigation Architecture
+
+**Decision**: Extend the existing `useState`-based navigation in `App.tsx` with a `PluginNavEntry` list derived from the Plugin Registry. Each installed plugin contributes one navigation entry. No routing library is introduced.
+
+**Rationale**: The app currently uses conditional `useState` flags in `App.tsx` to switch between views (ScoreViewer, RecordingView, PracticeView, RendererDemo). There is no react-router or router library. Introducing a router solely for plugin views would be disproportionate and inconsistent with the existing pattern. Instead, `App.tsx` reads installed plugins from the Plugin Registry on mount and renders a navigation list; selecting a plugin entry sets `activePlugin` state, which renders the `<PluginView>` wrapper mounting that plugin's view component.
+
+**State extension**:
+```ts
+const [activePlugin, setActivePlugin] = useState<string | null>(null);
+const [installedPlugins, setInstalledPlugins] = useState<PluginManifest[]>([]);
+// On mount: load from PluginRegistry; re-run after import
+```
+
+**Navigation rendering**: `installedPlugins.map(p => <PluginNavEntry key={p.id} plugin={p} onSelect={() => setActivePlugin(p.id)} />)` added to the existing navigation area in `ScoreViewer` or the app header.
+
+---
+
+## R-005: Plugin View Error Isolation
+
+**Decision**: Wrap each plugin view in a `<PluginView>` component that extends the existing `ErrorBoundary.tsx`. The boundary catches render-time and lifecycle errors from the plugin's component tree, displays an inline error message and a "Reload plugin" button, and does not affect other app views.
+
+**Rationale**: The existing `frontend/src/components/ErrorBoundary.tsx` already implements a class-based React error boundary. `<PluginView>` composes it with plugin-specific UI: the plugin name in the error message, a "Reload plugin" action that resets the boundary state (re-mounts the plugin), and a thin container `div` that preserves layout when the error state is shown (FR-020).
+
+**Key pattern**:
+```tsx
+export const PluginView = ({ plugin, children }: PluginViewProps) => (
+  <ErrorBoundary
+    fallback={({ error, reset }) => (
+      <div className="plugin-error">
+        <p>Plugin "{plugin.name}" encountered an error: {error.message}</p>
+        <button onClick={reset}>Reload plugin</button>
+      </div>
+    )}
+  >
+    {children}
+  </ErrorBoundary>
+);
+```
+
+---
+
+## R-006: Built-In Plugin Registration at Startup
+
+**Decision**: Built-in plugins (those in `frontend/plugins/*/`) are registered via a `builtinPlugins.ts` module that directly imports their manifests and view components at build time. They are added to the Plugin Registry in-memory on app startup without requiring IndexedDB persistence (they are always available).
+
+**Rationale**: Built-in plugins are bundled assets known at compile time. Writing them to IndexedDB introduces an unnecessary async dependency on app startup; treating them as hardcoded imports is simpler, faster, and avoids any IndexedDB failure modes affecting the built-in Virtual Keyboard. The Plugin Registry distinguishes between `builtin` and `imported` origin, allowing the UI to label them correctly and preventing users from accidentally overwriting them through the importer.
+
+**Pattern**:
+```ts
+// builtinPlugins.ts
+import virtualKeyboardManifest from '../../plugins/virtual-keyboard/plugin.json';
+import { VirtualKeyboardPlugin } from '../../plugins/virtual-keyboard/index';
+
+export const BUILTIN_PLUGINS: BuiltinPlugin[] = [
+  { manifest: virtualKeyboardManifest, component: VirtualKeyboardPlugin },
+];
+```
+
+---
+
+## Resolved Unknowns Summary
+
+| Unknown | Resolution |
+|---------|-----------|
+| IndexedDB library | ✅ `idb` v8 — typed, ~1.7 kB gz, active |
+| ZIP extraction library | ✅ `fflate` — ~8 kB gz, TypeScript types, active |
+| Plugin API boundary enforcement | ✅ ESLint `no-restricted-imports` in scoped flat-config block |
+| Navigation architecture | ✅ Extend existing `useState` in `App.tsx`; no router introduced |
+| Plugin view error isolation | ✅ `<PluginView>` composing existing `ErrorBoundary.tsx` |
+| Built-in plugin registration | ✅ Build-time imports in `builtinPlugins.ts`; in-memory; no IndexedDB write |
+

--- a/specs/030-plugin-architecture/spec.md
+++ b/specs/030-plugin-architecture/spec.md
@@ -1,0 +1,161 @@
+# Feature Specification: Plugin Architecture with Virtual Keyboard Sample Plugin
+
+**Feature Branch**: `030-plugin-architecture`
+**Created**: 2026-02-25
+**Status**: Draft
+**Input**: User description: "plugin architecture with virtual keyboard sample plugin — virtual keyboard view where touching keys shows notes on a staff; plugin assets in frontend/plugins/virtual-keyboard; same internal architecture as the rest of the project; plugins added via plugin importer controller; built-in repo plugins available by default; new navigation entry per installed plugin; plugins restricted to the Musicore Plugin API"
+
+## Clarifications
+
+### Session 2026-02-25
+
+- Q: US4-AC3 states a plugin violation "fails with a descriptive error", but SC-008 resolved to code-review-only enforcement (no runtime sandboxing) — these are contradictory. How should US4-AC3 be resolved? → A: Replace US4-AC3 with a static-analysis criterion: given a plugin file is linted, when static analysis runs, then any call to a non-Plugin-API Musicore internal is flagged as an error.
+- Q: When the user imports a plugin with the same name as an already-installed plugin, what should the importer do? → A: Overwrite with confirmation — the importer warns "A plugin named X is already installed. Replace it?" and proceeds only on user confirmation.
+- Q: When a plugin was built against an older or newer version of the Plugin API, how should incompatibility be handled? → A: The manifest declares the minimum Plugin API version it requires; the importer rejects packages that require a newer Plugin API than the current app provides, with a descriptive error.
+- Q: How should the system behave if a plugin crashes or throws an unhandled error during use? → A: Per-plugin error boundary — a crash is caught at the plugin view level; the user sees an inline error message with a "Reload plugin" option, and the rest of the app remains functional.
+- Q: What is the maximum permitted plugin package size? → A: 5 MB — packages exceeding this limit are rejected by the importer with a descriptive error.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Play Virtual Keyboard (Priority: P1)
+
+A user opens the Musicore app and finds the Virtual Keyboard plugin already available in the navigation. They tap individual piano keys and see the played notes rendered on a music staff in real time, giving them an interactive way to explore music notation while playing by ear.
+
+**Why this priority**: This is the core visible value of the entire feature. It proves the plugin architecture works end-to-end and delivers immediate musical utility without any setup required from the user.
+
+**Independent Test**: Can be fully tested by opening the app, navigating to the Virtual Keyboard plugin view, clicking piano keys, and verifying notes appear on the staff — no imports or configuration required.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has opened the app for the first time, **When** they look at the navigation, **Then** the Virtual Keyboard plugin is listed as a default navigation entry.
+2. **Given** the Virtual Keyboard view is open, **When** the user taps a white key (e.g., middle C), **Then** the corresponding note appears on the staff within 100 ms of the tap.
+3. **Given** the Virtual Keyboard view is open, **When** the user taps a black key (sharp/flat), **Then** the note with its correct accidental symbol appears on the staff.
+4. **Given** the user has played several notes in sequence, **When** they look at the staff, **Then** all played notes are shown in the order they were played.
+5. **Given** the Virtual Keyboard view is open on a touch device, **When** the user touches a key, **Then** the key shows a pressed visual state and the note appears on the staff.
+
+---
+
+### User Story 2 - Import a Third-Party Plugin (Priority: P2)
+
+A user who wants to extend Musicore beyond its defaults opens the plugin importer, selects a plugin package from their device, and adds it to the app. The new plugin immediately appears as a navigation entry they can access.
+
+**Why this priority**: This validates the extensibility mechanism. Without it, the plugin architecture is a build-time concept only — the importer is what makes it a live platform.
+
+**Independent Test**: Can be fully tested by accessing the plugin importer, uploading a valid plugin package, and confirming a new navigation entry appears — independently of the virtual keyboard plugin.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the plugin importer screen, **When** they select a valid plugin package from their device, **Then** the plugin is installed and a confirmation message is shown.
+2. **Given** a plugin has been successfully imported, **When** the user returns to the main navigation, **Then** a new entry for the imported plugin is visible.
+3. **Given** the user taps the new navigation entry, **When** the plugin view loads, **Then** the plugin's interface is displayed correctly.
+4. **Given** the user uploads an invalid or malformed plugin package, **When** the import is attempted, **Then** the system rejects it with a clear error message and no partial installation occurs.
+5. **Given** a previously imported plugin exists, **When** the user closes and reopens the app (PWA reload), **Then** the plugin is still present in the navigation and functional.
+
+---
+
+### User Story 3 - Navigate Between Installed Plugins (Priority: P3)
+
+A user who has the default Virtual Keyboard plugin plus one imported plugin can navigate freely between both plugin views and the rest of the app. Each plugin is reachable from a consistent place in the app UI.
+
+**Why this priority**: Navigation cohesion ensures plugins feel like first-class citizens rather than bolted-on extras. Depends on P1 and P2 being functional.
+
+**Independent Test**: Can be tested with only the built-in virtual keyboard plugin in navigation, confirming it can be accessed and the user can return to other app views without issues.
+
+**Acceptance Scenarios**:
+
+1. **Given** one or more plugins are installed, **When** the user opens the navigation, **Then** each installed plugin has exactly one entry listed.
+2. **Given** the user is in a plugin view, **When** they tap a non-plugin navigation entry, **Then** the plugin view is dismissed and the selected view loads correctly.
+3. **Given** multiple plugins are installed, **When** the user switches between plugin views, **Then** each plugin view renders its own independent state without interference from others.
+
+---
+
+### User Story 4 - Plugin Developer Builds with the Plugin API (Priority: P4)
+
+A plugin developer writes a new Musicore plugin using only the documented Plugin API. They can complete the plugin from scratch using the API reference and the virtual keyboard plugin as an example, without needing access to Musicore's internal source code.
+
+**Why this priority**: This ensures the Plugin API contract is robust and documented. It is the lowest priority as it serves developers rather than end users and depends on all prior stories being complete.
+
+**Independent Test**: Can be validated by confirming the Plugin API documentation covers all capabilities used by the virtual keyboard plugin, and that no undocumented internal APIs are referenced within `frontend/plugins/virtual-keyboard`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads the Plugin API documentation, **When** they build a plugin using only documented API methods, **Then** the plugin installs and runs correctly without errors.
+2. **Given** the virtual keyboard plugin codebase, **When** a developer reviews it, **Then** every Musicore-specific call goes through the Plugin API with no direct access to app internals.
+3. **Given** a plugin file is analysed by the project's static analysis tooling, **When** the analysis runs, **Then** any call to a Musicore internal that is not part of the Plugin API is flagged as a lint or type error.
+
+---
+
+### Edge Cases
+
+- When the user imports a plugin with the same name as an already-installed plugin, the importer shows a confirmation prompt: "A plugin named X is already installed. Replace it?" — the existing plugin is overwritten only on explicit user confirmation; cancelling leaves the current installation untouched.
+- Plugin packages exceeding 5 MB are rejected by the importer with a descriptive error before any extraction or validation is attempted.
+- What happens when the app is offline and the user tries to use the plugin importer?
+- If a plugin throws an unhandled error during use, the crash is caught at the plugin view level; the user sees an inline error message with a "Reload plugin" option, and all other app views and plugins remain functional.
+- What happens if the user plays keys faster than the staff can render (rapid sequential tapping)?
+- What happens on small screens that cannot fit a full piano keyboard?
+- How does the Virtual Keyboard layout adapt when the device orientation changes?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Plugin System**
+
+- **FR-001**: The app MUST define a Plugin API that is the exclusive interface through which plugins interact with Musicore functionality; plugins MUST NOT access any other internal application interfaces directly.
+- **FR-002**: The Plugin API MUST be documented in human-readable form within the repository, covering all available operations a plugin may invoke.
+- **FR-003**: Each plugin MUST be self-contained within a dedicated folder following the naming convention `frontend/plugins/[plugin-name]`; no plugin assets may reside outside its designated folder.
+- **FR-004**: Plugins MUST follow the same internal architectural patterns applied throughout the rest of the Musicore frontend project (component structure, state management approach, testing conventions).
+- **FR-005**: All plugins shipped within the Musicore repository MUST be available to the PWA by default without any user action; users MUST NOT need to manually import built-in plugins.
+- **FR-006**: When a plugin becomes available (built-in or imported), the app navigation MUST gain exactly one new entry pointing to that plugin's view.
+- **FR-007**: The app MUST provide a Plugin Importer that allows users to add external plugins to the PWA.
+- **FR-008**: The Plugin Importer MUST accept a plugin package in the form of a ZIP archive containing a plugin manifest file and the plugin's assets.
+- **FR-009**: The Plugin Importer MUST validate the uploaded package before activating it; packages that fail validation MUST be rejected with a descriptive error and leave the app state unchanged.
+- **FR-010**: Imported plugins MUST persist across app reloads (PWA sessions); a plugin installed in one session MUST still be available in subsequent sessions without re-importing.
+- **FR-011**: Users MUST be able to view a list of all currently installed plugins (both built-in and imported).
+
+**Virtual Keyboard Plugin**
+
+- **FR-012**: The Virtual Keyboard plugin MUST render a visual piano keyboard spanning at least two full octaves.
+- **FR-013**: When a user presses a key on the virtual keyboard, the corresponding musical note MUST be displayed on a music staff within the plugin view.
+- **FR-014**: All notes played during a session MUST accumulate on the staff in the order they were played, forming a growing notation sequence.
+- **FR-015**: The virtual keyboard MUST visually indicate the pressed state of a key during a tap or click interaction.
+- **FR-016**: The Virtual Keyboard plugin MUST display each played note on the staff within 100 ms of the key press.
+- **FR-017**: All assets for the Virtual Keyboard plugin MUST reside within `frontend/plugins/virtual-keyboard`; the plugin MUST use only the Musicore Plugin API to render notation and access any app capability.
+- **FR-018**: When the user imports a plugin whose name matches an already-installed plugin, the Plugin Importer MUST present a confirmation prompt before overwriting; the existing plugin MUST remain unchanged if the user cancels.
+- **FR-019**: The Plugin Importer MUST reject any package whose declared minimum Plugin API version exceeds the version currently supported by the app, displaying a descriptive error that states the required and current Plugin API versions.
+- **FR-020**: Each plugin view MUST be wrapped in an error boundary; if a plugin throws an unhandled error at runtime, the app MUST display an inline error message within the plugin view area and offer a "Reload plugin" action, leaving all other views and plugins unaffected.
+- **FR-021**: The Plugin Importer MUST reject any package whose uncompressed size exceeds 5 MB; the rejection MUST occur before any extraction or installation step, and the error message MUST state the package size limit.
+
+### Key Entities
+
+- **Plugin**: A self-contained module with a manifest, a view component, and a defined set of declared capabilities, accessible exclusively through the Plugin API. Identified by a unique name and version.
+- **Plugin Manifest**: A descriptor file bundled with a plugin that declares its name, version, entry point, the minimum Musicore Plugin API version it requires, and optionally the Plugin API operations it uses.
+- **Plugin Registry**: The in-app record of all installed plugins (built-in and imported), persisted across sessions.
+- **Musicore Plugin API**: The documented, versioned interface through which plugins access notation rendering and other Musicore capabilities without touching app internals.
+- **Plugin Importer**: The UI controller that orchestrates package upload, validation, registration, and navigation entry creation.
+- **Virtual Keyboard Plugin**: The reference plugin bundled with the repository, demonstrating the plugin architecture by displaying a piano keyboard that feeds played notes into a staff notation view.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A first-time user can access and play the Virtual Keyboard plugin within 30 seconds of opening the app, with no setup steps required.
+- **SC-002**: Every note played on the virtual keyboard appears on the staff in under 100 ms of the key press, ensuring the interaction feels instantaneous.
+- **SC-003**: A user can successfully import a valid third-party plugin in under 2 minutes from opening the plugin importer to seeing the new navigation entry.
+- **SC-004**: 100% of the Virtual Keyboard plugin's Musicore-facing calls go through the documented Plugin API — zero direct internal API calls, verifiable by code review and static analysis.
+- **SC-005**: An invalid plugin package is rejected with a descriptive error message in under 3 seconds of upload completion; the app remains fully functional after rejection.
+- **SC-006**: All installed plugins (built-in and imported) remain available across PWA reloads with no data loss and no re-import required.
+- **SC-007**: The Plugin API documentation covers every method used by the Virtual Keyboard plugin, enabling a developer to replicate the plugin from documentation alone without reading Musicore's internal source code.
+- **SC-008**: Plugin API compliance is enforced by documentation and code review; all plugins, including the virtual keyboard reference, are verified to contain zero direct calls to app internals. No runtime sandboxing is required for this phase; the Plugin API boundary is a documented contract upheld by repository policy.
+
+## Assumptions
+
+- Plugin packages are distributed as ZIP archives containing a `plugin.json` manifest and the plugin's assets; this is the format the importer accepts.
+- Notes played on the Virtual Keyboard accumulate onto the staff for the duration of the session; there is no note-by-note replacement or automatic scroll-off.
+- The Plugin API will initially expose notation rendering (display a note on a staff) and key-event handling; audio playback and score export capabilities may be added in future iterations.
+- Imported plugins are stored in the browser's local persistent storage after import, enabling offline access in subsequent sessions.
+- The virtual keyboard layout presents a fixed set of keys; the number of visible octaves may adapt to available screen width, but individual key dimensions do not resize.
+- Removing a plugin and its navigation entry is out of scope for this initial feature.
+- The Plugin Importer is accessible from the app's settings or a dedicated management area; exact placement in the navigation is determined during planning.
+
+

--- a/specs/030-plugin-architecture/tasks.md
+++ b/specs/030-plugin-architecture/tasks.md
@@ -1,0 +1,258 @@
+# Tasks: Plugin Architecture with Virtual Keyboard Sample Plugin
+
+**Input**: Design documents from `specs/030-plugin-architecture/`
+**Prerequisites**: [plan.md](plan.md) · [spec.md](spec.md) · [research.md](research.md) · [data-model.md](data-model.md) · [contracts/](contracts/)
+
+**Tests**: Included — Constitution Principle V (Test-First Development) explicitly requires TDD for all Plugin API methods, PluginRegistry operations, PluginImporter validation, Virtual Keyboard interactions, and error boundary behaviour (see [plan.md](plan.md) Constitution Check, row V).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no unresolved dependencies at that point)
+- **[Story]**: User story this task belongs to (US1–US4)
+- Exact file paths included in every task description
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Install dependencies, scaffold directories, and lock in the ESLint API boundary — prerequisite for all subsequent work.
+
+- [ ] T001 Install `fflate` and `idb` npm packages in `frontend/package.json`
+- [ ] T002 Create folder scaffold: `frontend/plugins/virtual-keyboard/`, `frontend/src/plugin-api/`, `frontend/src/services/plugins/`, `frontend/src/components/plugins/`
+- [ ] T003 [P] Add ESLint scoped `no-restricted-imports` block for `plugins/**/*.{ts,tsx}` in `frontend/eslint.config.js` (see [research.md R-003](research.md) for config snippet)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define the Plugin API contract and the Plugin Registry aggregate. All user stories depend on these being complete and passing tests.
+
+**⚠️ CRITICAL**: No user story implementation can begin until this phase is fully checkpointed.
+
+- [ ] T004 Define `PluginManifest`, `PluginNoteEvent`, `PluginContext`, `MusicorePlugin` interfaces and `PLUGIN_API_VERSION = "1"` constant in `frontend/src/plugin-api/types.ts` (see [contracts/plugin-api.ts](contracts/plugin-api.ts) for the target shape)
+- [ ] T005 [P] Create `frontend/src/plugin-api/index.ts` barrel that re-exports all public API surface from `types.ts` and nothing else
+- [ ] T006 [P] Write Plugin API contract tests (MUST FAIL before T004/T005 implementation is committed) in `frontend/src/plugin-api/plugin-api.test.ts` — assert: `PLUGIN_API_VERSION === "1"`; `MusicorePlugin` shape matches contract; `PluginNoteEvent` has no coordinate fields
+- [ ] T007 [P] Create `frontend/src/services/plugins/builtinPlugins.ts` with an empty `BUILTIN_PLUGINS: BuiltinPluginEntry[]` export (populated in US1, Phase 3)
+- [ ] T008 Write `PluginRegistry` tests (MUST FAIL before T009 implementation) in `frontend/src/services/plugins/PluginRegistry.test.ts` — cover: `register` persists manifest + assets atomically; `list` returns all entries; `get(id)` returns stored entry; duplicate `id` overwrites; removed entry is absent on `list`
+- [ ] T009 Implement `PluginRegistry` with `idb` v8 in `frontend/src/services/plugins/PluginRegistry.ts` — `openDB` schema (`manifests` keyed by `id`, `assets` keyed by `{pluginId}/{filename}`); `register(manifest, assets)` atomic tx; `list()`; `get(id)`; `remove(id)` (see [data-model.md](data-model.md) IndexedDB schema and [research.md R-001](research.md))
+
+**Checkpoint**: `npm test` passes for `plugin-api.test.ts` and `PluginRegistry.test.ts`. Plugin API types and registry accessible.
+
+---
+
+## Phase 3: User Story 1 — Play Virtual Keyboard (Priority: P1) 🎯 MVP
+
+**Goal**: The Virtual Keyboard plugin is available by default in navigation. Users tap keys and see notes on a staff within 100 ms. No user action needed to activate it.
+
+**Independent Test**: Open app → click "Virtual Keyboard" nav entry → click middle C key → note appears on staff. No imports or IndexedDB required.
+
+### Tests — US1 (write first, must fail before implementation)
+
+- [ ] T010 [P] [US1] Write `VirtualKeyboard.tsx` unit tests in `frontend/plugins/virtual-keyboard/VirtualKeyboard.test.tsx` — cover: renders 14+ white keys and 10 black keys; key press applies pressed CSS class; key press calls `context.emitNote()` with correct `midiNote`; white key C4 emits `midiNote: 60`; black key C#4 emits `midiNote: 61`
+- [ ] T011 [P] [US1] Write `PluginView.tsx` error boundary tests in `frontend/src/components/plugins/PluginView.test.tsx` — cover: renders children normally; catches thrown error and shows plugin name + error message; "Reload plugin" button resets boundary and remounts children
+
+### Implementation — US1
+
+- [ ] T012 [P] [US1] Create `frontend/plugins/virtual-keyboard/plugin.json` manifest: `id: "virtual-keyboard"`, `name: "Virtual Keyboard"`, `version: "1.0.0"`, `pluginApiVersion: "1"`, `entryPoint: "index.js"` (see [contracts/plugin-manifest.schema.json](contracts/plugin-manifest.schema.json))
+- [ ] T013 [P] [US1] Create `frontend/plugins/virtual-keyboard/VirtualKeyboard.css` — piano keyboard grid layout with two+ octave white/black key layout; pressed state class (`.key--pressed`); responsive width for tablet-first layout; 44×44 px minimum touch targets per constitution §III
+- [ ] T014 [US1] Implement `frontend/plugins/virtual-keyboard/VirtualKeyboard.tsx` — renders two minimum octaves (C3–B4, 24 white + 16 black keys); calls `context.emitNote({ midiNote, timestamp: Date.now() })` on click/touchstart; applies `.key--pressed` class during interaction; accepts `PluginContext` as prop (dependency-injected via `init()` pattern)
+- [ ] T015 [US1] Implement `frontend/plugins/virtual-keyboard/index.tsx` — default export `MusicorePlugin` with `init(context)` storing context ref; `Component` pointing to `VirtualKeyboard`; `dispose()` clearing refs
+- [ ] T016 [US1] Register Virtual Keyboard in `frontend/src/services/plugins/builtinPlugins.ts` — import manifest from `plugin.json` and plugin from `index.tsx`; export `BUILTIN_PLUGINS` array with single entry `{ manifest: { ...virtualKeyboardManifest, origin: 'builtin' }, plugin: virtualKeyboardPlugin }` (see [research.md R-006](research.md))
+- [ ] T017 [US1] Implement `frontend/src/components/plugins/PluginView.tsx` — wraps `ErrorBoundary.tsx` with plugin-specific fallback (shows `plugin.name`, error message, "Reload plugin" reset button); accepts `plugin: PluginManifest` + child `component` prop (see [research.md R-005](research.md))
+- [ ] T018 [P] [US1] Implement `frontend/src/components/plugins/PluginNavEntry.tsx` — navigation item showing plugin name; `onSelect` callback prop; active/inactive visual state; 44×44 px touch target
+- [ ] T019 [US1] Extend `frontend/src/App.tsx` with: `installedPlugins: PluginManifest[]` state initialised from `BUILTIN_PLUGINS` on mount; `activePlugin: string | null` state; render one `<PluginNavEntry>` per plugin in navigation area; render `<PluginView>` wrapping active plugin's `Component` when `activePlugin` is non-null
+
+**Checkpoint**: Open app → Virtual Keyboard entry visible → click key → note on staff. US1 fully functional. No IndexedDB or imports required.
+
+---
+
+## Phase 4: User Story 2 — Import a Third-Party Plugin (Priority: P2)
+
+**Goal**: Users can upload a ZIP plugin package. The importer validates it (size, manifest schema, API version, duplicate check), writes atomically to IndexedDB, and the new plugin appears in navigation immediately and after PWA reload.
+
+**Independent Test**: Access Plugin Importer → select a valid 3rd-party ZIP → confirm installation → new nav entry appears → reload app → entry still present.
+
+### Tests — US2 (write first, must fail before implementation)
+
+- [X] T020 [P] [US2] Write `PluginImporter.ts` tests in `frontend/src/services/plugins/PluginImporter.test.ts` — cover: rejects ZIP > 5 MB (FR-021); rejects package whose `pluginApiVersion > "1"` (FR-019); rejects missing/invalid `plugin.json` (FR-009); rejects `entryPoint` file absent from ZIP; accepts valid package and calls `PluginRegistry.register`; returns `{ duplicate: true }` when `id` already exists
+- [X] T021 [P] [US2] Write `PluginImporterDialog.tsx` tests in `frontend/src/components/plugins/PluginImporterDialog.test.tsx` — cover: shows file picker on open; displays success message on valid import; displays error message on invalid import; shows duplicate-name confirmation dialog; cancelling duplicate leaves existing plugin intact; confirming duplicate calls importer with `overwrite: true`
+
+### Implementation — US2
+
+- [X] T022 [US2] Implement `frontend/src/services/plugins/PluginImporter.ts`
+- [X] T023 [US2] Implement `frontend/src/components/plugins/PluginImporterDialog.tsx`
+- [X] T024 [US2] Extend `frontend/src/App.tsx` mount effect to also call `PluginRegistry.list()` and merge imported plugins into `installedPlugins` state (builtin plugins always prepended); add `showImporter` state; render `<PluginImporterDialog>` when open; on `onImportComplete` append new plugin to `installedPlugins`
+- [X] T025 [P] [US2] Add a "+" / "Import Plugin" trigger button to the plugin navigation area in `frontend/src/App.tsx` that sets `showImporter: true`
+
+**Checkpoint**: Import flow end-to-end: select ZIP → validate → confirm if duplicate → navigation entry added → reload app → entry persists.
+
+---
+
+## Phase 5: User Story 3 — Navigate Between Installed Plugins (Priority: P3)
+
+**Goal**: Each installed plugin has exactly one navigation entry. The user can move freely between plugin views and all other app views. Each plugin view is independent (no shared state leakage).
+
+**Independent Test**: With only the built-in Virtual Keyboard: navigate to it, return to score view, confirm no broken state. With two plugins installed, switch between both and confirm independent state.
+
+### Tests — US3 (write first, must fail before implementation)
+
+- [X] T026 [P] [US3] Write `App.tsx` navigation integration tests in `frontend/src/App.test.tsx` — 6 tests passing
+
+### Implementation — US3
+
+- [X] T027 [US3] Harden `PluginNavEntry.tsx` — `isActive` prop with visual styling already in place from T018; `handleSelectPlugin` already clears conflicting view flags from T019
+- [X] T028 [US3] Non-plugin handlers already call `setActivePlugin(null)` — `onShowRecording` and `onShowPractice` from T019; `showDemo` only set at startup (activePlugin is null at that point)
+
+**Checkpoint**: Navigation is fully cohesive. Plugins appear as first-class nav entries. No state leaks between views.
+
+---
+
+## Phase 6: User Story 4 — Plugin Developer Builds with the Plugin API (Priority: P4)
+
+**Goal**: A developer can write a complete Musicore plugin using only the documented Plugin API contract. ESLint statically enforces zero direct calls to app internals from within `frontend/plugins/`.
+
+**Independent Test**: `npx eslint plugins/` passes with 0 errors. No `src/` import in `virtual-keyboard/` other than `src/plugin-api`. All plugin API methods used by the virtual keyboard are covered in `contracts/plugin-api.ts`.
+
+### Tests — US4
+
+- [X] T029 [P] [US4] Create lint-boundary fixture at `frontend/plugins/lint-test/bad-import.ts`; confirmed `npx eslint plugins/lint-test/bad-import.ts` reports error
+
+### Implementation — US4
+
+- [X] T030 [P] [US4] `npx eslint plugins/virtual-keyboard/` → 0 violations after adding eslint-disable for react-refresh on index.tsx
+- [X] T031 [P] [US4] All interfaces (PluginNoteEvent, PluginManifest, PluginContext, MusicorePlugin) and PLUGIN_API_VERSION exported — cross-check passed
+- [X] T032 [P] [US4] `npx tsc --noEmit` with plugins/ in tsconfig.app.json include → 0 errors after fixing import paths
+
+**Checkpoint**: Static analysis enforces the Plugin API boundary. The virtual keyboard plugin is a fully compliant reference implementation.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, type-check gate, and quickstart walkthrough.
+
+- [X] T033 [P] `npx tsc --noEmit` → 0 errors (plugins/ added to tsconfig.app.json include; import paths fixed)
+- [X] T034 [P] Full Vitest suite → 1149 tests pass, 25 skipped, 0 failures
+- [X] T035 [P] `npx eslint plugins/virtual-keyboard/` → 0 violations; `plugins/lint-test/bad-import.ts` → 1 intentional error (boundary confirmed)
+- [ ] T036 Manually follow every scenario in `specs/030-plugin-architecture/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Requires Phase 1 complete — **BLOCKS all user story phases**
+- **Phase 3 (US1)**: Requires Phase 2 complete — no other story dependencies
+- **Phase 4 (US2)**: Requires Phase 2 complete — integrates with Phase 3 at App.tsx level (T024/T025 extend T019)
+- **Phase 5 (US3)**: Requires Phase 3 complete (navigation entries must exist)
+- **Phase 6 (US4)**: Requires Phase 3 complete (plugin under audit must exist)
+- **Phase 7 (Polish)**: Requires all desired stories complete
+
+### User Story Dependencies
+
+| Story | Depends On | Notes |
+|-------|-----------|-------|
+| US1 (P1) | Phase 2 only | Core MVP; independently testable |
+| US2 (P2) | Phase 2 + US1 partially | Shares `App.tsx` state from T019; independently testable via importer |
+| US3 (P3) | US1 complete | Requires nav entries to exist; independently testable with built-in plugin only |
+| US4 (P4) | US1 complete | Audits the virtual keyboard reference implementation |
+
+### Within Each Phase: Sequencing
+
+1. Tests marked (MUST FAIL) → written **before** implementation tasks
+2. Types/interfaces before services
+3. Services before components
+4. Components before App.tsx wiring
+5. Story checkpoint before next story
+
+---
+
+## Parallel Execution Examples
+
+### Phase 2 (Foundational) — run simultaneously after T001–T003
+
+```
+T004  Define Plugin API types (frontend/src/plugin-api/types.ts)
+T005  Create plugin-api/index.ts barrel        ← parallel with T004
+T006  Write plugin-api.test.ts                 ← parallel with T004
+T007  Create builtinPlugins.ts stub            ← parallel with T004
+T008  Write PluginRegistry.test.ts             ← parallel with T005
+↓
+T009  Implement PluginRegistry.ts              ← waits for T008
+```
+
+### Phase 3 (US1) — run simultaneously after Phase 2 checkpoint
+
+```
+T010  Write VirtualKeyboard.test.tsx           ← parallel
+T011  Create plugin.json manifest              ← parallel
+T013  Create VirtualKeyboard.css               ← parallel
+T011  Write PluginView.test.tsx                ← parallel with T010
+↓
+T014  Implement VirtualKeyboard.tsx            ← waits for T010 + T013
+T017  Implement PluginView.tsx                 ← waits for T011
+T018  Implement PluginNavEntry.tsx             ← parallel with T014
+↓
+T015  Implement index.tsx                      ← waits for T014
+T016  Register in builtinPlugins.ts            ← waits for T015
+↓
+T019  Extend App.tsx                           ← waits for T016 + T017 + T018
+```
+
+### Phase 4 (US2) — run simultaneously after Phase 2 checkpoint
+
+```
+T020  Write PluginImporter.test.ts             ← parallel
+T021  Write PluginImporterDialog.test.tsx      ← parallel
+↓
+T022  Implement PluginImporter.ts              ← waits for T020
+T023  Implement PluginImporterDialog.tsx       ← waits for T021
+T025  Add import trigger to App.tsx            ← parallel with T022/T023
+↓
+T024  Extend App.tsx mount effect              ← waits for T022 + T023
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (Setup) — ~1 session
+2. Complete Phase 2 (Foundational) — ~1 session; checkpoint tests
+3. Complete Phase 3 (US1 — Virtual Keyboard) — ~2 sessions
+4. **STOP and VALIDATE**: Open app, play keyboard, confirm notes on staff
+5. Merge to main as first increment
+
+### Incremental Delivery
+
+| Increment | Phases | Value Delivered |
+|-----------|--------|-----------------|
+| MVP | 1 + 2 + 3 | Virtual Keyboard playable; plugin architecture proven end-to-end |
+| +P2 | + 4 | Plugin Importer live; any developer can publish a plugin |
+| +P3 | + 5 | Navigation cohesion; plugins feel first-class |
+| +P4 | + 6 + 7 | API boundary enforced statically; developer experience complete |
+
+### Parallel Team Strategy
+
+With two developers after Phase 2 is complete:
+
+- Developer A: Phase 3 (US1 — Virtual Keyboard)
+- Developer B: Phase 4 (US2 — Plugin Importer service layer)
+
+Both work independently; App.tsx wiring (T019, T024) is the only integration point — merge after both are green.
+
+---
+
+## Notes
+
+- **[P]** = different files, no unresolved dependencies: safe for concurrent execution
+- **[Story]** label maps task to user story for traceability and independent delivery
+- **Test-first discipline**: every test in this file marked "MUST FAIL" must be written and verified failing before the implementation task it gates is begun (Constitution Principle V)
+- **Regression prevention**: any bug discovered during implementation becomes a [BUG] task following the pattern in the template: document → failing test → fix → verify (Constitution Principle VII)
+- **WASM authority** (Constitution Principle VI): `VirtualKeyboard.tsx` emits `PluginNoteEvent` with `midiNote` integer only — zero coordinate arithmetic allowed in plugin code; notation layout is exclusively WASM domain
+- Commit after each checkpointed phase, not after individual tasks


### PR DESCRIPTION
## Summary

Implements feature **030 - Plugin Architecture**: a versioned host API that lets plugins extend Musicore with new interactive views, audio playback and score integration - without direct access to host internals.

---

## What's included

### Plugin API v1 (`frontend/src/plugin-api/`)
- `PluginContext.emitNote()` - sends note events to the WASM layout pipeline
- `PluginContext.playNote()` - plays notes through the host audio engine (Salamander Grand Piano via ToneAdapter)
- `PluginNoteEvent` with `type: 'attack' | 'release'` for sustain/release control
- ESLint boundary: `plugins/**` may only import from `src/plugin-api/index` - all host internals are statically forbidden

### Virtual Keyboard plugin (builtin)
- Two-octave interactive piano keyboard (C3-B4, 24 notes)
- Audio via `context.playNote()` - host routes through ToneAdapter, no direct Tone.js access from plugins
- Score notation via `context.emitNote()` to WASM pipeline
- Unmount cleanup releases held notes (fixes stuck tone when pressing Back)

### ToneAdapter extensions
- `attackNote(pitch, velocity)` - immediate note-on for real-time input
- `releaseNote(pitch)` - immediate note-off
- `initPromise` guard - deduplicates concurrent `init()` calls (fixes 5s first-note delay and all-notes-at-once issue)
- Pre-warm triggered on plugin nav click to load Salamander samples ahead of first keypress

### Plugin Importer
- ZIP package validation (`plugin.json`, `entryPoint`, API version)
- `PluginImporterDialog` - styled modal UI
- `PluginRegistry` - IndexedDB persistence via `idb`

### Navigation
- Plugin sidebar nav entries with `PluginNavEntry`
- `PluginView` host component with Back button toolbar

### Documentation
- `PLUGINS.md` at repo root - full developer guide covering API reference, builtin plugin walkthrough, ZIP packaging, ESLint constraints, testing patterns, and the Virtual Keyboard as canonical reference

---

## Tests
- **1151 Vitest tests passing** (1176 total, 25 skipped)
- **0 TypeScript errors** (`tsc --noEmit`)
- **0 ESLint errors** (`npm run lint` exits 0)
- **304 Rust tests passing**

---

## Bug fixes included
- First note 5s delay: pre-warm on nav click + skip-if-not-ready guard prevents note queueing
- Notes firing all at once via PolySynth: `initPromise` guard ensures only one `_doInit()` runs
- Stuck tone on Back: `useEffect` cleanup releases all held MIDI notes on unmount
