### PR TITLE
feat(practice): show note display bar only on wrong note press

### DIFF
--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
@@ -1237,23 +1237,19 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
         </div>
       )}
 
-      {/* Real-time note display — pressed vs expected (visible during practice) */}
-      {(practiceActive || practiceWaiting) && (
+      {/* Real-time note display — pressed vs expected (only on wrong note) */}
+      {(practiceActive || practiceWaiting) &&
+        pressedPitchLabels.length > 0 &&
+        pressedPitchLabels.join(',') !== expectedPitchLabels.join(',') && (
         <div className="practice-plugin__note-display" aria-live="polite">
           <span className="practice-plugin__note-display-label">Expected:</span>
           <span className="practice-plugin__note-display-notes practice-plugin__note-display-notes--expected">
-            {expectedPitchLabels.length > 0 ? expectedPitchLabels.join(', ') : '—'}
+            {expectedPitchLabels.join(', ')}
           </span>
           <span className="practice-plugin__note-display-sep">|</span>
           <span className="practice-plugin__note-display-label">Playing:</span>
-          <span className={`practice-plugin__note-display-notes ${
-            pressedPitchLabels.length > 0
-              ? pressedPitchLabels.join(',') === expectedPitchLabels.join(',')
-                ? 'practice-plugin__note-display-notes--correct'
-                : 'practice-plugin__note-display-notes--wrong'
-              : ''
-          }`}>
-            {pressedPitchLabels.length > 0 ? pressedPitchLabels.join(', ') : '—'}
+          <span className="practice-plugin__note-display-notes practice-plugin__note-display-notes--wrong">
+            {pressedPitchLabels.join(', ')}
           </span>
         </div>
       )}


### PR DESCRIPTION
## Summary

The **Expected vs Playing** note display bar now only appears when the user presses a wrong note during practice mode. It hides automatically once the error is corrected (wrong key released or correct key pressed).

### Changes
- **PracticeViewPlugin.tsx**: Updated the note display bar visibility condition from always-shown to only render when pressed keys don't match the expected pitches.

### Before
The bar was always visible during practice, even when playing correctly.

### After
The bar appears only on wrong note presses, reducing visual noise and drawing attention to errors.

### Testing
- All 157 practice-view-plugin tests pass (89 engine + 27 toolbar + 41 plugin)
- 423 Rust tests pass
