### PR TITLE
feat(050): Staccato articulation in playback and practice mode

### DIFF
--- a/frontend/src/plugin-api/scorePlayerContext.ts
+++ b/frontend/src/plugin-api/scorePlayerContext.ts
@@ -432,13 +432,14 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
 
       // Group by start_tick; collect ALL pitches + note IDs at each tick (full chord).
       // durationTicks: take the maximum across chord notes (v7, feature 042).
-      const tickMap = new Map<number, { midiPitches: number[]; noteIds: string[]; tick: number; durationTicks: number; sustainedPitches: number[]; sustainedNoteIds: string[] }>();
+      const tickMap = new Map<number, { midiPitches: number[]; noteIds: string[]; tick: number; durationTicks: number; sustainedPitches: number[]; sustainedNoteIds: string[]; hasStaccato: boolean }>();
       for (const note of attackNotes) {
         const existing = tickMap.get(note.start_tick);
         if (existing) {
           existing.midiPitches.push(note.pitch);
           existing.noteIds.push(note.id);
           existing.durationTicks = Math.max(existing.durationTicks, note.duration_ticks);
+          if (note.staccato) existing.hasStaccato = true;
         } else {
           tickMap.set(note.start_tick, {
             midiPitches: [note.pitch],
@@ -447,6 +448,7 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
             durationTicks: note.duration_ticks,
             sustainedPitches: [],
             sustainedNoteIds: [],
+            hasStaccato: !!note.staccato,
           });
         }
       }
@@ -478,6 +480,13 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
         const gap = sorted[i + 1].tick - sorted[i].tick;
         if (gap > 0 && gap < sorted[i].durationTicks) {
           sorted[i].durationTicks = gap;
+        }
+      }
+
+      // Staccato: halve duration (standard musical convention)
+      for (const entry of sorted) {
+        if (entry.hasStaccato) {
+          entry.durationTicks = Math.round(entry.durationTicks * 0.5);
         }
       }
 

--- a/frontend/src/services/playback/PlaybackScheduler.ts
+++ b/frontend/src/services/playback/PlaybackScheduler.ts
@@ -194,6 +194,10 @@ export class PlaybackScheduler {
       if (this.scheduleTempoMultiplier !== 1.0) {
         durationSeconds = durationSeconds / this.scheduleTempoMultiplier;
       }
+      // Staccato: halve duration (standard musical convention)
+      if (note.staccato) {
+        durationSeconds *= 0.5;
+      }
       if (durationSeconds < MIN_NOTE_DURATION) {
         durationSeconds = MIN_NOTE_DURATION;
       }
@@ -242,6 +246,7 @@ export class PlaybackScheduler {
       pitch: r.pitch,
       start_tick: r.start_tick,
       duration_ticks: r.combinedDurationTicks,
+      staccato: r.staccato,
     }));
 
     // Filter out notes already past, then sort by start_tick

--- a/frontend/src/services/playback/TieResolver.ts
+++ b/frontend/src/services/playback/TieResolver.ts
@@ -16,6 +16,8 @@ export interface ResolvedNote {
   start_tick: number;
   /** Sum of all tied durations in the chain. */
   combinedDurationTicks: number;
+  /** Whether the note has a staccato articulation. */
+  staccato?: boolean;
 }
 
 /**
@@ -57,6 +59,7 @@ export function resolveTiedNotes(notes: Note[]): ResolvedNote[] {
       pitch: note.pitch,
       start_tick: note.start_tick,
       combinedDurationTicks: totalDuration,
+      staccato: note.staccato,
     });
   }
 

--- a/frontend/tests/unit/TieResolver.test.ts
+++ b/frontend/tests/unit/TieResolver.test.ts
@@ -78,4 +78,17 @@ describe('TieResolver', () => {
     expect(resolved[0].combinedDurationTicks).toBe(480);
     expect(resolved[1].combinedDurationTicks).toBe(480);
   });
+
+  it('propagates staccato flag from the tie-start note', () => {
+    const notes: Note[] = [
+      makeNote({ id: 'n1', pitch: 60, start_tick: 0, duration_ticks: 480, staccato: true }),
+      makeNote({ id: 'n2', pitch: 62, start_tick: 480, duration_ticks: 480 }),
+    ];
+
+    const resolved = resolveTiedNotes(notes);
+
+    expect(resolved).toHaveLength(2);
+    expect(resolved[0].staccato).toBe(true);
+    expect(resolved[1].staccato).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Apply staccato articulation to playback audio and practice mode note detection. Staccato notes now sound at 50% of their written duration (standard musical convention) and require proportionally shorter hold times in practice mode.

## Changes

### Playback Pipeline
- **TieResolver**: Propagate `staccato` flag through `ResolvedNote` so it survives tie resolution
- **PlaybackScheduler**: Forward `staccato` when mapping resolved notes; halve `durationSeconds` for staccato notes (applied before `MIN_NOTE_DURATION` floor)

### Practice Mode
- **scorePlayerContext**: Track `hasStaccato` per tick-group in `extractPracticeNotes()`; halve `durationTicks` for staccato entries after gap-truncation, reducing `requiredHoldMs` accordingly

### Tests
- New unit test verifying staccato propagation through `resolveTiedNotes()`
- All 1609 tests pass

## Files Changed (4)
- `frontend/src/services/playback/TieResolver.ts`
- `frontend/src/services/playback/PlaybackScheduler.ts`
- `frontend/src/plugin-api/scorePlayerContext.ts`
- `frontend/tests/unit/TieResolver.test.ts`
