### PR TITLE
fix: restore chord detector after rest-gap WRONG_MIDI rejection (#053)

### DIFF
--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
@@ -747,6 +747,16 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
           const prevEntry = ps.notes[ps.currentIndex - 1];
           const hasRestGap = prevEntry && (prevEntry.tick + prevEntry.durationTicks < currentEntry.tick);
           if (hasRestGap && expectedTimeMs - responseTimeMs > LATE_THRESHOLD_MS) {
+            // Restore the detector so the user can retry this beat.
+            // reset([]) above cleared it to prevent double-trigger, but since
+            // we're rejecting the chord (too early), the detector must be
+            // usable again — otherwise required=[] leaves it permanently stuck.
+            chordDetectorRef.current.reset(allRequired);
+            for (const p of allRequired) {
+              if (heldMidiKeysRef.current.has(p)) {
+                chordDetectorRef.current.pin(p);
+              }
+            }
             dispatchPractice({ type: 'WRONG_MIDI', midiNote: event.midiNote, responseTimeMs });
             return;
           }

--- a/frontend/src/utils/chordDetector.test.ts
+++ b/frontend/src/utils/chordDetector.test.ts
@@ -277,3 +277,58 @@ describe('ChordDetector — unpin()', () => {
     expect(result.missing).toEqual(expect.arrayContaining([48, 52, 55]));
   });
 });
+
+// ---------------------------------------------------------------------------
+// Reset recovery — simulates the rest-gap WRONG_MIDI scenario
+// ---------------------------------------------------------------------------
+
+describe('ChordDetector — reset recovery after premature reset([])', () => {
+  it('is permanently stuck after reset([]): press always returns incomplete', () => {
+    const det = new ChordDetector();
+    det.reset([60, 67]);
+    // Chord completes
+    det.press(60, T0);
+    const r1 = det.press(67, T0 + 10);
+    expect(r1.complete).toBe(true);
+    // Premature reset — detector disabled
+    det.reset([]);
+    // Any press now returns incomplete (required is empty)
+    const r2 = det.press(60, T0 + 100);
+    expect(r2.complete).toBe(false);
+    const r3 = det.press(67, T0 + 110);
+    expect(r3.complete).toBe(false);
+  });
+
+  it('recovers after reset([]) followed by reset(requiredPitches)', () => {
+    const det = new ChordDetector();
+    det.reset([60, 67]);
+    det.press(60, T0);
+    const r1 = det.press(67, T0 + 10);
+    expect(r1.complete).toBe(true);
+    // Premature reset
+    det.reset([]);
+    // Restore required pitches (as the fix does)
+    det.reset([60, 67]);
+    // Chord works again on retry
+    det.press(60, T0 + 200);
+    const r2 = det.press(67, T0 + 210);
+    expect(r2.complete).toBe(true);
+  });
+
+  it('recovers with pin after reset(requiredPitches) for held sustained note', () => {
+    const det = new ChordDetector();
+    det.reset([60, 67]);
+    det.press(60, T0);
+    const r1 = det.press(67, T0 + 10);
+    expect(r1.complete).toBe(true);
+    // Premature reset then restore
+    det.reset([]);
+    det.reset([60, 67]);
+    // Pin a held pitch (simulating re-pin of sustained note)
+    det.pin(67);
+    // Only pressing the remaining note completes
+    const r2 = det.press(60, T0 + 300);
+    expect(r2.complete).toBe(true);
+    expect(r2.collected).toEqual([60, 67]);
+  });
+});


### PR DESCRIPTION
## Summary

Fix chord detector getting permanently stuck after a rest-gap timing rejection in practice mode.

## Root Cause

When a completed chord was rejected by the inter-onset rest-gap enforcement (FR-005a), the `ChordDetector` was left with `required=[]` from a premature `reset([])` call (line 710). Since `WRONG_MIDI` changes neither `mode` nor `currentIndex`, the `useEffect` that resets the detector never re-ran — leaving it permanently unable to complete any chord. The user could never retry the beat.

**Scenario**: La Candeur M13, beat 4 (G5+C5 chord). After missing the chord and getting WRONG_MIDI from the rest-gap check, replaying the exact correct notes showed "expected C5+G5 / playing C5+G5" but the chord was never validated.

## Fix

Before dispatching `WRONG_MIDI` in the rest-gap path, restore the detector via `reset(allRequired)` and re-pin any held pitches so the user can retry.

## Changes

| File | Change |
|------|--------|
| `PracticeViewPlugin.tsx` | Restore ChordDetector state before rest-gap WRONG_MIDI dispatch (+10 lines) |
| `chordDetector.test.ts` | 3 new unit tests documenting the reset-recovery pattern (+55 lines) |

## Testing

- All 1636 frontend unit tests pass
- All 430 Rust tests pass
- E2E tests pass (2 passed within 3-min pre-push limit)
- Manual verification: M13 beat 4 chord retry now works correctly
