### PR TITLE
feat(guide): convert resource URLs to clickable links

### DIFF
--- a/frontend/plugins/guide/GuidePlugin.css
+++ b/frontend/plugins/guide/GuidePlugin.css
@@ -103,6 +103,19 @@
   padding: 0.1em 0.35em;
 }
 
+/* ── Links ───────────────────────────────────────────────────────────────── */
+
+.guide-section a {
+  color: var(--color-accent, #4a90e2);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.guide-section a:hover {
+  opacity: 0.8;
+}
+
 /* ── Responsive ───────────────────────────────────────────────────────────── */
 
 @media (max-width: 480px) {

--- a/frontend/plugins/guide/GuidePlugin.tsx
+++ b/frontend/plugins/guide/GuidePlugin.tsx
@@ -107,7 +107,12 @@ export function GuidePlugin() {
           <li>Select the <code>.mxl</code> or <code>.musicxml</code> file from your device.</li>
           <li>The score loads immediately and is saved in the browser — it will be available next time you open Graditone, even offline.</li>
         </ol>
-        <p>Free MusicXML scores are available at <strong>musescore.com</strong>, <strong>imslp.org</strong>, and <strong>kern.humdrum.org</strong>.</p>
+        <p>
+          Free MusicXML scores are available at{' '}
+          <a href="https://musescore.com" target="_blank" rel="noopener noreferrer">musescore.com</a>,{' '}
+          <a href="https://imslp.org" target="_blank" rel="noopener noreferrer">imslp.org</a>, and{' '}
+          <a href="https://kern.humdrum.org" target="_blank" rel="noopener noreferrer">kern.humdrum.org</a>.
+        </p>
       </section>
 
       </div>


### PR DESCRIPTION
Replace plain-text musescore.com, imslp.org, and kern.humdrum.org in the Loading a Score section with proper anchor tags (target=_blank, rel=noopener noreferrer). Add --color-accent themed link styles to GuidePlugin.css.