### PR TITLE
feat: serve PWA from graditone.com custom domain

### DIFF
--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -42,9 +42,9 @@ git push origin main
 
 After successful deployment:
 
-- **Base URL**: `https://<username>.github.io/graditone/`
-- **Manifest**: `https://<username>.github.io/graditone/manifest.webmanifest`
-- **Service Worker**: `https://<username>.github.io/graditone/sw.js`
+- **Base URL**: `https://graditone.com/`
+- **Manifest**: `https://graditone.com/manifest.webmanifest`
+- **Service Worker**: `https://graditone.com/sw.js`
 
 ---
 
@@ -92,7 +92,7 @@ The workflow supports two deployment scenarios:
 No configuration needed - uses default `base: '/'`
 
 #### Scenario 2: Project Site (Default)
-**URL Pattern**: `https://<username>.github.io/graditone/`
+**URL Pattern**: `https://graditone.com/`
 
 Configure base path in GitHub Actions workflow:
 
@@ -102,7 +102,7 @@ Configure base path in GitHub Actions workflow:
   working-directory: frontend
   run: npm run build
   env:
-VITE_BASE: '/graditone/'  # Uncomment and set your repo name
+VITE_BASE: '/'  # Uncomment and set your repo name
 ```
 
 The `vite.config.ts` automatically picks up `VITE_BASE` environment variable.
@@ -162,7 +162,7 @@ After deployment, verify these assets:
 
 ### 1. PWA Manifest
 ```bash
-curl https://<username>.github.io/graditone/manifest.webmanifest
+curl https://graditone.com/manifest.webmanifest
 ```
 
 Should return JSON with:
@@ -173,22 +173,22 @@ Should return JSON with:
 
 ### 2. Service Worker
 ```bash
-curl https://<username>.github.io/graditone/sw.js
+curl https://graditone.com/sw.js
 ```
 
 Should return minified JavaScript with Workbox
 
 ### 3. Icons
 ```bash
-curl -I https://<username>.github.io/graditone/icons/icon-512x512.png
-curl -I https://<username>.github.io/graditone/icons/apple-touch-icon.png
+curl -I https://graditone.com/icons/icon-512x512.png
+curl -I https://graditone.com/icons/apple-touch-icon.png
 ```
 
 Should return `200 OK` with `Content-Type: image/png`
 
 ### 4. WASM Module
 ```bash
