### PR TITLE
feat(guide): built-in Guide documentation plugin (001-docs-plugin)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -149,3 +149,30 @@ The **Play Score** plugin is a built-in full-screen plugin that lets users load,
 
 **Spec**: `specs/039-landing-page-redesign/`  
 **Updated**: March 2026
+
+---
+
+## Help & Documentation — Feature 001-docs-plugin
+
+Built-in documentation plugin (📖 Guide) that appears as the rightmost entry in the top nav bar and provides a single scrollable reference page for all Graditone features.
+
+### Sections
+
+| # | Heading | Content summary |
+|---|---------|----------------|
+| 1 | What is Graditone? | App overview, offline capability |
+| 2 | Playing a Score | Tap/long-press gestures, loop regions, tempo slider |
+| 3 | Practice Mode | MIDI-driven step practice workflow |
+| 4 | Train | Complexity levels, Flow/Step modes, exercise presets, MIDI/mic input |
+| 5 | Loading a Score | MusicXML export from notation software, preloaded demo scores, browser persistence |
+
+### Capabilities
+
+- **Nav bar entry**: `type: common`, `order: 99` — always rightmost in the top nav bar
+- **Host back button**: `view: window` + `pluginApiVersion: 1` — host renders “← Back” automatically
+- **Fully static**: no fetch, no state, fully offline-capable
+- **Theme-aware**: all CSS uses `--color-*` custom property tokens; inherits every landing theme automatically
+- **Responsive**: readable on 375 px–1366 px screen widths without truncation
+
+**Spec**: `specs/001-docs-plugin/`  
+**Updated**: March 2026

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -563,3 +563,32 @@ useEffect(() => {
 // Empty staff on load — notes=[] renders clef + time signature only
 <context.components.StaffViewer notes={playedNotes} clef="Treble" bpm={120} ... />
 ```
+```
+
+---
+
+## Reference: Guide plugin (common)
+
+| Field | Value |
+|-------|-------|
+| **ID** | `guide` |
+| **Name** | Guide |
+| **Icon** | 📖 |
+| **Version** | 1.0.0 |
+| **Plugin API Version** | 1 |
+| **Type** | `common` |
+| **View** | `window` |
+| **Order** | 99 (rightmost nav bar entry) |
+| **Entry point** | `index.tsx` |
+
+#### Description
+
+Built-in documentation plugin. Single scrollable reference page with five sections: app overview, score playback gestures, practice mode, train mode (ear-training), and MusicXML loading. Fully static — works offline.
+
+#### Manifest placement
+
+`type: "common"` → top nav bar. `order: 99` → rightmost. `view: "window"` + `pluginApiVersion: "1"` → host renders "← Back" button.
+
+#### CSS theming
+
+All colours use `--color-*` CSS custom properties (the App.css bridge tokens), inheriting every landing theme automatically. No hard-coded colour values.

--- a/frontend/plugins/guide/GuidePlugin.css
+++ b/frontend/plugins/guide/GuidePlugin.css
@@ -1,0 +1,112 @@
+/*
+ * GuidePlugin.css — Feature 001-docs-plugin: Graditone Documentation Plugin
+ *
+ * Uses --color-* CSS custom properties so the active landing theme cascades in
+ * automatically. The same token system is used by TrainPlugin.css and
+ * plugin-dialog.css. Fallback values apply when no theme is active.
+ *
+ * Token reference (defined on body[data-landing-theme] in App.css):
+ *   --color-surface          Page / panel background
+ *   --color-text             Heading / bold text colour
+ *   --color-text-secondary   Body / paragraph text colour
+ *   --color-border           Section divider line colour
+ *   --color-accent           Accent highlight (h2 underline)
+ */
+
+/* ── Root container (scroll host — fills the host flex column) ───────────── */
+
+.guide-plugin {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  background: var(--color-surface, #fff);
+  /* Themed scrollbar — appears at viewport edge, not inside the content box */
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border, #ccc) transparent;
+}
+
+.guide-plugin::-webkit-scrollbar {
+  width: 6px;
+}
+
+.guide-plugin::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.guide-plugin::-webkit-scrollbar-thumb {
+  background: var(--color-border, #ccc);
+  border-radius: 3px;
+}
+
+.guide-plugin::-webkit-scrollbar-thumb:hover {
+  background: var(--color-accent, #4a90e2);
+}
+
+/* ── Inner content wrapper (centred, width-capped) ───────────────────────── */
+
+.guide-plugin__inner {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px;
+  box-sizing: border-box;
+  font-size: 1rem;
+  line-height: 1.6;
+  word-wrap: break-word;
+  color: var(--color-text-secondary, #555);
+}
+
+/* ── Sections ─────────────────────────────────────────────────────────────── */
+
+.guide-section {
+  margin-bottom: 2.5rem;
+}
+
+.guide-section h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text, #222);
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 2px solid var(--color-accent, #4a90e2);
+}
+
+/* ── Body text ────────────────────────────────────────────────────────────── */
+
+.guide-section p {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  color: var(--color-text-secondary, #555);
+}
+
+.guide-section li {
+  margin-bottom: 0.4rem;
+  color: var(--color-text-secondary, #555);
+}
+
+.guide-section ul,
+.guide-section ol {
+  padding-left: 1.5rem;
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.guide-section strong {
+  color: var(--color-text, #222);
+}
+
+.guide-section code {
+  font-size: 0.875em;
+  color: var(--color-text, #222);
+  background: color-mix(in srgb, var(--color-border, #e0e0e0) 50%, transparent);
+  border-radius: 3px;
+  padding: 0.1em 0.35em;
+}
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .guide-plugin__inner {
+    padding: 16px;
+  }
+}

--- a/frontend/plugins/guide/GuidePlugin.test.tsx
+++ b/frontend/plugins/guide/GuidePlugin.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * GuidePlugin.test.tsx — Feature 001-docs-plugin
+ *
+ * Tests written BEFORE implementation (TDD — Constitution Principle V).
+ * Tests covering US1, US2, and US3 contract requirements.
+ *
+ * Run: npm run test -- plugins/guide
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GuidePlugin } from './GuidePlugin';
+import guidePlugin from './index';
+import manifest from './plugin.json';
+
+// ─── US1: First-Time User Orientation ───────────────────────────────────────
+
+describe('GuidePlugin — component (US1)', () => {
+  it('renders without crashing', () => {
+    render(<GuidePlugin />);
+  });
+
+  it('displays the "What is Graditone?" heading (FR-005)', () => {
+    render(<GuidePlugin />);
+    expect(screen.getByRole('heading', { name: /what is graditone\?/i })).toBeInTheDocument();
+  });
+
+  it('exports a valid GraditonePlugin object', () => {
+    expect(typeof guidePlugin.init).toBe('function');
+    expect(typeof guidePlugin.Component).toBe('function');
+  });
+
+  it('init stores context without throwing', () => {
+    expect(() => guidePlugin.init({} as never)).not.toThrow();
+  });
+});
+
+// ─── US1 + US2: Manifest contract ───────────────────────────────────────────
+
+describe('GuidePlugin — manifest', () => {
+  it('declares type: common to appear in the nav bar (FR-001)', () => {
+    expect(manifest.type).toBe('common');
+  });
+
+  it('declares order: 99 for rightmost nav bar placement (FR-002)', () => {
+    expect(manifest.order).toBe(99);
+  });
+
+  it('declares icon 📖 (FR-002)', () => {
+    expect(manifest.icon).toBe('📖');
+  });
+
+  it('declares name Guide (FR-002)', () => {
+    expect(manifest.name).toBe('Guide');
+  });
+
+  // US3: back-navigation contract (T014)
+  it('declares view: window so host renders the back button (R-002)', () => {
+    expect(manifest.view).toBe('window');
+  });
+
+  it('declares pluginApiVersion: "1" to activate the v1/v2 back-button path (R-002)', () => {
+    expect(manifest.pluginApiVersion).toBe('1');
+  });
+});
+
+// ─── US2: Feature Discovery by Section ──────────────────────────────────────
+
+describe('GuidePlugin — sections (US2)', () => {
+  it('renders exactly five <section> elements (FR-004)', () => {
+    const { container } = render(<GuidePlugin />);
+    expect(container.querySelectorAll('section')).toHaveLength(5);
+  });
+
+  it('displays heading "Playing a Score" (FR-006)', () => {
+    render(<GuidePlugin />);
+    expect(screen.getByRole('heading', { name: /playing a score/i })).toBeInTheDocument();
+  });
+
+  it('displays heading "Practice Mode" (FR-007)', () => {
+    render(<GuidePlugin />);
+    expect(screen.getByRole('heading', { name: /practice mode/i })).toBeInTheDocument();
+  });
+
+  it('displays heading "Train" (FR-008)', () => {
+    render(<GuidePlugin />);
+    expect(screen.getByRole('heading', { name: /^train$/i })).toBeInTheDocument();
+  });
+
+  it('displays heading "Loading a Score" (FR-009)', () => {
+    render(<GuidePlugin />);
+    expect(screen.getByRole('heading', { name: /loading a score/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/plugins/guide/GuidePlugin.tsx
+++ b/frontend/plugins/guide/GuidePlugin.tsx
@@ -1,0 +1,116 @@
+/**
+ * GuidePlugin.tsx — Feature 001-docs-plugin: Graditone Documentation Plugin
+ *
+ * Stateless React component rendering the complete Guide view.
+ * Single scrollable page with five sections: overview, playback, practice,
+ * train, and MusicXML loading.
+ *
+ * Receives no props — all content is static and fully offline (FR-010, FR-011).
+ * CSS uses --color-* custom properties so the active landing theme cascades in
+ * automatically (same pattern as TrainPlugin.css and plugin-dialog.css).
+ */
+
+import './GuidePlugin.css';
+
+export function GuidePlugin() {
+  return (
+    <div className="guide-plugin">
+      <div className="guide-plugin__inner">
+
+      {/* ── Section 1: What is Graditone? ─────────────────────────────── */}
+      <section className="guide-section" aria-labelledby="guide-h-what">
+        <h2 id="guide-h-what">What is Graditone?</h2>
+        <p>
+          Graditone is a tablet-native app for interactive music scores, designed
+          for practice and performance. Load any MusicXML score, hear it played
+          back with real-time note highlighting, and train note-by-note with
+          MIDI-driven step practice or ear-training exercises.
+        </p>
+        <p>
+          Graditone works fully offline — once loaded, no internet connection is
+          required.
+        </p>
+      </section>
+
+      {/* ── Section 2: Playing a Score ───────────────────────────────────── */}
+      <section className="guide-section" aria-labelledby="guide-h-play">
+        <h2 id="guide-h-play">Playing a Score</h2>
+        <p>Open the <strong>Play</strong> plugin (🎼) to load and play a score.</p>
+        <ul>
+          <li><strong>Tap a note</strong> — seek playback to that note and highlight it.</li>
+          <li><strong>Long-press a note</strong> — pin it (green highlight); sets the loop start point.</li>
+          <li><strong>Long-press a second note</strong> — define a loop region between the two pinned notes.</li>
+          <li><strong>Tap inside the loop region</strong> — clear the loop and return to free playback.</li>
+        </ul>
+        <p>Use the tempo slider in the playback toolbar to slow down or speed up playback for practice.</p>
+      </section>
+
+      {/* ── Section 3: Practice Mode ──────────────────────────────────────── */}
+      <section className="guide-section" aria-labelledby="guide-h-practice">
+        <h2 id="guide-h-practice">Practice Mode</h2>
+        <p>Open the <strong>Practice</strong> plugin to practise a score note by note.</p>
+        <ol>
+          <li>Select a score from the library.</li>
+          <li>Connect your MIDI keyboard (USB or Bluetooth) to your device.</li>
+          <li>Tap <strong>Practice</strong> — the first target note is highlighted on the staff.</li>
+          <li>Play the highlighted note on your MIDI keyboard to advance. The app waits until you play the correct pitch.</li>
+          <li>Continue until the end of the score. Your progress is shown in the toolbar.</li>
+        </ol>
+        <p>Practice also works without a loaded score — play freely and see each detected note displayed on the staff in real time.</p>
+      </section>
+
+      {/* ── Section 4: Train ──────────────────────────────────────────────── */}
+      <section className="guide-section" aria-labelledby="guide-h-train">
+        <h2 id="guide-h-train">Train</h2>
+        <p>Open the <strong>Train</strong> plugin (🎹) to sharpen your note-reading with ear-training exercises.</p>
+        <p><strong>Complexity levels</strong> — tap one to preset tempo, note count, and mode:</p>
+        <ul>
+          <li><strong>Low</strong> — 8 notes · C4 scale · Step mode · 40 BPM</li>
+          <li><strong>Mid</strong> — 16 notes · Random · Step mode · 80 BPM</li>
+          <li><strong>High</strong> — 20 notes · Random · Flow mode · 100 BPM</li>
+        </ul>
+        <p>Your selected level is remembered across sessions.</p>
+        <p><strong>Training modes</strong>:</p>
+        <ul>
+          <li><strong>Step</strong> — the app waits for you to play the correct note before advancing.</li>
+          <li><strong>Flow</strong> — the exercise plays through in real time; you play along and receive a score at the end.</li>
+        </ul>
+        <p><strong>Exercise presets</strong>:</p>
+        <ul>
+          <li><strong>Random</strong> — random notes from the selected clef and octave range.</li>
+          <li><strong>C4 Scale</strong> — notes from the C4 major scale (good for beginners).</li>
+          <li><strong>Score</strong> — notes extracted from the currently loaded score.</li>
+        </ul>
+        <p><strong>Input sources</strong>: Connect a MIDI keyboard (USB or Bluetooth) for best pitch accuracy. Alternatively, use the device microphone for acoustic instruments.</p>
+      </section>
+
+      {/* ── Section 5: Loading a Score ───────────────────────────────────── */}
+      <section className="guide-section" aria-labelledby="guide-h-loading">
+        <h2 id="guide-h-loading">Loading a Score</h2>
+        <p>
+          Graditone loads <strong>MusicXML</strong> files (<code>.mxl</code>,{' '}
+          <code>.musicxml</code>, <code>.xml</code>) — the industry-standard open
+          format exported by <strong>MuseScore</strong> (free), Sibelius, Finale,
+          Dorico, and hundreds of other notation apps.
+        </p>
+        <p>
+          <strong>Preloaded demo scores</strong> — no upload needed. Tap{' '}
+          <strong>Load score</strong> inside the Play or Train plugin to choose
+          from the built-in library: Bach Invention No.&nbsp;1, Beethoven Für Elise,
+          Burgmuller Arabesque, Chopin Nocturne Op.&nbsp;9 No.&nbsp;2, and
+          Pachelbel Canon in D.
+        </p>
+        <p><strong>Loading your own MusicXML file</strong>:</p>
+        <ol>
+          <li>Export your score as MusicXML from your notation software (in MuseScore: <em>File → Export → MusicXML</em>).</li>
+          <li>In the Play or Train plugin, tap <strong>Load score → Load from file…</strong>.</li>
+          <li>Select the <code>.mxl</code> or <code>.musicxml</code> file from your device.</li>
+          <li>The score loads immediately and is saved in the browser — it will be available next time you open Graditone, even offline.</li>
+        </ol>
+        <p>Free MusicXML scores are available at <strong>musescore.com</strong>, <strong>imslp.org</strong>, and <strong>kern.humdrum.org</strong>.</p>
+      </section>
+
+      </div>
+    </div>
+  );
+}

--- a/frontend/plugins/guide/index.tsx
+++ b/frontend/plugins/guide/index.tsx
@@ -1,0 +1,41 @@
+/**
+ * Guide Plugin — Entry Point
+ * Feature 001-docs-plugin: Graditone Documentation Plugin
+ *
+ * Default export must satisfy the GraditonePlugin interface.
+ * Only imports from ../../src/plugin-api/index are permitted — no Graditone internals.
+ *
+ * Context is stored module-level and injected into the component via init().
+ * The Guide plugin is purely static — context is stored for future extensibility
+ * but no context features are consumed.
+ */
+
+/* eslint-disable react-refresh/only-export-components */
+
+import type { GraditonePlugin, PluginContext } from '../../src/plugin-api/index';
+import { GuidePlugin } from './GuidePlugin';
+
+let _context: PluginContext | null = null;
+
+/**
+ * Wrapper that provides the stored PluginContext to GuidePlugin.
+ * Returns a fallback if Component is called before init() (defensive guard).
+ */
+function GuidePluginWithContext() {
+  if (!_context) {
+    return <div className="guide-plugin">Guide: context not initialised</div>;
+  }
+  return <GuidePlugin />;
+}
+
+const guidePlugin: GraditonePlugin = {
+  init(context: PluginContext) {
+    _context = context;
+  },
+  dispose() {
+    _context = null;
+  },
+  Component: GuidePluginWithContext,
+};
+
+export default guidePlugin;

--- a/frontend/plugins/guide/plugin.json
+++ b/frontend/plugins/guide/plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "guide",
+  "name": "Guide",
+  "version": "1.0.0",
+  "pluginApiVersion": "1",
+  "entryPoint": "index.tsx",
+  "description": "App guide and usage documentation for Graditone.",
+  "type": "common",
+  "view": "window",
+  "icon": "📖",
+  "order": 99
+}

--- a/specs/001-docs-plugin/checklists/requirements.md
+++ b/specs/001-docs-plugin/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Graditone Documentation Plugin
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit.plan`.

--- a/specs/001-docs-plugin/contracts/plugin-contract.md
+++ b/specs/001-docs-plugin/contracts/plugin-contract.md
@@ -1,0 +1,101 @@
+# Contract: Guide Plugin — Plugin API Contract
+
+**Phase 1 output** | Feature `001-docs-plugin` | 2026-03-13
+
+This file documents the interface contracts between the Guide plugin and the Graditone plugin host (App.tsx).
+
+---
+
+## Contract 1: `plugin.json` Schema
+
+The Guide plugin manifest must satisfy `PluginManifest` (omitting `origin`, which is set by the host):
+
+```jsonc
+{
+  "id": "guide",
+  "name": "Guide",
+  "version": "1.0.0",
+  "pluginApiVersion": "1",
+  "entryPoint": "index.tsx",
+  "description": "App guide and usage documentation for Graditone.",
+  "type": "common",         // required: makes plugin appear in the nav bar
+  "view": "window",         // required: host provides back-button bar
+  "icon": "📖",             // required: displayed in nav bar entry
+  "order": 99               // required: guarantees rightmost nav bar placement
+}
+```
+
+**Invariants enforced by host**:
+- If `type` ≠ `"common"`, the plugin will NOT appear in the nav bar.
+- If `order` is absent or non-finite, the plugin sorts alphabetically after ordered common plugins.
+- If `pluginApiVersion` ≥ `"3"`, the host uses the V3PluginWrapper (no host back button rendered) — Guide must remain at `"1"` to receive the host back button.
+
+---
+
+## Contract 2: `GraditonePlugin` Interface
+
+The default export from `index.tsx` must satisfy:
+
+```ts
+import type { GraditonePlugin, PluginContext } from '../../src/plugin-api/index';
+
+const guidePlugin: GraditonePlugin = {
+  init(context: PluginContext): void { /* store context, no features consumed */ },
+  dispose(): void { /* release stored context */ },
+  Component: GuidePlugin,   // React ComponentType; renders the full guide view
+};
+
+export default guidePlugin;
+```
+
+**Invariants**:
+- Only `../../src/plugin-api/index` may be imported from the host application (ESLint `no-restricted-imports` enforced).
+- `Component` must render without crashing when `init()` has been called (context set).
+- No network requests are permitted in `Component` — content must be fully static.
+
+---
+
+## Contract 3: Component Rendering Contract
+
+The `GuidePlugin` React component must satisfy:
+
+| Requirement | Specification |
+|-------------|---------------|
+| Props | None (stateless; receives no props) |
+| DOM structure | Root element with `className="guide-plugin"` |
+| Sections | Five `<section>` elements, each with a unique `<h2>` heading |
+| Section headings | "What is Graditone?", "Playing a Score", "Practice Mode", "Train", "Loading a Score" |
+| Scroll | Root element must scroll vertically (`overflow-y: auto`) |
+| Responsive | Width must not overflow viewport on 375 px–1366 px screens |
+| Offline | No `fetch`, `import()`, or dynamic content loading |
+| Theming | All CSS colours and fonts MUST use `--color-*` custom properties (see Contract 5) |
+
+**Tested by**: `GuidePlugin.test.tsx` — tests 1 (render), 2 (sections), 3 (contract), 4 (manifest order).
+
+---
+
+## Contract 4: Nav Bar Positioning Contract
+
+The Guide plugin must be the rightmost visible entry in the Graditone nav bar.
+
+**Mechanism**: `sortPluginsByOrder` in `sortPlugins.ts` sorts all plugin entries by `manifest.order` ascending (Infinity for absent). The nav bar renders `allPlugins.filter(type !== 'core' && !hidden)`. With `order: 99`, Guide sorts after all current core plugins (order 1/2/3) in the global sort; core plugins are filtered out before rendering, leaving Guide as the only (rightmost) visible nav entry.
+
+**Future compatibility**: Any future `common` plugin without an explicit `order` value will sort at Infinity and appear to the right of Guide. Any future `common` plugin with `order < 99` will appear to the left of Guide. No code changes are required in Guide to maintain rightmost placement among intentionally ordered plugins.
+
+---
+
+## Contract 5: CSS Theming Contract
+
+All colour and font values in `GuidePlugin.css` MUST use the app's `--color-*` CSS custom property tokens. Hard-coded colour values are not permitted.
+
+**Token reference** (defined on `body[data-landing-theme]` in `App.css`, bridged from `--ls-*` theme tokens):
+
+| Token | Role | Fallback |
+|-------|------|----------|
+| `--color-surface` | Background of the guide panel | `#fff` |
+| `--color-text` | Heading / bold text colour | `#222` |
+| `--color-text-secondary` | Body / paragraph text colour | `#555` |
+| `--color-border` | Section divider line colour | `#e0e0e0` |
+| `--color-accent` | Accent highlight (e.g. h2 underline) | `#4a90e2` |
+
+**Rationale**: This is the established pattern for all plugins (`TrainPlugin.css`, `plugin-dialog.css`). When a user switches landing theme, every theme-aware property in GuidePlugin.css updates automatically without requiring a code change in the Guide.

--- a/specs/001-docs-plugin/data-model.md
+++ b/specs/001-docs-plugin/data-model.md
@@ -1,0 +1,122 @@
+# Data Model: Graditone Documentation Plugin
+
+**Phase 1 output** | Feature `001-docs-plugin` | 2026-03-13
+
+---
+
+## Overview
+
+The Guide plugin has no persistent data model — all content is static and embedded in the component. This document describes the structural entities defined in code (plugin manifest, plugin contract) and the content taxonomy (sections and their content).
+
+---
+
+## Entity: Plugin Manifest (`plugin.json`)
+
+The manifest is the single source of truth for plugin identity, positioning, and behavior.
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| `id` | `"guide"` | Unique identifier; also determines plugin directory name |
+| `name` | `"Guide"` | Display name in the nav bar entry |
+| `version` | `"1.0.0"` | Semantic version of this plugin |
+| `pluginApiVersion` | `"1"` | Minimum API version required (uses only base contract) |
+| `entryPoint` | `"index.tsx"` | Module resolved by Vite glob at build time |
+| `description` | `"App guide and usage documentation for Graditone."` | Used in plugin management UI |
+| `type` | `"common"` | Makes the plugin appear in the top nav bar (not landing screen) |
+| `view` | `"window"` | Host renders a back-button bar; plugin renders in overlay |
+| `icon` | `"📖"` | Displayed in the nav bar entry |
+| `order` | `99` | Sentinel value; ensures rightmost placement in nav bar |
+
+---
+
+## Entity: Plugin Contract (`GraditonePlugin`)
+
+The Guide plugin satisfies the base `GraditonePlugin` interface defined in `plugin-api/types.ts`:
+
+```ts
+interface GraditonePlugin {
+  init(context: PluginContext): void;  // called once on activation; context stored but unused
+  dispose?(): void;                    // optional; sets stored context to null
+  Component: ComponentType;            // root React component rendered by the host
+}
+```
+
+The `PluginContext` is stored in module scope for future extensibility but no context features are consumed by the Guide plugin.
+
+---
+
+## Content Taxonomy (Sections)
+
+The Guide component renders five mandatory sections (FR-004). Each section has a canonical heading and minimum content requirements.
+
+### Section 1: What is Graditone?
+
+**Heading**: "What is Graditone?"
+**Content**: Brief explanation of Graditone as a tablet-native app for interactive music scores; who it is for (musicians practicing, performing, studying); core capabilities in plain language.
+**Acceptance**: Renders a readable paragraph; user understands what the app does after reading (SC-002).
+
+### Section 2: Playing a Score
+
+**Heading**: "Playing a Score"
+**Content**: How to start audio playback; the gesture reference table (tap to seek, long-press to pin/loop, tap inside loop to clear); tempo control description.
+**Acceptance**: All documented gestures in the README gesture table are covered (FR-006).
+
+### Section 3: Practice Mode
+
+**Heading**: "Practice Mode"
+**Content**: How to open the Practice plugin; what MIDI-driven step practice means; how to connect a MIDI device; how to advance through notes; what the score progress indicator shows.
+**Acceptance**: A user with no prior knowledge can follow the steps to start a practice session (FR-007).
+
+### Section 4: Train
+
+**Heading**: "Train"
+**Content**: The three complexity levels (Low — 8 notes, step mode, 40 BPM; Mid — 16 notes, step mode, 80 BPM; High — 20 notes, flow mode, 100 BPM) and that the selected level persists across sessions; the two training modes (Flow — play all notes in real time; Step — wait for the correct note before advancing); the three exercise presets (Random, C4 Scale, Score — notes extracted from the currently loaded score); input sources (MIDI keyboard auto-detected or device microphone).
+**Acceptance**: A user new to Train can set up and start an exercise from the Guide alone (FR-008).
+
+### Section 5: Loading a Score
+
+**Heading**: "Loading a Score"
+**Content**: What MusicXML is and which file extensions are accepted (.mxl, .musicxml, .xml); how to export MusicXML from MuseScore (free), Sibelius, Finale, or Dorico; the bundled preloaded demo scores (Bach Invention No. 1, Beethoven Für Elise, Burgmuller Arabesque, Chopin Nocturne Op. 9 No. 2, Pachelbel Canon in D) available without uploading; how to upload a custom file from the device via the score picker; that uploaded scores are stored in the browser's IndexedDB and persist across sessions. This section applies as shared context to both the Play and Train plugins.
+**Acceptance**: User understands how to load their first score and knows that uploaded scores are remembered (FR-009).
+
+---
+
+## CSS Theming
+
+All colours and fonts in `GuidePlugin.css` MUST use the app's `--color-*` CSS custom properties, which are declared on `body[data-landing-theme]` in `App.css` and mapped from the active `--ls-*` landing theme tokens. Hardcoded colour values are not permitted.
+
+| CSS token | Semantic role | Fallback |
+|-----------|--------------|----------|
+| `var(--color-surface, #fff)` | Page / panel background | White |
+| `var(--color-text, #222)` | Heading and bold text | Near-black |
+| `var(--color-text-secondary, #555)` | Body / paragraph text | Mid-grey |
+| `var(--color-border, #e0e0e0)` | Section divider line | Light grey |
+| `var(--color-accent, #4a90e2)` | Accent highlight (h2 underline) | Blue |
+
+This pattern matches `TrainPlugin.css` and `plugin-dialog.css`. When no theme is active the fallback values apply; when a landing theme is active the tokens automatically inherit the palette.
+
+---
+
+## State Model
+
+The Guide component has no state. It is a pure presentational component — no useState, no useEffect, no context consumption beyond storing the injected PluginContext at module level (standard plugin pattern).
+
+```
+GuidePlugin: () => JSX.Element       // stateless, no props
+```
+
+---
+
+## Data Flow
+
+```
+App.tsx
+  └─ sortPluginsByOrder([...BUILTIN_PLUGINS, ...imported])
+       └─ guide plugin entry (order: 99, type: common)
+            └─ rendered in nav bar via PluginNavEntry
+                 └─ on tap: setActivePlugin("guide")
+                      └─ activePlugin overlay rendered by App.tsx
+                           └─ host back-button bar (pluginApiVersion: "1" path)
+                                └─ GuidePlugin component
+                                     └─ static section content (no data sources)
+```

--- a/specs/001-docs-plugin/plan.md
+++ b/specs/001-docs-plugin/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: Graditone Documentation Plugin
+
+**Branch**: `001-docs-plugin` | **Date**: 2026-03-13 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/001-docs-plugin/spec.md`
+
+## Summary
+
+A new built-in "Guide" plugin (`📖`) that appears as the rightmost entry in the Graditone navigation bar and renders a single scrollable documentation page covering: app overview, score playback gestures, practice mode, and MusicXML import. The plugin is preloaded automatically via the existing Vite glob resolver — no manual registration is needed. It declares `type: "common"` to appear in the nav bar (not as a landing screen button), `view: "window"` so the host provides back navigation, and `order: 99` to guarantee rightmost placement. Content is static inline JSX requiring no network access.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x / React 18+ (existing frontend stack)
+**Primary Dependencies**: React (existing), Vitest + Testing Library (existing test stack)
+**Storage**: None — content is static inline JSX; no IndexedDB or network required
+**Testing**: Vitest + @testing-library/react (existing pattern)
+**Target Platform**: Tablet devices (iPad/Android) and desktop; PWA (all Plugin API targets)
+**Project Type**: Web application (frontend-only change to existing monorepo)
+**Performance Goals**: Plugin load must match existing core plugin load time; content renders within a single paint cycle (<16 ms)
+**Constraints**: Must not import any Graditone internal modules — only `../../src/plugin-api/index` (ESLint-enforced boundary); fully offline; no scroll-jank on long content
+**Scale/Scope**: Single new plugin directory (`frontend/plugins/guide/`) + one-line sort fix in `builtinPlugins.ts`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Domain-Driven Design | ✅ PASS | No domain model changes; plugin is presentation-only |
+| II. Hexagonal Architecture | ✅ PASS | Plugin imports only from `plugin-api/index` (the designated boundary); no internal module access |
+| III. PWA Architecture | ✅ PASS | Static content; fully offline-capable; no network dependency |
+| IV. Precision & Fidelity | ✅ PASS | No music timeline logic involved |
+| V. Test-First Development | ✅ PASS | Component rendering tests required before implementation |
+| VI. Layout Engine Authority | ✅ PASS | No coordinate calculation; no layout engine interaction |
+| VII. Regression Prevention | ✅ PASS | Any discovered bugs during implementation must produce a test before a fix |
+
+**Gate result**: No violations. No Complexity Tracking section needed.
+
+## Architecture Decision: Plugin Type Correction
+
+> **IMPORTANT**: The spec clarification session (Q3) recommended `"type": "core"` based on an incorrect understanding that core plugins appear in the top nav bar. Research shows that `type: "core"` plugins appear exclusively on the **landing screen** as large launch buttons and — when activated — replace the entire app viewport via early-return rendering (no nav bar visible). The top navigation bar renders only `type: "common"` plugins that are not hidden.
+>
+> **Correction**: The Guide plugin MUST be declared `"type": "common"` to appear in the top nav bar, as originally required by the user. The spec's Assumptions and FR-001 must be updated accordingly (done in this plan).
+
+**Final manifest decisions:**
+
+| Field | Value | Reason |
+|-------|-------|--------|
+| `type` | `"common"` | Only common plugins appear in the top nav bar |
+| `view` | `"window"` | Host provides a back button; Guide does not need to own back navigation |
+| `pluginApiVersion` | `"1"` | Guide uses only the base `GraditonePlugin` interface (init/dispose/Component); declaring v1 activates the host-provided back-button bar, keeping the plugin implementation minimal |
+| `icon` | `"📖"` | Confirmed in clarification Q1 |
+| `name` | `"Guide"` | Confirmed in clarification Q1 |
+| `order` | `99` | Confirmed in clarification Q4; `sortPluginsByOrder` in App.tsx sorts all plugins by order — Guide at 99 appears after the three core plugins (1/2/3) in the sorted list; since core plugins are filtered from the nav bar, Guide is the first (and rightmost) nav entry |
+
+## Architectural Constraint: Access from Core Plugins (US3)
+
+When a core plugin (Play, Practice, Train) is active, the entire app is replaced via early-return rendering — the header, nav bar, and all overlays are not rendered. The Guide cannot be reached directly from within a core plugin.
+
+**Resolution**: US3 acceptance criteria hold as written for the non-core nav context: when the user is on the landing screen (no plugin active), the Guide is accessible from the right of the nav bar. Navigation back to any other plugin is achieved by:
+1. Inside the Guide view: tap the host-provided "← Back" button → returns to landing screen
+2. From landing screen: tap any plugin launch button to resume
+
+For a future improvement, a floating "?" button persisted inside core plugin views would enable inline access — but this is out of scope for this feature.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-docs-plugin/
+├── plan.md              ← This file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+├── contracts/           ← Phase 1 output
+└── tasks.md             ← Phase 2 output (/speckit.tasks — not created here)
+```
+
+### Source Code
+
+```text
+frontend/plugins/guide/          ← NEW plugin directory
+├── plugin.json                  ← Manifest (type: common, view: window, order: 99)
+├── index.tsx                    ← Plugin entry (GraditonePlugin contract)
+├── GuidePlugin.tsx              ← React content component (scrollable sections)
+├── GuidePlugin.css              ← Scoped styles for typography and sections
+└── GuidePlugin.test.tsx         ← Vitest unit tests
+
+frontend/src/services/plugins/
+└── builtinPlugins.ts            ← MODIFIED: extend common-plugin sort to respect `order` field
+                                    (currently only core plugins use order; common sorts alphabetically)
+```
+
+**Structure Decision**: Frontend-only change. No backend modifications. Single new directory under `frontend/plugins/` following the established pattern (index.tsx + plugin.json + component + tests). One targeted modification to `builtinPlugins.ts` to honour `order` for common plugins, enabling `order: 99` to position Guide rightmost in the nav bar among common plugins.
+

--- a/specs/001-docs-plugin/quickstart.md
+++ b/specs/001-docs-plugin/quickstart.md
@@ -1,0 +1,332 @@
+# Quick Start: Graditone Documentation Plugin
+
+**Phase 1 output** | Feature `001-docs-plugin` | 2026-03-13
+
+This guide enables a developer to implement the Guide plugin from scratch following the plan.
+
+---
+
+## Prerequisites
+
+- Working Graditone development environment (`npm run dev` serving the frontend)
+- Familiarity with the plugin system (see `specs/030-plugin-architecture/quickstart.md`)
+- Node dependencies installed (`cd frontend && npm install`)
+
+---
+
+## Step 1: Create the plugin directory
+
+```bash
+mkdir frontend/plugins/guide
+```
+
+All files for the plugin live here. No registration in any existing file is needed — Vite's `import.meta.glob` in `builtinPlugins.ts` picks up any directory with `index.{ts,tsx}` + `plugin.json` automatically.
+
+---
+
+## Step 2: Write the plugin manifest
+
+Create `frontend/plugins/guide/plugin.json`:
+
+```json
+{
+  "id": "guide",
+  "name": "Guide",
+  "version": "1.0.0",
+  "pluginApiVersion": "1",
+  "entryPoint": "index.tsx",
+  "description": "App guide and usage documentation for Graditone.",
+  "type": "common",
+  "view": "window",
+  "icon": "📖",
+  "order": 99
+}
+```
+
+Key decisions:
+- `"type": "common"` → appears in the top nav bar (not on the landing screen)
+- `"view": "window"` → App.tsx renders a host "← Back" button automatically
+- `"pluginApiVersion": "1"` → activates the v1/v2 rendering path (host back button bar)
+- `"order": 99` → rightmost position in the nav bar (sortPluginsByOrder handles this)
+
+---
+
+## Step 3: Write the entry point
+
+Create `frontend/plugins/guide/index.tsx`:
+
+```tsx
+import type { GraditonePlugin, PluginContext } from '../../src/plugin-api/index';
+import { GuidePlugin } from './GuidePlugin';
+
+let _context: PluginContext | null = null;
+
+function GuidePluginWithContext() {
+  if (!_context) {
+    return <div className="guide-plugin">Guide: context not initialised</div>;
+  }
+  return <GuidePlugin />;
+}
+
+const guidePlugin: GraditonePlugin = {
+  init(context: PluginContext) {
+    _context = context;
+  },
+  dispose() {
+    _context = null;
+  },
+  Component: GuidePluginWithContext,
+};
+
+export default guidePlugin;
+```
+
+> **Note**: `PluginContext` is stored but not consumed — the Guide is purely static. The pattern follows existing plugins (practice-view-plugin, play-score) for future extensibility.
+
+---
+
+## Step 4: Write the Guide component
+
+Create `frontend/plugins/guide/GuidePlugin.tsx`:
+
+```tsx
+import './GuidePlugin.css';
+
+export function GuidePlugin() {
+  return (
+    <div className="guide-plugin">
+      <section className="guide-section" aria-labelledby="guide-h-what">
+        <h2 id="guide-h-what">What is Graditone?</h2>
+        <p>
+          Graditone is a tablet-native app for interactive music scores, designed
+          for practice and performance. Load any MusicXML score, hear it played
+          back, follow along as notes are highlighted in real time, and train
+          note by note with MIDI-driven step practice.
+        </p>
+        <p>
+          Graditone works fully offline — once loaded, no internet connection is
+          required.
+        </p>
+      </section>
+
+      <section className="guide-section" aria-labelledby="guide-h-play">
+        <h2 id="guide-h-play">Playing a Score</h2>
+        <p>Open the <strong>Play</strong> plugin to load and play a score.</p>
+        <ul>
+          <li><strong>Tap a note</strong> — seek playback to that note and highlight it</li>
+          <li><strong>Long-press a note</strong> — pin it (green highlight); sets the loop start point</li>
+          <li><strong>Long-press a second note</strong> — define a loop region between the two pinned notes</li>
+          <li><strong>Tap inside the loop region</strong> — clear the loop and return to free playback</li>
+        </ul>
+        <p>Use the tempo slider in the playback toolbar to slow down or speed up playback for practice.</p>
+      </section>
+
+      <section className="guide-section" aria-labelledby="guide-h-practice">
+        <h2 id="guide-h-practice">Practice Mode</h2>
+        <p>Open the <strong>Practice</strong> plugin to practise a score note by note.</p>
+        <ol>
+          <li>Select a score from the library.</li>
+          <li>Connect your MIDI keyboard (USB or Bluetooth) to your device.</li>
+          <li>Tap <strong>Practice</strong> — the first target note is highlighted.</li>
+          <li>Play the highlighted note on your MIDI keyboard to advance. The app waits until you play the correct pitch.</li>
+          <li>Continue until the end of the score. Your progress is shown in the toolbar.</li>
+        </ol>
+        <p>Practice works without a score selected — you can also play freely and see each note displayed on the staff.</p>
+      </section>
+
+      <section className="guide-section" aria-labelledby="guide-h-train">
+        <h2 id="guide-h-train">Train</h2>
+        <p>Open the <strong>Train</strong> plugin to sharpen your note-reading with ear-training exercises.</p>
+        <p><strong>Complexity levels</strong> — choose one to set tempo, note count, and mode:</p>
+        <ul>
+          <li><strong>Low</strong> — 8 notes, C4 scale, Step mode, 40 BPM</li>
+          <li><strong>Mid</strong> — 16 notes, Random, Step mode, 80 BPM</li>
+          <li><strong>High</strong> — 20 notes, Random, Flow mode, 100 BPM</li>
+        </ul>
+        <p>Your selected level is remembered across sessions.</p>
+        <p><strong>Training modes</strong>:</p>
+        <ul>
+          <li><strong>Step</strong> — the app waits for you to play the correct note before advancing to the next slot.</li>
+          <li><strong>Flow</strong> — the exercise plays through in real time; you play along and receive a score at the end.</li>
+        </ul>
+        <p><strong>Exercise presets</strong>:</p>
+        <ul>
+          <li><strong>Random</strong> — random notes from the selected clef and octave range.</li>
+          <li><strong>C4 Scale</strong> — notes from the C4 major scale (good for beginners).</li>
+          <li><strong>Score</strong> — notes extracted from the currently loaded score.</li>
+        </ul>
+        <p><strong>Input sources</strong>: Connect a MIDI keyboard (USB or Bluetooth) for best accuracy. Alternatively, use the device microphone for acoustic instruments.</p>
+      </section>
+
+      <section className="guide-section" aria-labelledby="guide-h-loading">
+        <h2 id="guide-h-loading">Loading a Score</h2>
+        <p>
+          Graditone loads <strong>MusicXML</strong> files (.mxl, .musicxml, .xml) — the
+          industry-standard open format supported by <strong>MuseScore</strong> (free),
+          Sibelius, Finale, Dorico, and hundreds of other notation apps.
+        </p>
+        <p><strong>Using a preloaded demo score</strong>: tap <strong>Load score</strong> inside the Play or Train plugin and choose from the built-in library (Bach Invention No. 1, Beethoven Für Elise, Burgmuller Arabesque, Chopin Nocturne Op. 9 No. 2, Pachelbel Canon in D). No upload needed.</p>
+        <p><strong>Loading your own MusicXML file</strong>:</p>
+        <ol>
+          <li>Export your score as MusicXML from your notation software (in MuseScore: <em>File → Export → MusicXML</em>).</li>
+          <li>In the Play or Train plugin, tap <strong>Load score → Load from file…</strong>.</li>
+          <li>Select the .mxl or .musicxml file from your device.</li>
+          <li>The score loads immediately and is saved in the browser. It will be available next time you open Graditone, even offline.</li>
+        </ol>
+        <p>Free MusicXML scores are available at <strong>musescore.com</strong>, <strong>imslp.org</strong>, and <strong>kern.humdrum.org</strong>.</p>
+      </section>
+    </div>
+  );
+}
+```
+
+---
+
+## Step 5: Write the styles
+
+Create `frontend/plugins/guide/GuidePlugin.css`:
+
+```css
+/*
+ * GuidePlugin.css — uses --color-* CSS custom properties so the Guide
+ * automatically inherits every landing theme. The same token pattern is
+ * used by TrainPlugin.css and plugin-dialog.css.
+ * Fallback values apply when no theme is active (plain white background).
+ */
+.guide-plugin {
+  padding: 24px;
+  max-width: 720px;
+  margin: 0 auto;
+  overflow-y: auto;
+  box-sizing: border-box;
+  font-size: 1rem;
+  line-height: 1.6;
+  background: var(--color-surface, #fff);
+  color: var(--color-text-secondary, #555);
+}
+
+.guide-section {
+  margin-bottom: 2.5rem;
+}
+
+.guide-section h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text, #222);
+  margin-bottom: 0.75rem;
+  border-bottom: 2px solid var(--color-accent, #4a90e2);
+  padding-bottom: 0.25rem;
+}
+
+.guide-section p,
+.guide-section li {
+  margin-bottom: 0.5rem;
+  color: var(--color-text-secondary, #555);
+}
+
+.guide-section ul,
+.guide-section ol {
+  padding-left: 1.5rem;
+}
+
+.guide-section strong {
+  color: var(--color-text, #222);
+}
+
+@media (max-width: 480px) {
+  .guide-plugin {
+    padding: 16px;
+  }
+}
+```
+
+---
+
+## Step 6: Write the tests (Test-First)
+
+Write `frontend/plugins/guide/GuidePlugin.test.tsx` **before** implementing the component:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GuidePlugin } from './GuidePlugin';
+import guidePlugin from './index';
+import manifest from './plugin.json';
+
+describe('GuidePlugin — component', () => {
+  it('renders without crashing', () => {
+    render(<GuidePlugin />);
+  });
+
+  it('displays the five required section headings', () => {
+    render(<GuidePlugin />);
+    expect(screen.getByRole('heading', { name: /what is graditone/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /playing a score/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /practice mode/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^train$/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /loading a score/i })).toBeInTheDocument();
+  });
+});
+
+describe('GuidePlugin — plugin contract', () => {
+  it('exports a valid GraditonePlugin object', () => {
+    expect(typeof guidePlugin.init).toBe('function');
+    expect(typeof guidePlugin.Component).toBe('function');
+  });
+
+  it('init stores context without throwing', () => {
+    expect(() => guidePlugin.init({} as never)).not.toThrow();
+  });
+});
+
+describe('GuidePlugin — manifest', () => {
+  it('declares type: common to appear in the nav bar', () => {
+    expect(manifest.type).toBe('common');
+  });
+
+  it('declares order: 99 for rightmost nav bar placement', () => {
+    expect(manifest.order).toBe(99);
+  });
+
+  it('declares icon 📖', () => {
+    expect(manifest.icon).toBe('📖');
+  });
+
+  it('declares name Guide', () => {
+    expect(manifest.name).toBe('Guide');
+  });
+});
+```
+
+---
+
+## Step 7: Verify
+
+```bash
+cd frontend
+
+# Run tests
+npm run test -- plugins/guide
+
+# Type-check
+npx tsc --noEmit
+
+# Start dev server and verify nav bar entry appears
+npm run dev
+# → Open http://localhost:5173 → "Guide 📖" should appear rightmost in the nav bar
+# → Tap Guide → scrollable guide content displays → "← Back" button works
+```
+
+---
+
+## Files Created
+
+| File | Purpose |
+|------|---------|
+| `frontend/plugins/guide/plugin.json` | Plugin manifest |
+| `frontend/plugins/guide/index.tsx` | Plugin entry point (GraditonePlugin contract) |
+| `frontend/plugins/guide/GuidePlugin.tsx` | React content component |
+| `frontend/plugins/guide/GuidePlugin.css` | Scoped typography and layout styles |
+| `frontend/plugins/guide/GuidePlugin.test.tsx` | Unit tests (written first) |
+
+**No changes to existing files are required.** The Vite glob in `builtinPlugins.ts` auto-discovers the new plugin.

--- a/specs/001-docs-plugin/research.md
+++ b/specs/001-docs-plugin/research.md
@@ -1,0 +1,163 @@
+# Research: Graditone Documentation Plugin
+
+**Phase 0 output** | Feature `001-docs-plugin` | 2026-03-13
+
+---
+
+## R-001: Plugin type classification — `"core"` vs `"common"`
+
+**Question**: Should the Guide plugin be `"type": "core"` or `"type": "common"`?
+
+**Research findings**:
+
+The Graditone Plugin API (types.ts) defines two roles:
+- `'core'` — first-class feature; shown as a launch button on the Landing Screen. The host rendering in App.tsx uses an early-return pattern when a core full-screen plugin is active: the entire React tree (including header and nav bar) is replaced by the plugin's component.
+- `'common'` — utility/tool; accessible via the plugin nav bar in the header. The nav bar rendering in App.tsx filters to `p.manifest.type !== 'core' && !p.manifest.hidden`.
+
+**Implication**: `type: "core"` plugins do NOT appear in the top nav bar — they appear on the landing screen as large launch buttons. This directly contradicts the user requirement "shown in the top menu bar, to the right."
+
+The spec clarification session (Q3) incorrectly recommended `"type": "core"` based on the mistaken assumption that Play/Train/Practice appear in the nav bar. In reality, they appear on the landing screen only.
+
+**Decision**: `"type": "common"`
+
+**Rationale**: Only `common` plugins appear in the top nav bar. This is the only way to satisfy FR-002 and the user requirement.
+
+**Alternatives rejected**:
+- `"type": "core"`: Places plugin on landing screen, not in nav bar. Contradicts requirement.
+
+---
+
+## R-002: Plugin view mode — `"window"` vs `"full-screen"`
+
+**Question**: What view mode should the Guide use?
+
+**Research findings**:
+
+- `"view": "full-screen"`: When `activePlugin` targets a full-screen plugin, App.tsx performs an early return — the entire app tree (header, nav, landing) is replaced. The plugin owns the entire viewport and must provide its own back navigation.
+- `"view": "window"`: The common plugin overlay (position: fixed, inset 0, z-index 100) is rendered inline within the existing app tree. For plugins with `pluginApiVersion < 3`, App.tsx renders a host-provided back button bar (`← Back`). For `pluginApiVersion >= 3`, the V3PluginWrapper is used (no host back button — plugin must handle its own navigation).
+
+**Decision**: `"view": "window"` + `"pluginApiVersion": "1"`
+
+**Rationale**: The Guide is a simple documentation plugin that does not need to own viewport navigation. Using `view: "window"` and declaring `pluginApiVersion: "1"` (the base contract) causes App.tsx to render the host-provided `← Back` button automatically. The Guide component only needs to render content. This is the minimal, correct approach.
+
+**Alternatives rejected**:
+- `"view": "full-screen"`: Requires Guide to implement its own back navigation, adding complexity without benefit.
+- `pluginApiVersion: "6"` with `view: "window"`: Would activate V3PluginWrapper, which does not render a host back button; Guide would need its own back button. Unnecessary for a static content plugin.
+
+---
+
+## R-003: Plugin order and nav-bar positioning
+
+**Question**: How does `order: 99` guarantee rightmost placement in the nav bar?
+
+**Research findings**:
+
+`App.tsx` calls `sortPluginsByOrder(entries)` where `entries` = BUILTIN_PLUGINS + imported plugins. `sortPluginsByOrder` (sortPlugins.ts) sorts all entries by `manifest.order` ascending (Infinity if absent).
+
+Current order values:
+- `play-score`: 1 (core)
+- `train-view`: 2 (core)
+- `practice-view-plugin`: 3 (core)
+- `virtual-keyboard`: no order, hidden (common)
+- User-imported plugins: no order (sorts as Infinity)
+
+The nav bar renders `allPlugins.filter(p => p.manifest.type !== 'core' && !p.manifest.hidden)`. After filtering, visible common plugins appear in the same order as the sorted `allPlugins` array.
+
+With `order: 99`, Guide appears after core plugins (1/2/3) in the global sort. When the nav bar filters out core plugins, Guide is positionally before any unordered common plugins (Infinity). This ensures:
+- Guide appears to the right of all other visible common plugins (none currently)
+- Any future common plugin with no order (Infinity) appears to the right of Guide — unless they also specify an order < 99
+
+**Decision**: `"order": 99` is correct and sufficient.
+
+**Issue**: `builtinPlugins.ts` builds COMMON_BUILTINS sorting only by `id` alphabetically (ignores `order`). However, `builtinPlugins.ts` is only one input — the final sort comes from `sortPluginsByOrder` in App.tsx which processes all plugins together. The common-sort in `builtinPlugins.ts` only determines order within `BUILTIN_PLUGINS` before it reaches `sortPluginsByOrder`. Since `sortPluginsByOrder` re-sorts everything by `order`, the internal common sort in `builtinPlugins.ts` does not matter for final nav bar order.
+
+**Conclusion**: No change to `builtinPlugins.ts` is required for order. `sortPluginsByOrder` already handles common plugins correctly. The preliminary `buildEntries('common')` sort by id inside `builtinPlugins.ts` is overridden by the final `sortPluginsByOrder` call.
+
+---
+
+## R-004: Plugin API surface required by Guide
+
+**Question**: What Plugin API features does the Guide plugin need?
+
+**Research findings**: The Guide plugin is pure documentation — static content in a scrollable React component. It does not need:
+- Score loading or playback (`context.scorePlayer`)
+- MIDI input (`context.recording`)
+- Staff viewer rendering (`context.components.StaffViewer`)
+- Metronome (`context.metronome`)
+
+It uses only the base `GraditonePlugin` contract:
+```ts
+interface GraditonePlugin {
+  init(context: PluginContext): void;
+  dispose?(): void;
+  Component: ComponentType;
+}
+```
+The `context` argument in `init()` can be stored but is not read (no context features used).
+
+**Decision**: Declare `"pluginApiVersion": "1"`. This is semantically correct (uses only v1 API surface) and activates the host back-button bar.
+
+---
+
+## R-005: Plugin content structure and format
+
+**Question**: How should the Guide content be authored and stored?
+
+**Research findings**:
+
+Options considered:
+- **Markdown files loaded at runtime**: Requires a markdown parser dependency and either a fetch (breaking offline guarantee) or bundling as raw string (complex Vite config).
+- **Inline JSX with semantic HTML**: Zero dependencies, works offline by definition, fully type-checked, consistent with React component conventions. Other plugins do not load external content files.
+- **Separate JSON data file imported as module**: Possible but adds indirection with no benefit over inline JSX.
+
+**Decision**: Inline JSX/HTML in `GuidePlugin.tsx`. Sections are `<section>` elements with `<h2>` headings and `<p>`/`<ul>` content. The component receives no props (static).
+
+**Rationale**: Simplest approach, fully offline, no new dependencies. Consistent with constitutional principle of minimal complexity.
+
+---
+
+## R-006: Test strategy for a static content plugin
+
+**Question**: What tests are needed for a plugin that renders only static content?
+
+**Research findings**:
+
+Following the existing plugin test pattern (e.g., `PlayScorePlugin.test.tsx`), tests use Vitest + `@testing-library/react`. For a static content plugin, the meaningful tests are:
+
+1. **Rendering smoke test**: Component renders without throwing.
+2. **Section heading presence**: All four required sections have labelled headings in the DOM (maps to FR-004, SC-003).
+3. **Plugin contract**: The `index.tsx` exports a valid `GraditonePlugin` object with `init`, `Component` fields (maps to FR-001).
+4. **Nav entry rightmost**: A test verifying the manifest declares `order: 99` and `type: "common"` (structural, maps to FR-002).
+5. **Offline capability**: Content renders without any `fetch` or network calls (implicit in static JSX; can be verified with a mock that throws on `fetch`).
+
+**Decision**: Write tests 1–4. Test 5 is implicit (static JSX cannot trigger fetch) — document in comments but no assertion needed.
+
+---
+
+## R-007: Spec correction — Update required before implementation
+
+The following spec fields must be updated to reflect R-001 findings:
+
+| Location | Current value | Correct value |
+|----------|--------------|---------------|
+| Assumptions bullet 2 | `"type": "core"` | `"type": "common"` |
+| FR-001 | `"type": "core"` | `"type": "common"` |
+| Clarification Q3 | `full-screen — consistent with core nav plugins` | `window — common plugin, host provides back button` |
+
+These will be corrected as part of the plan deliverables (spec updated in-place).
+
+---
+
+## Summary of Decisions
+
+| Decision | Value | Research ref |
+|----------|-------|-------------|
+| Plugin type | `"common"` | R-001 |
+| Plugin view | `"window"` | R-002 |
+| pluginApiVersion | `"1"` | R-002, R-004 |
+| Plugin icon/name | `📖 / "Guide"` | Clarification Q1 |
+| Plugin order | `99` | R-003 |
+| `builtinPlugins.ts` change needed? | No | R-003 |
+| Content format | Inline JSX | R-005 |
+| Test strategy | 4 tests (render, sections, contract, order) | R-006 |
+| Plugin id | `guide` | Convention (`frontend/plugins/guide/`) |

--- a/specs/001-docs-plugin/spec.md
+++ b/specs/001-docs-plugin/spec.md
@@ -1,0 +1,114 @@
+# Feature Specification: Graditone Documentation Plugin
+
+**Feature Branch**: `001-docs-plugin`  
+**Created**: 2026-03-13  
+**Status**: Draft  
+**Input**: User description: "Create a new plugin documenting what is Graditone and how to use for end users. This plugin must be preloaded and it must be shown in the top menu bar, to the right."
+
+## Clarifications
+
+### Session 2026-03-13
+
+- Q: What is the canonical menu label and icon for the documentation plugin entry in the top menu bar? → A: "Guide" with icon 📖.
+- Q: How are sections within the Guide view navigated — scrollable page, tabs, or accordion? → A: Single scrollable page with clearly styled section headings; users read top-to-bottom and scroll to the desired section.
+- Q: What plugin view type should the Guide use — `full-screen` (like core nav plugins) or `window` (floating overlay)? → A: **Revised during planning**: Research showed that `type: "core"` plugins appear only on the landing screen, not in the nav bar. Guide must be `"type": "common"` (nav bar) with `"view": "window"` and `"pluginApiVersion": "1"` so the host provides the back button. See research.md R-001 and R-002.
+- Q: What `order` value should the Guide plugin declare in its manifest to guarantee rightmost placement? → A: `order: 99` — a high sentinel value that stays rightmost even as new core plugins are added.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - First-Time User Orientation (Priority: P1)
+
+A user opens Graditone for the first time and doesn't know what the app is or how to start. They tap the **Guide** entry (📖) in the top menu bar (rightmost entry) and immediately see a clear overview of what Graditone is, what it can do, and where to begin.
+
+**Why this priority**: This is the single most valuable outcome of the feature — reducing confusion and abandonment for new users. It can be delivered and demonstrated as a standalone experience without any other story being complete.
+
+**Independent Test**: Can be fully tested by opening the app, tapping the documentation plugin entry in the top menu bar, and verifying that an overview description of Graditone is displayed with a description of its core purpose.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has just opened Graditone, **When** they look at the top menu bar, **Then** the **Guide** entry (📖) is visible as the rightmost item.
+2. **Given** the user taps the documentation plugin entry, **When** the plugin view opens, **Then** they see a clear, friendly title and a short paragraph explaining what Graditone is.
+3. **Given** the documentation view is open, **When** the user reads the overview section, **Then** they understand Graditone is a tablet-native app for interactive music scores designed for practice and performance.
+4. **Given** the documentation view is open on any device size, **When** the content is displayed, **Then** all text is legible without horizontal scrolling or truncation.
+
+---
+
+### User Story 2 - Feature Discovery by Section (Priority: P2)
+
+A user who already knows Graditone wants to understand how a specific feature works (e.g., how to loop a section, how to use the practice mode, how to import a MusicXML file). They open the guide plugin and navigate to the relevant section to find step-by-step instructions.
+
+**Why this priority**: Sectioned content transforms the guide from a one-time read into an on-demand reference. Users can re-consult it whenever they forget a specific workflow, reducing reliance on trial-and-error.
+
+**Independent Test**: Can be fully tested by opening the Guide plugin and verifying that at least five distinct feature sections exist and are reachable by scrolling the single-page view.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Guide view is open, **When** the user looks at the content, **Then** they can identify five clearly labelled sections — app overview, score playback, practice mode, train mode, and MusicXML loading — each visually separated by a prominent heading on the single scrollable page.
+2. **Given** the documentation view has multiple sections, **When** the user navigates to the "Score Playback" section, **Then** they see instructions covering how to start playback, how to tap notes to seek, and how to create a loop region.
+3. **Given** the documentation view has multiple sections, **When** the user navigates to the "Practice" section, **Then** they see instructions covering how to load a score, how to connect a MIDI device, and how the step-by-step guidance works.
+4. **Given** the documentation view has multiple sections, **When** the user navigates to the "Train" section, **Then** they see instructions explaining the three complexity levels (Low/Mid/High), the two training modes (Flow/Step), the three exercise presets (Random/C4 Scale/Score), and how to use a MIDI keyboard or microphone as input.
+5. **Given** the documentation view has multiple sections, **When** the user navigates to the "Loading a Score" section, **Then** they see instructions for: how to generate a MusicXML file (export from MuseScore, Sibelius, or Finale), the preloaded demo scores available without uploading, how to upload a custom .mxl/.musicxml file, and how uploaded scores persist across sessions.
+
+---
+
+### User Story 3 - Access from Any App State (Priority: P3)
+
+A user is in the middle of using another plugin (e.g., watching playback in the Play view) and wants to quickly check how a gesture works. They tap the documentation plugin entry in the top menu bar, read what they need, and return to the Play view without losing their place.
+
+**Why this priority**: The guide is most valuable when reachable from anywhere without disrupting the user's current workflow. This story depends on the top-menu positioning (P1) and sectioned content (P2) both being complete.
+
+**Independent Test**: Can be tested by navigating to any other plugin view (e.g., Play), tapping the documentation entry, verifying the guide loads, then tapping another plugin entry and verifying the user returns to that plugin's state.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is viewing any plugin other than the documentation plugin, **When** they tap the documentation plugin entry in the top menu bar, **Then** the documentation view opens.
+2. **Given** the documentation view is open, **When** the user taps another plugin entry in the top menu bar, **Then** they are taken to that plugin and can continue their previous task.
+3. **Given** the documentation plugin is the rightmost item in the top menu bar, **When** the user is on any screen, **Then** the top menu bar remains visible and the documentation entry is always reachable without scrolling.
+
+---
+
+### Edge Cases
+
+- What happens when the documentation view is opened on a small mobile screen where the full menu bar might overlap the content?
+- What happens if the documentation plugin fails to load (content parse error)?
+- How does the section layout behave when the device is rotated between portrait and landscape mid-view?
+
+## Assumptions
+
+- The documentation plugin is built-in (shipped with the app) and cannot be uninstalled or hidden by users.
+- The plugin uses `"type": "common"`, `"view": "window"`, and `"pluginApiVersion": "1"` in its manifest. This makes it appear in the top nav bar (common plugins are nav bar entries; core plugins are landing screen entries only) and activates the host-provided back button bar (no need for the Guide to implement its own back navigation).
+- The plugin declares `"order": 99` in its manifest — a high sentinel value that ensures rightmost placement in the top menu bar regardless of what order values future core plugins use.
+- The documentation plugin appears as the last (rightmost) item in the top navigation menu, after all other core plugins.
+- The content of the guide is presented as a single scrollable page with section headings; no tabs, accordions, or in-page search are required.
+- The content of the guide is static — it does not pull data from a server and works fully offline.
+- The guide covers the features that exist at the time of implementation: score viewing, audio playback with gestures, practice mode (MIDI-driven step practice), train mode (ear-training exercises with MIDI/mic input and complexity levels), and MusicXML loading (bundled demo scores + user-uploaded scores persisted in browser storage).
+- The Guide plugin CSS MUST use the app's `--color-*` CSS custom properties (defined in `App.css` and mapped from the active landing theme's `--ls-*` tokens) for all colors and fonts. Hard-coded colour values are not permitted. This ensures the Guide inherits every future theme change automatically, matching the pattern established by `TrainPlugin.css` and `plugin-dialog.css`.
+- The documentation plugin does not require a score to be loaded to be usable.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The documentation plugin MUST be included in the application by default and available without any user installation step. It MUST be declared as `"type": "common"`, `"view": "window"`, and `"pluginApiVersion": "1"` in its manifest.
+- **FR-002**: The documentation plugin MUST appear as a persistent entry in the top navigation menu bar, positioned to the right of all other core navigation entries. Its canonical label is **"Guide"** and its icon is 📖 (reflected in `plugin.json` `name` and `icon` fields). It MUST declare `"order": 99` to guarantee rightmost placement.
+- **FR-003**: The documentation plugin MUST be accessible regardless of which other plugin or view is currently active.
+- **FR-004**: The documentation plugin view MUST display content organized into clearly labelled sections covering: app overview, score playback and gestures, practice mode, train mode, and MusicXML loading. The MusicXML loading section is cross-view shared context (applies to both Play and Train plugins).
+- **FR-005**: The app overview section MUST explain in plain language what Graditone is and who it is for.
+- **FR-006**: The score playback section MUST document all available tap and gesture interactions (tap to seek, long-press to pin/loop, tap inside loop to clear).
+- **FR-007**: The practice section MUST explain how to start a practice session, the role of a MIDI device, and how step-by-step note guidance works.
+- **FR-008**: The Train section MUST explain: (a) the three complexity levels (Low — 8 notes, step, 40 BPM; Mid — 16 notes, step, 80 BPM; High — 20 notes, flow, 100 BPM); (b) the two training modes (Flow — play all notes in time; Step — wait for the correct note before advancing); (c) the three exercise presets (Random, C4 Scale, Score — uses notes extracted from the loaded score); (d) input sources (MIDI keyboard auto-detected, or device microphone); (e) that the selected complexity level is remembered across sessions.
+- **FR-009**: The MusicXML loading section MUST describe: (a) what MusicXML is and which file extensions are supported (.mxl, .musicxml, .xml); (b) how to export MusicXML from common notation software (MuseScore — free, Sibelius, Finale, Dorico); (c) the bundled preloaded demo scores available without any upload; (d) how to upload a custom file from the device; (e) that uploaded scores are stored in the browser and persist across sessions.
+- **FR-010**: The documentation content MUST be readable without an internet connection (fully offline-capable).
+- **FR-011**: The documentation plugin MUST load its content within the same time budget as other core plugins.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The documentation plugin entry is visible in the top menu bar on every screen of the app, verified by navigating to each core plugin view.
+- **SC-002**: A first-time user can identify what Graditone is and locate the primary action (loading a score or starting playback) within 60 seconds of opening the guide.
+- **SC-003**: All five documented sections (overview, playback, practice, train, MusicXML loading) are present and contain at least one concrete user instruction each.
+- **SC-004**: The guide is accessible and fully readable while the device is in offline/airplane mode.
+- **SC-005**: Navigating from the documentation plugin back to any other plugin takes no more than one tap.
+- **SC-006**: The guide content renders correctly on screen widths from 375 px (small phone) to 1366 px (large tablet) without content truncation or overlap, and it visually matches the active landing theme by using `--color-*` CSS tokens for all colors and fonts.
+

--- a/specs/001-docs-plugin/tasks.md
+++ b/specs/001-docs-plugin/tasks.md
@@ -1,0 +1,186 @@
+# Tasks: Graditone Documentation Plugin
+
+**Input**: Design documents from `/specs/001-docs-plugin/`
+**Prerequisites**: plan.md ✅ | spec.md ✅ | research.md ✅ | data-model.md ✅ | contracts/ ✅ | quickstart.md ✅
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no incomplete-task dependencies)
+- **[Story]**: Which user story this task belongs to ([US1], [US2], [US3])
+- All paths are relative to the repository root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create the plugin directory — required before any file can be created inside it
+
+- [X] T001 Create plugin directory `frontend/plugins/guide/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Plugin manifest and entry-point skeleton — required before any user story can be independently tested
+
+**⚠️ CRITICAL**: The Vite glob in `builtinPlugins.ts` auto-discovers any directory under `frontend/plugins/` that has both an `index.{ts,tsx}` and a `plugin.json`. Both files must exist before the plugin appears in the nav bar.
+
+- [X] T002 [P] Create plugin manifest in `frontend/plugins/guide/plugin.json` with `id: "guide"`, `name: "Guide"`, `icon: "📖"`, `type: "common"`, `view: "window"`, `pluginApiVersion: "1"`, `order: 99`
+- [X] T003 Create entry-point skeleton in `frontend/plugins/guide/index.tsx` — exports a valid `GraditonePlugin` object with `init`, `dispose` and a stub `Component` that renders `null` (Vite discoverable; replaced in T007)
+
+**Checkpoint**: `npm run dev` — "Guide" entry should now appear rightmost in the Graditone nav bar; tapping it shows a blank window with a host "← Back" button
+
+---
+
+## Phase 3: User Story 1 — First-Time User Orientation (Priority: P1) 🎯 MVP
+
+**Goal**: User opens Graditone, sees the Guide entry (📖) as the rightmost nav item, taps it, and is shown a clear "What is Graditone?" overview.
+
+**Independent Test**: Open the app → tap the Guide entry (rightmost in nav bar) → verify overview section renders with a description of Graditone. Verifiable without any other user story being complete.
+
+> **⚠️ TDD**: Write T004 first and verify tests FAIL before implementing T005–T007.
+
+- [X] T004 [US1] Write `frontend/plugins/guide/GuidePlugin.test.tsx` with:
+  - Smoke test: `GuidePlugin` component renders without crashing
+  - Test: `plugin.json` declares `type: "common"` (nav bar placement — FR-001)
+  - Test: `plugin.json` declares `order: 99` (rightmost placement — FR-002)
+  - Test: `plugin.json` declares `icon: "📖"` and `name: "Guide"` (FR-002)
+  - Test: rendered output contains heading "What is Graditone?" (FR-005)
+  - Test: exported `guidePlugin` has `init` function and `Component` property (GraditonePlugin contract)
+- [X] T005 [US1] Create `frontend/plugins/guide/GuidePlugin.tsx` — stateless React component rendering a `<div className="guide-plugin">` containing a `<section>` with `<h2>What is Graditone?</h2>` and a paragraph describing Graditone as a tablet-native app for interactive music scores, designed for practice and performance (FR-005)
+- [X] T006 [US1] Create `frontend/plugins/guide/GuidePlugin.css` — base layout styles using `--color-*` CSS custom properties (same theming as `TrainPlugin.css`): `.guide-plugin` with `padding: 24px`, `max-width: 720px`, `margin: 0 auto`, `overflow-y: auto`, `background: var(--color-surface, #fff)`, `color: var(--color-text-secondary, #555)`; `.guide-section` with `margin-bottom: 2.5rem`
+- [X] T007 [US1] Replace the stub `Component` in `frontend/plugins/guide/index.tsx` with `GuidePluginWithContext` (imports `GuidePlugin` from `./GuidePlugin`; only `../../src/plugin-api/index` permitted as host import)
+
+**Checkpoint**: All T004 tests pass. Guide entry visible in nav bar; tapping opens view with "What is Graditone?" section; "← Back" returns to previous screen. **This is the MVP.**
+
+---
+
+## Phase 4: User Story 2 — Feature Discovery by Section (Priority: P2)
+
+**Goal**: Guide view displays all five required sections on a single scrollable page — app overview, score playback, practice mode, train mode, and MusicXML loading — each with accurate, actionable instructions.
+
+**Independent Test**: Open the Guide plugin → verify five section headings are present on the single scrollable page → scroll to each section and verify it contains at least one instruction.
+
+> **⚠️ TDD**: Write T008 first and verify new test cases FAIL before implementing T009–T013.
+
+- [X] T008 [US2] Add section heading tests to `frontend/plugins/guide/GuidePlugin.test.tsx`:
+  - Test: heading "Playing a Score" present in rendered output (FR-006)
+  - Test: heading "Practice Mode" present in rendered output (FR-007)
+  - Test: heading "Train" present in rendered output (FR-008)
+  - Test: heading "Loading a Score" present in rendered output (FR-009)
+  - Test: exactly five `<section>` elements rendered (FR-004)
+- [X] T009 [P] [US2] Add "Playing a Score" section to `frontend/plugins/guide/GuidePlugin.tsx` — `<section>` with `<h2>Playing a Score</h2>`, a `<ul>` documenting all four gestures: tap to seek, long-press to pin, long-press second note to loop, tap inside loop to clear (FR-006)
+- [X] T010 [P] [US2] Add "Practice Mode" section to `frontend/plugins/guide/GuidePlugin.tsx` — `<section>` with `<h2>Practice Mode</h2>`, an `<ol>` listing: open Practice plugin, connect MIDI keyboard, tap Practice, play highlighted note to advance, continue to end (FR-007)
+- [X] T011 [P] [US2] Add "Train" section to `frontend/plugins/guide/GuidePlugin.tsx` — `<section>` with `<h2>Train</h2>` covering: (a) three complexity levels (Low — 8 notes/step/40 BPM, Mid — 16 notes/step/80 BPM, High — 20 notes/flow/100 BPM); (b) two modes (Flow — play all notes in time; Step — wait for correct note before advancing); (c) three exercise presets (Random, C4 Scale, Score — notes extracted from loaded score); (d) input sources (MIDI keyboard auto-detected or device microphone); (e) that the complexity level is remembered across sessions (FR-008)
+- [X] T012 [P] [US2] Add "Loading a Score" section to `frontend/plugins/guide/GuidePlugin.tsx` — `<section>` with `<h2>Loading a Score</h2>` covering: (a) what MusicXML is and supported extensions (.mxl, .musicxml, .xml); (b) how to export from MuseScore (free), Sibelius, Finale, or Dorico; (c) the bundled preloaded demo scores (Bach, Beethoven, Burgmuller, Chopin, Pachelbel) available without uploading; (d) how to load a file from the device via the score picker; (e) that uploaded scores are stored in the browser and persist across sessions (FR-009)
+- [X] T013 [US2] Add section typography styles to `frontend/plugins/guide/GuidePlugin.css` — `.guide-section h2` with `font-size: 1.25rem`, `color: var(--color-text, #222)`, `border-bottom: 2px solid var(--color-accent, #4a90e2)` accent line; `.guide-section p`, `.guide-section li` spacing with `color: var(--color-text-secondary, #555)`; `ul`/`ol` left padding (all tokens from `--color-*` system, Contract 5, SC-006 readability)
+
+**Checkpoint**: All T008 tests pass. Five sections visible and scrollable; "Playing a Score" gesture list, "Practice Mode" numbered steps, "Train" complexity/mode/preset table, "Loading a Score" MusicXML instructions — all present.
+
+---
+
+## Phase 5: User Story 3 — Access from Any App State (Priority: P3)
+
+**Goal**: The Guide is persistently reachable from the nav bar; back navigation returns to the previous screen without losing state.
+
+**Independent Test**: From the landing screen, tap Guide → verify content loads → tap "← Back" → verify landing screen returns. Tap Guide again from the nav bar → verify Guide re-opens.
+
+> **⚠️ TDD**: Write T014 first; verify FAIL before implementing T015.
+
+- [X] T014 [US3] Add back-navigation contract tests to `frontend/plugins/guide/GuidePlugin.test.tsx`:
+  - Test: `plugin.json` declares `view: "window"` (host renders back button — R-002)
+  - Test: `plugin.json` declares `pluginApiVersion: "1"` (activates v1/v2 host back-button path — R-002)
+- [X] T015 [US3] Add defensive context guard to `frontend/plugins/guide/index.tsx` — `GuidePluginWithContext` returns `<div className="guide-plugin">Guide: context not initialised</div>` when `_context` is null (matches existing plugin pattern; prevents blank crash if host calls Component before init)
+
+**Checkpoint**: All US3 tests pass. Guide is always reachable from the nav bar on the landing screen. Back navigation works using the host-provided "← Back" button. Plugin state is cleanly reset via `dispose()`.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Responsive layout validation, documentation currency
+
+- [X] T016 [P] Add responsive CSS breakpoints to `frontend/plugins/guide/GuidePlugin.css` — ensure `.guide-plugin` content does not overflow or truncate on screen widths 375 px–1366 px (SC-006); `max-width: 720px` + `box-sizing: border-box` on root + `word-wrap: break-word` on text
+- [X] T017 [P] Update `FEATURES.md` to document the Guide plugin under a "Help & Documentation" section
+- [X] T018 [P] Update `PLUGINS.md` to list the Guide plugin (id: guide, type: common, order: 99) with its purpose and manifest fields
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on T001 (directory must exist) — **blocks all user stories**
+- **US1 (Phase 3)**: Depends on T002 + T003 (manifest + entry point must exist)
+- **US2 (Phase 4)**: Depends on T005 (GuidePlugin.tsx must exist to add sections to)
+- **US3 (Phase 5)**: Depends on T003 + T007 (index.tsx complete); US1 and US2 should be complete for meaningful validation
+- **Polish (Phase 6)**: Depends on all user story phases being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends only on Foundational — independently testable ✅
+- **US2 (P2)**: Depends on US1 (GuidePlugin.tsx and GuidePlugin.css must exist); independently testable after US1 ✅
+- **US3 (P3)**: Depends on US1 + US2 for meaningful end-to-end validation; manifest contract tests (T014) are independently testable ✅
+
+### Parallel Opportunities
+
+- T002 and T003 can be written in parallel (plugin.json and index.tsx are independent files)
+- T009, T010, T011, T012 can all be written in parallel (each adds a separate `<section>` to `GuidePlugin.tsx`, all touching the same file — coordinate to avoid merge conflicts; safest to do sequentially)
+- T016, T017, T018 can all run in parallel
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```
+# Both can be done simultaneously (different files):
+Task T002: Create frontend/plugins/guide/plugin.json
+Task T003: Create frontend/plugins/guide/index.tsx (skeleton)
+```
+
+## Parallel Example: User Story 2 (Section Content)
+
+```
+# T008 must complete first (tests), then sections can be written in parallel
+# (same file — coordinate to avoid conflicts, or do sequentially):
+Task T009: "Playing a Score" section in GuidePlugin.tsx
+Task T010: "Practice Mode" section in GuidePlugin.tsx
+Task T011: "Train" section in GuidePlugin.tsx
+Task T012: "Loading a Score" section in GuidePlugin.tsx
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001)
+2. Complete Phase 2: Foundational (T002–T003)
+3. Complete Phase 3: User Story 1 (T004–T007)
+4. **STOP and VALIDATE**: Guide entry visible in nav bar; overview section readable
+5. Demo / deploy if ready — this is a useful, working documentation plugin
+
+### Incremental Delivery
+
+1. Setup + Foundational → Plugin auto-discovered ✅
+2. US1 → Overview section live → **MVP** ✅
+3. US2 → All five sections → Full reference guide ✅
+4. US3 → Back-nav contract validated → Robustness confirmed ✅
+5. Polish → Responsive layout + docs updated → Feature complete ✅
+
+---
+
+## Summary
+
+| Phase | Tasks | User Story | Files Touched |
+|-------|-------|-----------|---------------|
+| 1 — Setup | T001 | — | `frontend/plugins/guide/` (dir) |
+| 2 — Foundational | T002–T003 | — | `plugin.json`, `index.tsx` |
+| 3 — US1 (P1) 🎯 | T004–T007 | US1 | `GuidePlugin.test.tsx`, `GuidePlugin.tsx`, `GuidePlugin.css`, `index.tsx` |
+| 4 — US2 (P2) | T008–T013 | US2 | `GuidePlugin.test.tsx`, `GuidePlugin.tsx`, `GuidePlugin.css` |
+| 5 — US3 (P3) | T014–T015 | US3 | `GuidePlugin.test.tsx`, `index.tsx` |
+| 6 — Polish | T016–T018 | — | `GuidePlugin.css`, `FEATURES.md`, `PLUGINS.md` |
+
+**Total tasks**: 18 | **Parallelizable**: T002, T003, T009, T010, T011, T012, T016, T017, T018 | **New files**: 5 | **Existing files modified**: 0 (plugin auto-discovered via Vite glob)


### PR DESCRIPTION
## Summary

Adds a new built-in **Guide** plugin (📖) — a fully static, offline-capable documentation page accessible from the top nav bar on every landing theme.

## What's new

| File | Purpose |
|------|---------|
| `frontend/plugins/guide/plugin.json` | Manifest — `type: common`, `view: window`, `order: 99` |
| `frontend/plugins/guide/index.tsx` | `GraditonePlugin` entry point with context guard |
| `frontend/plugins/guide/GuidePlugin.tsx` | Stateless component with 5 sections |
| `frontend/plugins/guide/GuidePlugin.css` | Themed via `--color-*` tokens; scroll host fills viewport |
| `frontend/plugins/guide/GuidePlugin.test.tsx` | 15 TDD tests — all pass |

## Five content sections

1. **What is Graditone?** — app overview
2. **Playing a Score** — tap/long-press/loop gestures
3. **Practice Mode** — step-by-step MIDI practice
4. **Train** — complexity levels, modes, presets, input sources
5. **Loading a Score** — MusicXML formats, MuseScore export, bundled demos, persistence

## Design decisions

- **Scroll on desktop**: `.guide-plugin` is the full-width scroll host (`flex: 1; overflow-y: auto`) so the scrollbar sits at the viewport edge, not in the middle of the 720px-wide content box. Scrollbar is themed with `--color-border` / `--color-accent` tokens.
- **Theming**: All colours use `--color-*` CSS custom properties (App.css bridge tokens) — inherits every landing theme automatically.
- **Auto-discovery**: No manual registration — Vite `import.meta.glob` picks it up from the `plugins/guide/` directory.

## Testing

- 15 tests covering US1 (component renders), manifest (type/order/icon/view/pluginApiVersion), and US2 (all 5 section headings)
- TDD: tests written and verified failing before implementation

## Docs updated

- `FEATURES.md` — new "Help & Documentation" section
- `PLUGINS.md` — Guide plugin reference table
- `specs/001-docs-plugin/` — full speckit artifacts (spec, plan, data-model, contracts, tasks — all 18 tasks ✅)
