### PR TITLE
feat: add Google Analytics (GA4) tracking to PWA

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,15 @@
     <link rel="icon" type="image/png" sizes="32x32" href="icons/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="icons/favicon-16x16.png" />
     <link rel="icon" type="image/svg+xml" href="icons/favicon.svg" />
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CF9B75XQ7T"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-CF9B75XQ7T');
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

Add the Google Analytics 4 (gtag.js) snippet for property **G-CF9B75XQ7T** to the `<head>` of `frontend/index.html`.

This enables page-view and event tracking in GA4 during the pre-release QA phase so the tester group can be monitored.

## Change

```html
<!-- Google tag (gtag.js) -->
<script async src="https://www.googletagmanager.com/gtag/js?id=G-CF9B75XQ7T"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());
  gtag('config', 'G-CF9B75XQ7T');
</script>
```

## Testing

1. Merge and deploy (or use the preview deploy from CI).
2. Open Google Analytics → Real-time → Overview.
3. Confirm page views are recorded for `graditone.com`.

## Testers

jgb@gsyc.es, pheras@gmail.com, grex@gsyc.urjc.es, cpetisco@gmail.com, aliciaca75@hotmail.com, borca_delca@hotmail.com, pepasfa@gmail.com, anasanfelix.sanfelix@gmail.com