-curl -I https://<username>.github.io/graditone/wasm/musicore_backend_bg.wasm
+curl -I https://graditone.com/wasm/musicore_backend_bg.wasm
 ```
 
 Should return `200 OK` with `Content-Type: application/wasm`

--- a/.github/workflows/deploy-pwa.yml
+++ b/.github/workflows/deploy-pwa.yml
@@ -125,7 +125,7 @@ jobs:
           # Set base path for GitHub Pages deployment
           # If deploying to https://<username>.github.io/<repo>/
           # Uncomment and set VITE_BASE if needed:
-          VITE_BASE: '/graditone/'
+          VITE_BASE: '/'
 
       # ========================================
       # Stage 3: Deploy to GitHub Pages

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -94,7 +94,7 @@ jobs:
   # -----------------------------------------------------------------------
   # Production-simulation E2E tests
   #
-  # Builds the frontend with the GitHub Pages sub-path (VITE_BASE=/graditone/)
+  # Builds the frontend with the GitHub Pages sub-path (VITE_BASE=/)
   # and runs Playwright tests against `vite preview`. This catches asset-path
   # bugs (hardcoded '/' prefixes, missing BASE_URL usage, etc.) that only
   # appear on the deployed sub-path, not during local dev.
@@ -121,7 +121,7 @@ jobs:
       - name: Build with production base path
         working-directory: frontend
         env:
-          VITE_BASE: /graditone/
+          VITE_BASE: /
         run: npm run build
 
       - name: Install Playwright browsers

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # Graditone
 
-**Live App**: [https://graditone.github.io/graditone/](https://graditone.github.io/graditone/)
+**Live App**: [https://graditone.com/](https://graditone.com/)
 
 A tablet-native app for interactive scores, designed for practice and performance.
 
@@ -76,7 +76,7 @@ A tablet-native app for interactive scores, designed for practice and performanc
 
 ## Quick Start
 
-**Try it now**: [https://graditone.github.io/graditone/](https://graditone.github.io/graditone/)
+**Try it now**: [https://graditone.com/](https://graditone.com/)
 
 1. **Launch the app** - Opens with a demo score
 2. **Import your score** - Click "Import Score" to load MusicXML files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎵 Graditone
 
-**🚀 Live App**: [https://graditone.github.io/graditone/](https://graditone.github.io/graditone/)
+**🚀 Live App**: [https://graditone.com/](https://graditone.com/)
 
 ### Play view gestures
 
@@ -100,7 +100,7 @@ Graditone is a tablet-native app for interactive scores, designed for practice a
 
 ### Use the Live App
 
-**🚀 [Launch Graditone](https://graditone.github.io/graditone/)**
+**🚀 [Launch Graditone](https://graditone.com/)**
 
 - Works on tablets (iPad, Surface, Android)
 - No installation required

--- a/frontend/e2e/load-score-dialog.spec.ts
+++ b/frontend/e2e/load-score-dialog.spec.ts
@@ -6,7 +6,7 @@
  * - All 6 preloaded score files are fetched at the correct URL (no 404)
  * - Selecting a preloaded score loads it without console errors
  *
- * Run against the production build (VITE_BASE=/graditone/) to catch
+ * Run against the production build (VITE_BASE=/) to catch
  * sub-path base URL issues before they reach GitHub Pages.
  *
  * ## Why we stub .mxl responses in the URL test
@@ -64,7 +64,7 @@ test.describe('Feature 028: Load Score Dialog', () => {
     const fetchedUrl = request.url();
 
     // URL must include the correct scores path.
-    // On GitHub Pages (VITE_BASE=/graditone/): …/graditone/scores/Bach_InventionNo1.mxl
+    // On GitHub Pages (VITE_BASE=/): …/scores/Bach_InventionNo1.mxl
     // Locally (VITE_BASE=/):                  …/scores/Bach_InventionNo1.mxl
     expect(fetchedUrl).toMatch(/\/scores\/Bach_InventionNo1\.mxl$/);
   });

--- a/frontend/playwright.config.prod.ts
+++ b/frontend/playwright.config.prod.ts
@@ -4,10 +4,10 @@ import { defineConfig, devices } from '@playwright/test';
  * Production-simulation Playwright config.
  *
  * Runs E2E tests against a `vite preview` server built with
- * VITE_BASE=/graditone/ — the same sub-path used on GitHub Pages.
+ * VITE_BASE=/ — matches the root served at graditone.com.
  *
  * Usage (from the frontend/ directory):
- *   VITE_BASE=/graditone/ npm run build
+ *   VITE_BASE=/ npm run build
  *   npx playwright test --config playwright.config.prod.ts
  *
  * Why this exists:
@@ -29,7 +29,7 @@ export default defineConfig({
 
   use: {
     // Must match the sub-path the build was produced with
-    baseURL: 'http://localhost:4173/graditone/',
+    baseURL: 'http://localhost:4173/',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     // Block the PWA service worker during E2E tests.
@@ -46,11 +46,11 @@ export default defineConfig({
     },
   ],
 
-  // Expects the dist/ to already be built with VITE_BASE=/graditone/
+  // Expects the dist/ to already be built with VITE_BASE=/
   // The CI workflow does the build step before invoking playwright.
   webServer: {
-    command: 'VITE_BASE=/graditone/ npx vite preview --port 4173',
-    url: 'http://localhost:4173/graditone/',
+    command: 'VITE_BASE=/ npx vite preview --port 4173',
+    url: 'http://localhost:4173/',
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
   },

--- a/frontend/public/CNAME
+++ b/frontend/public/CNAME
@@ -1,0 +1,1 @@
+graditone.com

--- a/frontend/public/pwa-debug.html
+++ b/frontend/public/pwa-debug.html
@@ -170,7 +170,7 @@
     async function checkManifest() {
       const el = document.getElementById('manifestCheck');
       try {
-        const basePath = document.querySelector('base')?.href || window.location.origin + '/graditone/';
+        const basePath = document.querySelector('base')?.href || window.location.origin + '/';
         const manifestUrl = new URL('manifest.webmanifest', basePath).href;
         log(`Fetching manifest from: ${manifestUrl}`);
         

--- a/frontend/src/data/preloadedScores.test.ts
+++ b/frontend/src/data/preloadedScores.test.ts
@@ -13,7 +13,7 @@ describe('PRELOADED_SCORES', () => {
 
   it('all paths end with scores/<filename>.mxl', () => {
     for (const score of PRELOADED_SCORES) {
-      // BASE_URL is '/' in tests, '/graditone/' in production — allow any prefix
+      // BASE_URL is '/' in tests, '/' in production — allow any prefix
       expect(score.path).toMatch(/scores\/[^/]+\.mxl$/);
     }
   });

--- a/frontend/src/data/preloadedScores.ts
+++ b/frontend/src/data/preloadedScores.ts
@@ -3,18 +3,18 @@
  * Files are served from {BASE_URL}scores/ (symlinked from frontend/public/scores/ → ../../scores).
  *
  * Paths use import.meta.env.BASE_URL so they resolve correctly both locally (/)
- * and on GitHub Pages (/graditone/).
+ * and on GitHub Pages (/).
  *
  * Feature 028: Load Score Dialog
  */
 export interface PreloadedScore {
   id: string;
   displayName: string;
-  /** Path relative to the app's base URL, e.g. "/graditone/scores/Bach_InventionNo1.mxl" */
+  /** Path relative to the app's base URL, e.g. "/scores/Bach_InventionNo1.mxl" */
   path: string;
 }
 
-const base = import.meta.env.BASE_URL; // "/" locally, "/graditone/" on GitHub Pages
+const base = import.meta.env.BASE_URL; // "/" locally, "/" on GitHub Pages
 
 export const PRELOADED_SCORES: ReadonlyArray<PreloadedScore> = [
   {

--- a/frontend/src/services/recording/useAudioRecorder.ts
+++ b/frontend/src/services/recording/useAudioRecorder.ts
@@ -169,7 +169,7 @@ export function useAudioRecorder(
 
     // 3. Load AudioWorklet
     // Use import.meta.env.BASE_URL so the path is correct on both local dev
-    // (base '/') and GitHub Pages (base '/graditone/'). A hardcoded leading '/'
+    // (base '/') and GitHub Pages (base '/'). A hardcoded leading '/'
     // would skip the sub-path and produce a 404 on the deployed site.
     try {
       await audioCtx.audioWorklet.addModule(`${import.meta.env.BASE_URL}audio-processor.worklet.js`);


### PR DESCRIPTION
Add CNAME for graditone.com and change VITE_BASE from /graditone/ to / so all PWA assets resolve correctly at the custom domain root. Updates CI workflows, playwright prod config, pwa-debug.html, source comments, and docs.