### PR TITLE
chore: migrate repo URLs from aylabs/graditone to graditone/graditone

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # Graditone
 
-**Live App**: [https://aylabs.github.io/graditone/](https://aylabs.github.io/graditone/)
+**Live App**: [https://graditone.github.io/graditone/](https://graditone.github.io/graditone/)
 
 A tablet-native app for interactive scores, designed for practice and performance.
 
@@ -76,7 +76,7 @@ A tablet-native app for interactive scores, designed for practice and performanc
 
 ## Quick Start
 
-**Try it now**: [https://aylabs.github.io/graditone/](https://aylabs.github.io/graditone/)
+**Try it now**: [https://graditone.github.io/graditone/](https://graditone.github.io/graditone/)
 
 1. **Launch the app** - Opens with a demo score
 2. **Import your score** - Click "Import Score" to load MusicXML files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎵 Graditone
 
-**🚀 Live App**: [https://aylabs.github.io/graditone/](https://aylabs.github.io/graditone/)
+**🚀 Live App**: [https://graditone.github.io/graditone/](https://graditone.github.io/graditone/)
 
 ### Play view gestures
 
@@ -100,7 +100,7 @@ Graditone is a tablet-native app for interactive scores, designed for practice a
 
 ### Use the Live App
 
-**🚀 [Launch Graditone](https://aylabs.github.io/graditone/)**
+**🚀 [Launch Graditone](https://graditone.github.io/graditone/)**
 
 - Works on tablets (iPad, Surface, Android)
 - No installation required
@@ -303,7 +303,7 @@ See repository root for license information.
 
 ---
 
-**Version**: [1.0](https://github.com/aylabs/graditone)  
+**Version**: [1.0](https://github.com/graditone/graditone)  
 **Last Updated**: 2026-02-12  
 **Status**: ✅ PWA deployed to GitHub Pages | Layout Engine Complete  
 **Test Coverage**: 669 tests (589 integration + 47 layout utilities + 33 component) - 100% passing

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -109,7 +109,7 @@ The `[skip ci]` tag prevents infinite loops (version bump commit doesn't trigger
 - PWA may cache old version (service worker update can take up to 24h)
 
 ### Version bump failed in CI?
-Check workflow logs: https://github.com/aylabs/graditone/actions
+Check workflow logs: https://github.com/graditone/graditone/actions
 - Ensure `contents: write` permission is set
 - Check for merge conflicts in package.json
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -368,7 +368,7 @@ function App() {
           <h1>
             <span className="app-title-initial">G</span>raditone{' '}
             <a 
-              href="https://github.com/aylabs/graditone" 
+              href="https://github.com/graditone/graditone" 
               target="_blank" 
               rel="noopener noreferrer"
               style={{ 
@@ -405,7 +405,7 @@ function App() {
           <h1>
             <span className="app-title-initial">G</span>raditone{' '}
             <a 
-              href="https://github.com/aylabs/graditone" 
+              href="https://github.com/graditone/graditone" 
               target="_blank" 
               rel="noopener noreferrer"
               style={{ 
@@ -531,7 +531,7 @@ function App() {
                 <h1>
                   <span className="app-title-initial">G</span>raditone{' '}
                   <a
-                    href="https://github.com/aylabs/graditone"
+                    href="https://github.com/graditone/graditone"
                     target="_blank"
                     rel="noopener noreferrer"
                     style={{


### PR DESCRIPTION
- App.tsx: 3x GitHub href
- README.md, FEATURES.md: live app + repo links
- VERSIONING.md: CI actions URL
- Git remote updated to git@github.com:graditone/graditone.git