### PR TITLE
fix(039): theme-aware return-to-start button in Play and Practice

### DIFF
--- a/frontend/src/components/plugins/ScoreRendererPlugin.css
+++ b/frontend/src/components/plugins/ScoreRendererPlugin.css
@@ -1,0 +1,22 @@
+.score-renderer-return-btn {
+  display: block;
+  width: 100%;
+  padding: 12px 0;
+  font-size: 0.9rem;
+  font-weight: bold;
+  color: var(--ls-accent, #1976d2);
+  background: var(--ls-bg, #fff);
+  border: none;
+  border-top: 1px solid color-mix(in srgb, var(--ls-accent, #1976d2) 20%, transparent);
+  cursor: pointer;
+  text-align: center;
+  letter-spacing: 0.03em;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s;
+}
+
+.score-renderer-return-btn:hover {
+  background: color-mix(in srgb, var(--ls-accent, #1976d2) 10%, var(--ls-bg, #fff));
+}

--- a/frontend/src/components/plugins/ScoreRendererPlugin.tsx
+++ b/frontend/src/components/plugins/ScoreRendererPlugin.tsx
@@ -16,6 +16,7 @@
 import { useMemo, useRef } from 'react';
 import { LayoutView } from '../layout/LayoutView';
 import type { PluginScoreRendererProps } from '../../plugin-api/types';
+import './ScoreRendererPlugin.css';
 import type { Note, Score } from '../../types/score';
 import type { PlaybackStatus, ITickSource } from '../../types/playback';
 
@@ -140,7 +141,7 @@ export function ScoreRendererPlugin({
           at the bottom of the container. play-score__score-area is overflow:hidden
           so layoutWrapperRef is the only scroll container; scrollTop=0 works. */}
       <button
-        style={styles.returnToStartButton}
+        className="score-renderer-return-btn"
         onClick={() => {
           onReturnToStart();
           if (layoutWrapperRef.current) {
@@ -191,21 +192,5 @@ const styles = {
     fontSize: '1.1rem',
     color: '#888',
   },
-  returnToStartButton: {
-    display: 'block',
-    width: '100%',
-    padding: '12px 0',
-    fontSize: '0.9rem',
-    fontWeight: 'bold' as const,
-    color: '#1976d2',
-    background: '#fff',
-    border: 'none',
-    borderTop: '1px solid #e0e0e0',
-    cursor: 'pointer',
-    textAlign: 'center' as const,
-    letterSpacing: '0.03em',
-    userSelect: 'none' as const,
-    WebkitUserSelect: 'none' as const,
-    WebkitTapHighlightColor: 'transparent',
-  },
+
 } as const;


### PR DESCRIPTION
Replace hardcoded #1976d2/#fff/#e0e0e0 inline styles on the return-to-start button (shared by Play and Practice) with a CSS class using var(--ls-accent) and var(--ls-bg), so it honours the active landing theme. Adds a hover state via color-mix.