### PR TITLE
fix(practice): results overlay UX improvements

### DIFF
--- a/frontend/plugins/practice-view/PracticePlugin.css
+++ b/frontend/plugins/practice-view/PracticePlugin.css
@@ -224,7 +224,8 @@
   box-sizing: border-box;
 }
 
-.practice-sidebar--collapsed {
+/* Completely hidden — used for preset levels where config is irrelevant */
+.practice-sidebar--hidden {
   width: 0;
   overflow: hidden;
   padding: 0;
@@ -232,12 +233,29 @@
   min-width: 0;
 }
 
+/* Collapsed — narrow strip showing only the toggle button */
+.practice-sidebar--collapsed {
+  width: 28px;
+  overflow: hidden;
+  padding: 0;
+  border-right: 1px solid var(--color-border, #e0e0e0);
+}
+
+/* Hide the content sections but keep the toggle button visible.
+ * Use height:0 + overflow:hidden rather than visibility:hidden so elements
+ * remain in the accessibility tree (tests use happy-dom with css:true). */
+.practice-sidebar--collapsed .practice-sidebar__sections {
+  height: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
 .practice-sidebar__toggle {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 28px;
+  min-height: 44px;
   flex-shrink: 0;
   background: none;
   border: none;
@@ -247,6 +265,11 @@
   cursor: pointer;
   transition: background 0.12s;
   user-select: none;
+  /* Always occupy its column width even when sidebar is collapsed */
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--color-surface-alt, #f9f9f9);
 }
 
 .practice-sidebar__toggle:focus {
@@ -580,6 +603,10 @@
 
 .practice-results__table-wrapper {
   overflow-x: auto;
+  overflow-y: auto;
+  max-height: 40vh;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
 }
 
 .practice-results__table {
@@ -701,7 +728,8 @@
     flex-shrink: 0;
   }
 
-  .practice-sidebar--collapsed {
+  .practice-sidebar--collapsed,
+  .practice-sidebar--hidden {
     display: none;
   }
 
@@ -894,4 +922,64 @@
   flex-shrink: 0;
   -webkit-overflow-scrolling: touch;
   background: var(--color-surface, #fff);
+}
+
+/* ── Results overlay on mobile landscape ────────────────────────────────────
+ * In landscape orientation on a phone the keyboard fills the lower half of the
+ * screen, leaving no room to scroll down to a results panel.  Display it as a
+ * centred modal overlay instead so the score is always immediately visible.    */
+/* Backdrop div (real element — pseudo-elements cannot receive touch events) */
+.practice-results__backdrop {
+  display: none;
+}
+
+/* Close button — hidden outside overlay context */
+.practice-results__close {
+  display: none;
+}
+
+@media (orientation: landscape) and (max-height: 520px) {
+  .practice-plugin--results .practice-results__backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 200;
+    cursor: pointer;
+  }
+
+  .practice-plugin--results .practice-results {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 201;
+    width: min(92vw, 420px);
+    max-height: calc(100dvh - 64px);
+    overflow-y: auto;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+    border-radius: 16px;
+    /* Ensure it sits above the virtual keyboard */
+    pointer-events: auto;
+  }
+
+  /* × button in top-right corner of the overlay card */
+  .practice-plugin--results .practice-results__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    width: 2rem;
+    height: 2rem;
+    border: none;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.12);
+    color: inherit;
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+    z-index: 1;
+  }
 }

--- a/frontend/plugins/practice-view/PracticePlugin.tsx
+++ b/frontend/plugins/practice-view/PracticePlugin.tsx
@@ -128,6 +128,10 @@ export function PracticePlugin({ context }: PracticePluginProps) {
     () => sessionStorage.getItem('practice-tips-v1-dismissed') !== 'yes',
   );
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
+  // Controls whether the results overlay is visible on mobile landscape.
+  // Resets to true each time results phase is entered; can be dismissed by
+  // tapping the backdrop so the user can see the staff underneath.
+  const [resultsOverlayVisible, setResultsOverlayVisible] = useState(true);
 
   // Sound toggle — muting silences guide notes without affecting user MIDI feedback
   const [soundEnabled, setSoundEnabled] = useState(true);
@@ -577,6 +581,7 @@ export function PracticePlugin({ context }: PracticePluginProps) {
         };
         setResult(exerciseResult);
         setHighlightedSlotIndex(null);
+        setResultsOverlayVisible(true);
         setPhase('results');
         phaseRef.current = 'results';
       } else {
@@ -722,6 +727,7 @@ export function PracticePlugin({ context }: PracticePluginProps) {
           { includeTimingScore: inputSourceRef.current === 'midi' },
         );
         setResult(exerciseResult);
+        setResultsOverlayVisible(true);
         setPhase('results');
         phaseRef.current = 'results';
       }, finishMs);
@@ -774,6 +780,7 @@ export function PracticePlugin({ context }: PracticePluginProps) {
       { includeTimingScore: inputSourceRef.current === 'midi' },
     );
     setResult(exerciseResult);
+    setResultsOverlayVisible(true);
     setPhase('results');
     phaseRef.current = 'results';
   }, [context, resetOnsetDetection, clearStepTimeout]);
