### PR TITLE
fix(041): honor repeats in practice view and fix pinned highlight/scroll

### DIFF
--- a/frontend/src/components/LayoutRenderer.tsx
+++ b/frontend/src/components/LayoutRenderer.tsx
@@ -342,7 +342,11 @@ export class LayoutRenderer extends Component<LayoutRendererProps> {
   private updatePinnedHighlights(): void {
     const svg = this.svgRef.current;
     if (!svg) return;
-    const currentPinned = this.props.pinnedNoteIds ?? new Set<string>();
+    const rawPinned = this.props.pinnedNoteIds ?? new Set<string>();
+
+    // Strip repeat-expansion suffix (e.g. "-r1") so layout DOM elements
+    // (which use original note IDs) are found during repeated sections.
+    const currentPinned = new Set([...rawPinned].map(id => id.replace(/-r\d+$/, '')));
 
     // Remove .pinned from ALL matching layout-glyph elements for IDs no longer pinned.
     // Scoped to .layout-glyph to skip hit-rects (transparent overlays) and beams.

--- a/frontend/src/pages/ScoreViewer.tsx
+++ b/frontend/src/pages/ScoreViewer.tsx
@@ -621,10 +621,13 @@ export class ScoreViewer extends Component<ScoreViewerProps, ScoreViewerState> {
     // Ensure reverse index is up-to-date (O(N) once, then cached)
     this.ensureNoteIdIndex();
 
-    // O(k) lookup: find system index for any target note
+    // O(k) lookup: find system index for any target note.
+    // Strip repeat-expansion suffix (e.g. "-r1") so repeated-section IDs
+    // resolve to their original layout position.
     let targetSystemIndex = -1;
     for (const noteId of targetNoteIds) {
-      const systemIndex = this.noteIdToSystemIndex.get(noteId);
+      const baseId = noteId.replace(/-r\d+$/, '');
+      const systemIndex = this.noteIdToSystemIndex.get(baseId);
       if (systemIndex !== undefined) {
         targetSystemIndex = systemIndex;
         break;

--- a/frontend/src/plugin-api/scorePlayerContext.ts
+++ b/frontend/src/plugin-api/scorePlayerContext.ts
@@ -101,6 +101,22 @@ function extractNotes(score: Score): Note[] {
 }
 
 /**
+ * Extract notes per staff from a Score (voice-0 only).
+ * Returns an array indexed by staff position across all instruments.
+ * Used to build per-staff expanded note lists for practice mode.
+ */
+function extractNotesByStaff(score: Score): Note[][] {
+  const byStaff: Note[][] = [];
+  for (const instrument of score.instruments) {
+    for (const staff of instrument.staves) {
+      const firstVoice = staff.voices[0];
+      byStaff.push(firstVoice ? [...firstVoice.interval_events] : []);
+    }
+  }
+  return byStaff;
+}
+
+/**
  * Extract the initial tempo (BPM) from a Score's global structural events.
  * Defaults to 120 BPM if no Tempo event is found at tick 0.
  */
@@ -130,59 +146,6 @@ function extractTimeSignature(score: Score): { numerator: number; denominator: n
   return { numerator: 4, denominator: 4 };
 }
 
-/**
- * Extract pitched notes for practice from a Score, returning all chord pitches and note IDs (v6).
- *
- * Rules (v6 update from Feature 037):
- *   1. Source: instruments[0].staves[staffIndex].voices[0] (target staff by index)
- *   2. Group by start_tick; collect ALL pitches at each tick (full chord, not just max)
- *   3. Sort ascending by tick → ordered note-entry sequence
- *   4. Clef: read from the target staff's active_clef; normalise to 'Treble' | 'Bass'
- *   5. Cap to maxCount if provided; report totalAvailable before cap
- */
-function extractPracticeNotesFromScore(
-  score: Score,
-  staffIndex: number,
-  maxCount?: number,
-): PluginScorePitches {
-  const instrument = score.instruments[0];
-  const staff = instrument?.staves[staffIndex] ?? instrument?.staves[0];
-  const voice = staff?.voices[0];
-  const events = voice?.interval_events ?? [];
-
-  // Group by start_tick; collect ALL pitches + note IDs at each tick (full chord)
-  const tickMap = new Map<number, PluginPracticeNoteEntry>();
-  for (const note of events) {
-    const existing = tickMap.get(note.start_tick);
-    if (existing) {
-      // Append this note to the chord at this tick
-      tickMap.set(note.start_tick, {
-        midiPitches: [...existing.midiPitches, note.pitch],
-        noteIds: [...existing.noteIds, note.id],
-        tick: note.start_tick,
-      });
-    } else {
-      tickMap.set(note.start_tick, {
-        midiPitches: [note.pitch],
-        noteIds: [note.id],
-        tick: note.start_tick,
-      });
-    }
-  }
-
-  // Sort by tick → ordered sequence
-  const allEntries = [...tickMap.values()].sort((a, b) => a.tick - b.tick);
-
-  const totalAvailable = allEntries.length;
-  const notes = maxCount !== undefined ? allEntries.slice(0, maxCount) : allEntries;
-
-  // Clef normalisation: Bass passes through; everything else → Treble
-  const rawClef = staff?.active_clef ?? 'Treble';
-  const clef: 'Treble' | 'Bass' = rawClef === 'Bass' ? 'Bass' : 'Treble';
-
-  return { notes, totalAvailable, clef, title: null };
-}
-
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -201,6 +164,8 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
   const [score, setScore] = useState<Score | null>(null);
   const [notes, setNotes] = useState<Note[]>([]);
   const [rawNotes, setRawNotes] = useState<Note[]>([]);
+  /** Expanded notes per staff (indexed by staff position), used by extractPracticeNotes. */
+  const [expandedNotesByStaff, setExpandedNotesByStaff] = useState<Note[][]>([]);
   const [scoreTempo, setScoreTempo] = useState<number>(120);
   const [scoreTimeSignature, setScoreTimeSignature] = useState<{ numerator: number; denominator: number }>({ numerator: 4, denominator: 4 });
   const [title, setTitle] = useState<string | null>(null);
@@ -330,12 +295,20 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
         result.metadata.file_name?.replace(/\.[^.]+$/, '') ??
         null;
 
+      // Per-staff expanded notes — used by extractPracticeNotes so the
+      // practice engine sees repeat-expanded ticks matching the playback engine.
+      const rawNotesByStaff = extractNotesByStaff(result.score);
+      const parsedNotesByStaff = rawNotesByStaff.map(staffNotes =>
+        expandNotesWithRepeats(staffNotes, result.score.repeat_barlines)
+      );
+
       // Reset playback state for the new score
       playbackState.resetPlayback();
 
       setScore(result.score);
       setNotes(parsedNotes);
       setRawNotes(extractedNotes);
+      setExpandedNotesByStaff(parsedNotesByStaff);
       setScoreTempo(parsedTempo);
       setScoreTimeSignature(parsedTimeSignature);
       setTitle(parsedTitle);
@@ -408,11 +381,43 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
     (staffIndex: number, maxCount?: number): PluginScorePitches | null => {
       // Only available when a score is fully loaded
       if (pluginStatus !== 'ready' || !score) return null;
-      const result = extractPracticeNotesFromScore(score, staffIndex, maxCount);
-      // Include the display title from the loaded score metadata
-      return { ...result, title };
+
+      // Use pre-expanded per-staff notes so the practice engine sees repeat-
+      // expanded ticks that match the playback engine tick space.
+      const staffNotes = expandedNotesByStaff[staffIndex] ?? expandedNotesByStaff[0] ?? [];
+
+      // Group by start_tick; collect ALL pitches + note IDs at each tick (full chord)
+      const tickMap = new Map<number, PluginPracticeNoteEntry>();
+      for (const note of staffNotes) {
+        const existing = tickMap.get(note.start_tick);
+        if (existing) {
+          tickMap.set(note.start_tick, {
+            midiPitches: [...existing.midiPitches, note.pitch],
+            noteIds: [...existing.noteIds, note.id],
+            tick: note.start_tick,
+          });
+        } else {
+          tickMap.set(note.start_tick, {
+            midiPitches: [note.pitch],
+            noteIds: [note.id],
+            tick: note.start_tick,
+          });
+        }
+      }
+
+      const allEntries = [...tickMap.values()].sort((a, b) => a.tick - b.tick);
+      const totalAvailable = allEntries.length;
+      const notes = maxCount !== undefined ? allEntries.slice(0, maxCount) : allEntries;
+
+      // Clef: read from score structure (unchanged from original)
+      const instrument = score.instruments[0];
+      const staff = instrument?.staves[staffIndex] ?? instrument?.staves[0];
+      const rawClef = staff?.active_clef ?? 'Treble';
+      const clef: 'Treble' | 'Bass' = rawClef === 'Bass' ? 'Bass' : 'Treble';
+
+      return { notes, totalAvailable, clef, title };
     },
-    [pluginStatus, score, title],
+    [pluginStatus, score, expandedNotesByStaff, title],
   );
 
   // ─── Return the bridge object ─────────────────────────────────────────────

--- a/specs/041-repeat-barlines/research.md
+++ b/specs/041-repeat-barlines/research.md
@@ -141,3 +141,37 @@ The SC-001 success criterion in `spec.md` encodes this exact count. Integration 
 **Lookup**: For each `measure_index` in the `repeat_barlines` array, set the corresponding `MeasureInfo` flag. Since `MeasureInfo` is built by iterating `measures` with `enumerate`, the index mapping is direct.
 
 **Alternatives considered**: A separate WASM function accepting a `repeat_barlines` parameter. Rejected as unnecessary indirection — the score JSON is already the single input contract.
+
+---
+
+## R-007: Practice View Repeat Expansion (Platform-Level)
+
+**Decision**: `extractPracticeNotes()` in `scorePlayerContext.ts` must use pre-expanded, per-staff note lists rather than re-reading raw `interval_events` from the `Score` object.
+
+**Problem identified (post-implementation bug)**: The original `extractPracticeNotesFromScore()` helper read `score.instruments[0].staves[staffIndex].voices[0].interval_events` directly — bypassing the `expandNotesWithRepeats()` call made during `loadScore`. The practice engine therefore received raw (unexpanded) ticks and stopped at the end of the written score without executing any repeat passes.
+
+**Evidence**: `scorePlayerContext.ts` `loadScore` already stores:
+- `notes` (expanded flat array, all staves merged) — used by the playback engine
+- `rawNotes` (unexpanded flat array) — used by the layout engine
+
+The practice engine needs per-staff expanded notes. `notes` is a flat merged array with no staff attribute on `Note`, so it cannot be filtered back to per-staff after the fact.
+
+**Fix**: Introduce `extractNotesByStaff(score): Note[][]` that returns one `Note[]` per staff (voice-0 only). In `loadScore`, map each per-staff slice through `expandNotesWithRepeats(staffNotes, score.repeat_barlines)` and store the result as `expandedNotesByStaff: Note[][]` state. `extractPracticeNotes(staffIndex)` reads from `expandedNotesByStaff[staffIndex]` and groups by `start_tick` to produce `PluginPracticeNoteEntry[]` with repeat-expanded ticks.
+
+**Architectural principle**: Repeat expansion is platform logic. Plugins receive already-expanded data; they do not call `expandNotesWithRepeats` themselves.
+
+**Tick space alignment**: `PluginPracticeNoteEntry.tick` values are now in the **expanded tick space**, matching `playerState.currentTick` (which also comes from the playback engine operating on expanded notes). Practice start-index lookup (`notes[i].tick >= currentTick`) is therefore correct.
+
+---
+
+## R-008: Pinned (Green) Highlight and Auto-Scroll Repeat Suffix Stripping
+
+**Decision**: `LayoutRenderer.updatePinnedHighlights()` and `ScoreViewer.scrollToHighlightedSystem()` must strip the `-r\d+$` repeat-expansion suffix from note IDs before querying DOM elements or the `noteIdToSystemIndex` reverse index.
+
+**Problem identified (post-implementation bug)**: `targetNoteIds` / `pinnedNoteIds` in the practice plugin are populated from `practiceState.notes[currentIndex].noteIds`. After the R-007 fix, those IDs are expanded IDs (e.g. `uuid-r1`) during repeat passes. The SVG DOM elements and the layout index both use raw IDs (no suffix), so:
+- `updatePinnedHighlights()` found zero matching `.layout-glyph[data-note-id="uuid-r1"]` elements → no green highlight rendered.
+- `scrollToHighlightedSystem()` looked up `uuid-r1` in `noteIdToSystemIndex` → got `undefined` → auto-scroll stopped during repeat sections.
+
+**Fix**: Both methods apply `.replace(/-r\d+$/, '')` to each ID before DOM queries / map lookups. This is consistent with `updateHighlights()` and `reapplyHighlights()`, which already stripped the suffix for the orange playback highlight.
+
+**Scope**: `LayoutRenderer.tsx` (`updatePinnedHighlights`) and `ScoreViewer.tsx` (`scrollToHighlightedSystem`). No changes to plugin code or the `PluginPracticeNoteEntry` type.


### PR DESCRIPTION
## Summary

Follow-up fixes to feature 041 (repeat barlines) addressing three bugs discovered after the initial implementation.

### Bug 1: Practice view did not honor repeats

**Root cause**: `extractPracticeNotes()` in `scorePlayerContext.ts` called `extractPracticeNotesFromScore(score, staffIndex)`, which re-read `interval_events` directly from the raw `Score` object — bypassing `expandNotesWithRepeats()`. Practice notes therefore had raw (unexpanded) ticks and stopped at the end of the written score without executing any repeat passes.

**Fix**: Added `extractNotesByStaff(score)` helper returning `Note[][]` (one array per staff). In `loadScore`, each per-staff slice is passed through `expandNotesWithRepeats()` and cached as `expandedNotesByStaff` state. `extractPracticeNotes()` now reads from this pre-expanded state so practice ticks align with the playback engine.

Platform principle: expansion logic lives entirely in `scorePlayerContext` (the platform); plugins receive already-expanded data.

### Bug 2: Green target note disappeared during repeat sections

**Root cause**: `LayoutRenderer.updatePinnedHighlights()` queried the SVG DOM with expanded IDs (e.g. `uuid-r1`) but DOM elements only carry raw IDs (`uuid`). Zero elements were matched → no green highlight.

**Fix**: Strip `-rN` suffix before DOM query, consistent with `updateHighlights()` / `reapplyHighlights()` which already handled this for the orange playback highlight.

### Bug 3: Auto-scroll stopped during repeat sections

**Root cause**: `ScoreViewer.scrollToHighlightedSystem()` looked up expanded IDs in the `noteIdToSystemIndex` reverse index, which is built from `sourceToNoteIdMap` (raw IDs only). All lookups returned `undefined` during repeat passes.

**Fix**: Strip `-rN` suffix before the map lookup.

## Files Changed

- `frontend/src/plugin-api/scorePlayerContext.ts` — per-staff expand + rewrite `extractPracticeNotes`
- `frontend/src/components/LayoutRenderer.tsx` — suffix strip in `updatePinnedHighlights`
- `frontend/src/pages/ScoreViewer.tsx` — suffix strip in `scrollToHighlightedSystem`
- `specs/041-repeat-barlines/research.md` — add R-007 and R-008

## Tests

All 1466 frontend tests pass.
