### PR TITLE
fix(train): tips banner honors theme; mic released when MIDI is active

### DIFF
--- a/frontend/plugins/train-view/TrainPlugin.css
+++ b/frontend/plugins/train-view/TrainPlugin.css
@@ -164,8 +164,8 @@
   align-items: flex-start;
   gap: 0.75rem;
   padding: 0.625rem 1rem;
-  background: #e8f4fd;
-  border-bottom: 1px solid #bee3f8;
+  background: color-mix(in srgb, var(--color-accent, #4f8ef7) 10%, var(--color-surface, #fff));
+  border-bottom: 1px solid color-mix(in srgb, var(--color-accent, #4f8ef7) 30%, var(--color-border, #e0e0e0));
   flex-shrink: 0;
 }
 
@@ -174,7 +174,7 @@
   margin: 0;
   padding: 0 0 0 1.25rem;
   font-size: 0.82rem;
-  color: #1a5276;
+  color: var(--color-text, #222);
   list-style: disc;
   line-height: 1.6;
 }
@@ -187,18 +187,18 @@
   flex-shrink: 0;
   align-self: center;
   padding: 0.3rem 0.75rem;
-  border: 1px solid #7fb3d3;
+  border: 1px solid color-mix(in srgb, var(--color-accent, #4f8ef7) 40%, var(--color-border, #e0e0e0));
   border-radius: 6px;
   font-size: 0.8rem;
   font-weight: 600;
-  background: #fff;
-  color: #1a5276;
+  background: var(--color-surface, #fff);
+  color: var(--color-text, #222);
   cursor: pointer;
   transition: background 0.12s;
 }
 
 .train-plugin__tips-dismiss:hover {
-  background: #d6eaf8;
+  background: color-mix(in srgb, var(--color-accent, #4f8ef7) 15%, var(--color-surface, #fff));
 }
 
 /* ── Body: sidebar + main ────────────────────────────────────────────────── */

--- a/frontend/plugins/train-view/TrainPlugin.tsx
+++ b/frontend/plugins/train-view/TrainPlugin.tsx
@@ -348,7 +348,19 @@ export function TrainPlugin({ context }: TrainPluginProps) {
   //    finalising the pending note and resetting the state machine
   //  - Filters pitches outside CAPTURE_MIDI_MIN..CAPTURE_MIDI_MAX (ultrasonic artefacts)
   //  - Ignores frames with confidence < MIN_CONFIDENCE
+  //  - Mic stream is stopped entirely while MIDI is the active input source;
+  //    it restarts automatically when MIDI disconnects.
   useEffect(() => {
+    // MIDI active → release the microphone hardware immediately.
+    // The effect re-runs when inputSource changes, so the stream restarts
+    // automatically if MIDI is later disconnected.
+    if (inputSource === 'midi') {
+      context.recording.stop();
+      setMicActive(null);
+      setMicError(null);
+      return;
+    }
+
     const unsubError = context.recording.onError((err) => {
       setMicError(err);
       setMicActive(false);
@@ -358,8 +370,8 @@ export function TrainPlugin({ context }: TrainPluginProps) {
       setMicActive(true);
       setMicError(null);
 
-      // MIDI takes priority over mic; virtual keyboard suspends mic entirely (Feature 001 — T008)
-      if (inputSourceRef.current === 'midi' || inputSourceRef.current === 'virtual-keyboard') return;
+      // Virtual keyboard suspends mic entirely (Feature 001 — T008)
+      if (inputSourceRef.current === 'virtual-keyboard') return;
 
       // Determine if this frame carries a valid in-range pitch
       const midi = hzToMidi(event.hz);
@@ -459,7 +471,7 @@ export function TrainPlugin({ context }: TrainPluginProps) {
       unsubPitch();
       unsubError();
     };
-  }, [context]);
+  }, [context, inputSource]);
 
   // ── MIDI subscription — detect source, capture, and auto-start ──────────────
   useEffect(() => {

--- a/specs/036-rename-practice-train/research.md
+++ b/specs/036-rename-practice-train/research.md
@@ -135,3 +135,54 @@ function pluginSortKey(m: PluginManifest): [number, string] {
 **Decision**: Update all three locations in `PLUGINS.md`.
 
 **Alternatives considered**: Only update the manifest schema (minimal change). Rejected: the reference section pointing to `frontend/plugins/practice-view/` becomes a broken path after the rename.
+
+---
+
+## R-008 — Tips banner must use CSS design tokens, not hardcoded colours
+
+**Problem**: `.train-plugin__tips`, `.train-plugin__tips-list`, and `.train-plugin__tips-dismiss` in `TrainPlugin.css` used hardcoded light-blue hex values (`#e8f4fd`, `#1a5276`, `#bee3f8`, etc.), making the banner invisible or illegible in dark/custom themes.
+
+**Finding**: All other Train plugin CSS rules already use `var(--color-*)` tokens defined in `App.css` (the Feature 039 bridge layer that maps `--ls-*` landing tokens). The tips section was the only block that bypassed this system.
+
+**Decision**: Replace hardcoded colours with `color-mix(in srgb, var(--color-accent, …) N%, var(--color-surface, …))` for backgrounds/borders and `var(--color-text)` for text. The `color-mix()` approach derives a contextual tint from the theme accent colour without needing new tokens.
+
+```css
+/* Before */
+background: #e8f4fd;
+border-bottom: 1px solid #bee3f8;
+color: #1a5276;
+
+/* After */
+background: color-mix(in srgb, var(--color-accent, #4f8ef7) 10%, var(--color-surface, #fff));
+border-bottom: 1px solid color-mix(in srgb, var(--color-accent, #4f8ef7) 30%, var(--color-border, #e0e0e0));
+color: var(--color-text, #222);
+```
+
+**Alternatives considered**: Adding a dedicated `--color-info-*` token set. Rejected — one-off usage; `color-mix` on the existing accent token is sufficient and consistent with how `--color-danger-bg` is derived elsewhere.
+
+---
+
+## R-009 — Microphone must be released when MIDI input is active
+
+**Problem**: When a MIDI keyboard was connected, the browser microphone stream remained open (browser mic indicator lit, AudioWorklet running), wasting resources and creating user confusion. Mic input was silently ignored in the pitch handler but the hardware was never released.
+
+**Finding**: The mic subscription `useEffect` had `[context]` as its dep array — it subscribed once on mount regardless of whether MIDI was active. The MIDI-priority guard (`if (inputSourceRef.current === 'midi') return;`) discarded events but never stopped the stream.
+
+**Decision**: Add `inputSource` to the mic `useEffect` dep array and insert an early-return branch:
+
+```tsx
+useEffect(() => {
+  // MIDI active → release the microphone hardware immediately.
+  if (inputSource === 'midi') {
+    context.recording.stop();
+    setMicActive(null);
+    setMicError(null);
+    return;
+  }
+  // … normal subscribe …
+}, [context, inputSource]);
+```
+
+When `inputSource` transitions to `'midi'` (on first MIDI attack or device detection), React runs the effect cleanup (unsubscribing the previous handler, which triggers `PluginMicBroadcaster.stopMic()` via subscriber-count teardown), then runs the new effect body which calls `stop()` as an extra safety net and returns without re-subscribing. When MIDI disconnects and `inputSource` reverts to `null`, the effect re-runs and the mic stream restarts.
+
+**Alternatives considered**: Calling `context.recording.stop()` directly inside the MIDI subscription handler. Rejected — that would stop the shared broadcaster stream for all current subscribers including any other plugin that might be using it; the `useEffect` scope restricts the teardown to the re-render triggered by this component's state change.


### PR DESCRIPTION
## Summary

Two standalone Train view bug fixes.

### Fix 1: Tips banner did not honor the active theme

The recording-tips info panel (`.train-plugin__tips`) used hardcoded light-blue hex values (`#e8f4fd`, `#bee3f8`, `#1a5276`, etc.) in `TrainPlugin.css`. Every other section of the Train plugin CSS already used `var(--color-*)` tokens, so the tips banner was the only element that ignored theme changes — appearing washed-out or illegible in dark/custom themes.

**Fix**: Replaced all hardcoded colours with `color-mix(in srgb, var(--color-accent) N%, var(--color-surface))` for backgrounds/borders and `var(--color-text)` for text, consistent with the rest of the plugin's token usage.

### Fix 2: Microphone stream not released when MIDI is active

When a MIDI keyboard was connected, the browser microphone stream remained open (mic indicator lit, AudioWorklet running). MIDI input was correctly taking priority for scoring, but the hardware was never released — wasting resources and misleading the user into thinking the mic was in use.

**Root cause**: The mic `useEffect` had `[context]` as its dep array — it subscribed once on mount and never reacted to `inputSource` changes. The MIDI-priority guard inside the handler discarded events but never called `context.recording.stop()`.

**Fix**: Added `inputSource` to the mic `useEffect` dep array. When `inputSource === 'midi'`, the effect calls `context.recording.stop()` immediately and returns without subscribing — releasing the hardware. When MIDI disconnects and `inputSource` returns to `null`, the effect re-runs and the mic stream restarts automatically.

## Files Changed

- `frontend/plugins/train-view/TrainPlugin.css` — theme tokens in tips banner
- `frontend/plugins/train-view/TrainPlugin.tsx` — mic released when MIDI active
- `specs/036-rename-practice-train/research.md` — add R-008 and R-009

## Tests

All 1466 frontend tests pass.