@@ -927,9 +934,12 @@ export function PracticePlugin({ context }: PracticePluginProps) {
   // ── Sidebar: only visible in Custom mode, hidden during exercise ──────────
   useEffect(() => {
     if (complexityLevel === null) {
-      // Custom mode: open when idle, collapse during exercise or results
-      if (phase !== 'playing' && phase !== 'countdown' && phase !== 'results') setSidebarCollapsed(false);
-      else setSidebarCollapsed(true);
+      // Custom: collapse while playing/countdown; open when ready; leave alone on results
+      // (results phase: the user may have explicitly opened it via the level selector,
+      //  so don't auto-close — Retry/New already advance to the next state)
+      if (phase === 'playing' || phase === 'countdown') setSidebarCollapsed(true);
+      else if (phase === 'ready') setSidebarCollapsed(false);
+      // phase === 'results': no change — preserve manual open/close state
     } else {
       // Preset level: always hidden
       setSidebarCollapsed(true);
@@ -1053,7 +1063,7 @@ export function PracticePlugin({ context }: PracticePluginProps) {
   // ── Render ───────────────────────────────────────────────────────────────────
 
   return (
-    <div className="practice-plugin" data-testid="practice-view">
+    <div className={`practice-plugin${phase === 'results' && resultsOverlayVisible ? ' practice-plugin--results' : ''}`} data-testid="practice-view">
       {/* ── Header ───────────────────────────────────────────────────────── */}
       <header className="practice-plugin__header">
         <button
@@ -1167,7 +1177,18 @@ export function PracticePlugin({ context }: PracticePluginProps) {
       <div className="practice-plugin__body">
 
         {/* ── Sidebar ────────────────────────────────────────────────────── */}
-        <aside className={`practice-sidebar${sidebarCollapsed ? ' practice-sidebar--collapsed' : ''}`}>
+        <aside className={`practice-sidebar${sidebarCollapsed ? ' practice-sidebar--collapsed' : ''}${complexityLevel !== null ? ' practice-sidebar--hidden' : ''}`}>
+          {complexityLevel === null && (
+            <button
+              className="practice-sidebar__toggle"
+              onClick={() => setSidebarCollapsed(prev => !prev)}
+              aria-label={sidebarCollapsed ? 'Open config panel' : 'Collapse config panel'}
+              aria-expanded={!sidebarCollapsed}
+              title={sidebarCollapsed ? 'Open config' : 'Collapse config'}
+            >
+              {sidebarCollapsed ? '⚙' : '‹'}
+            </button>
+          )}
           <div className="practice-sidebar__sections">
               {/* MODE */}
               <div className="practice-sidebar__section">
@@ -1388,7 +1409,30 @@ export function PracticePlugin({ context }: PracticePluginProps) {
 
           {/* Results panel */}
           {phase === 'results' && result && (
-            <div className="practice-results" role="region" aria-label="Exercise results">
+            <>
+              {/* Backdrop — only visible in mobile landscape overlay mode.
+                  Tap it to dismiss the overlay (returns to staff view). */}
+              <div
+                className="practice-results__backdrop"
+                role="button"
+                aria-label="Close results"
+                onClick={() => setResultsOverlayVisible(false)}
+                onTouchEnd={(e) => { e.preventDefault(); setResultsOverlayVisible(false); }}
+              />
+              <div
+                className="practice-results"
+                role="region"
+                aria-label="Exercise results"
+                onClick={(e) => e.stopPropagation()}
+              >
+              {/* Close button — only shown in mobile landscape overlay */}
+              <button
+                className="practice-results__close"
+                aria-label="Close results"
+                onClick={() => setResultsOverlayVisible(false)}
+              >
+                ×
+              </button>
               {/* Score headline */}
               <div className="practice-results__score-block">
                 <div className="practice-results__score-ring">
@@ -1495,6 +1539,7 @@ export function PracticePlugin({ context }: PracticePluginProps) {
 
               {/* Retry / New actions are in the toolbar — no redundant buttons here */}
             </div>
+          </>
           )}
         </main>
       </div>


### PR DESCRIPTION
## Summary

Follow-up UX fixes for Feature 001 (Practice Virtual Keyboard), focusing on the results overlay in mobile landscape.

## Changes

### Sidebar
- Add collapse toggle button (⚙ / ‹) to the sidebar — only shown in custom complexity mode so users can hide/restore the config panel
- Fix config panel not opening on the first custom level selection (effect no longer forces state during the `results` phase)

### Results overlay (mobile landscape)
- Results are shown as a centred fixed overlay with a dimmed backdrop when `orientation: landscape` and `max-height ≤ 520px`
- **Backdrop dismissal**: backdrop div uses `role=button` + `onTouchEnd` for iOS reliability (pseudo-elements can't receive touch events, so replaced `::before` with a real DOM element)
- **× close button**: absolute-positioned top-right button inside the card, only visible in overlay context — ensures users can always dismiss even when the card fills the viewport
- `resultsOverlayVisible` reset to `true` in all three code paths that enter the `results` phase (step completion, flow countdown, `handleStop`)

### Note table
- Add `overflow-y: auto`, `max-height: 40vh`, `-webkit-overflow-scrolling: touch`, and `touch-action: pan-y` to the note-by-note details table wrapper for tap-and-drag touch scroll

## Tests

- Unit: 1220 passed
- E2E: 39 passed