### PR TITLE
feat(practice): hide overlay during replay, stop button cancels replay

### DIFF
--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx
@@ -497,29 +497,34 @@ describe('PracticeViewPlugin — Replay (038-practice-replay)', () => {
     expect(screen.getByRole('button', { name: /replay your performance/i })).toBeTruthy();
   });
 
-  // T008: Replay button replaced by Stop button when Replay pressed
-  it('T008: replaces Replay with Stop button when Replay is pressed', () => {
+  // T008: Replay hides overlay when pressed
+  it('T008: hides results overlay when Replay is pressed', () => {
     const { ctx } = setupCompletedPractice();
+    expect(screen.getByRole('region', { name: /practice results/i })).toBeTruthy();
     const replayBtn = screen.getByRole('button', { name: /replay your performance/i });
     act(() => {
       fireEvent.click(replayBtn);
     });
-    expect(screen.queryByRole('button', { name: /replay your performance/i })).toBeNull();
-    expect(screen.getByRole('button', { name: /stop replay/i })).toBeTruthy();
+    // Overlay is hidden during replay
+    expect(screen.queryByRole('region', { name: /practice results/i })).toBeNull();
   });
 
-  // T009: Stop button cancels playback and restores Replay button
-  it('T009: Stop cancels playback and restores Replay button', () => {
+  // T009: Toolbar Stop button cancels replay and restores overlay
+  it('T009: Stop cancels playback and restores results overlay', () => {
     const { ctx } = setupCompletedPractice();
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: /replay your performance/i }));
     });
+    // Overlay hidden during replay
+    expect(screen.queryByRole('region', { name: /practice results/i })).toBeNull();
+    // Use toolbar Stop button to cancel replay
     act(() => {
-      fireEvent.click(screen.getByRole('button', { name: /stop replay/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^Stop$/ }));
     });
     expect(ctx.mockStopPlayback).toHaveBeenCalled();
+    // Overlay reappears with Replay button
+    expect(screen.getByRole('region', { name: /practice results/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /replay your performance/i })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: /stop replay/i })).toBeNull();
   });
 
   // T010: context.playNote called N times with offsetMs = real responseTimeMs
@@ -683,11 +688,10 @@ describe('PracticeViewPlugin — Replay (038-practice-replay)', () => {
     });
 
     expect(ctx.mockStopPlayback).toHaveBeenCalled();
+    // Overlay reappears after natural replay end
+    expect(screen.getByRole('region', { name: /practice results/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /replay your performance/i })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: /stop replay/i })).toBeNull();
   });
-
-  // T013: unmount during replay clears all timers
   it('T013: clears timers on unmount during replay', () => {
     const notes = [
       { midiPitches: [60], noteIds: ['n1'], tick: 0 },
@@ -862,8 +866,15 @@ describe('PracticeViewPlugin — Replay (038-practice-replay)', () => {
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: /replay your performance/i }));
     });
-    expect(screen.getByRole('button', { name: /stop replay/i })).toBeTruthy();
+    // Overlay is hidden during replay
+    expect(screen.queryByRole('region', { name: /practice results/i })).toBeNull();
 
+    // Stop replay via toolbar, which restores the overlay
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /^Stop$/ }));
+    });
+
+    // Now click repractice in the restored overlay
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: /repractice/i }));
     });

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
@@ -160,6 +160,15 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   const [performanceRecord, setPerformanceRecord] = useState<PerformanceRecord | null>(null);
   const [isReplaying, setIsReplaying] = useState(false);
   const [replayHighlightedNoteIds, setReplayHighlightedNoteIds] = useState<ReadonlySet<string>>(new Set());
+  const wasReplayingRef = useRef(false);
+
+  // Restore results overlay when replay finishes (natural end or stop)
+  useEffect(() => {
+    if (wasReplayingRef.current && !isReplaying) {
+      setResultsOverlayVisible(true);
+    }
+    wasReplayingRef.current = isReplaying;
+  }, [isReplaying]);
 
   // ─── Partial results on Stop (US7, 053-fix-lacandeur-practice) ─────────────
   const [partialPerformanceRecord, setPartialPerformanceRecord] = useState<PartialPerformanceRecord | null>(null);
@@ -309,6 +318,13 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   const handlePlay = useCallback(() => context.scorePlayer.play(), [context.scorePlayer]);
   const handlePause = useCallback(() => context.scorePlayer.pause(), [context.scorePlayer]);
   const handleStop = useCallback(() => {
+    // If a replay is in progress, stop audio and reset replay state
+    if (isReplaying) {
+      context.stopPlayback();
+      setIsReplaying(false);
+      setReplayHighlightedNoteIds(new Set());
+      return;
+    }
     // US7: Snapshot partial results before STOP clears engine state
     const ps = practiceStateRef.current;
     if (ps.mode === 'active' || ps.mode === 'waiting' || ps.mode === 'holding') {
@@ -327,7 +343,7 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
     const lr = loopRegionRef.current;
     context.scorePlayer.seekToTick(lr ? lr.startTick : 0);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [context.scorePlayer, playerState.bpm]);
+  }, [context, context.scorePlayer, playerState.bpm, isReplaying]);
 
   const handleTempoChange = useCallback(
     (m: number) => {

--- a/frontend/plugins/practice-view-plugin/ResultsOverlay.tsx
+++ b/frontend/plugins/practice-view-plugin/ResultsOverlay.tsx
@@ -86,6 +86,15 @@ export function ResultsOverlay({
     };
   }, []);
 
+  // Clean up replay timers when isReplaying is set to false externally (e.g. stop button)
+  useEffect(() => {
+    if (!isReplaying && replayTimersRef.current.length > 0) {
+      context.stopPlayback();
+      replayTimersRef.current.forEach(clearTimeout);
+      replayTimersRef.current = [];
+    }
+  }, [isReplaying, context]);
+
   const handleReplayStop = useCallback(() => {
     context.stopPlayback();
     replayTimersRef.current.forEach(clearTimeout);
@@ -155,7 +164,10 @@ export function ResultsOverlay({
     timers.push(finishTimer);
 
     replayTimersRef.current = timers;
-  }, [context, performanceRecord, isReplaying, setIsReplaying, setReplayHighlightedNoteIds]);
+
+    // Hide the results overlay so the score is visible during replay
+    onDismiss();
+  }, [context, performanceRecord, isReplaying, setIsReplaying, setReplayHighlightedNoteIds, onDismiss]);
 
   const handleRepractice = useCallback(() => {
     if (isReplaying) handleReplayStop();


### PR DESCRIPTION
- ResultsOverlay.handleReplay calls onDismiss() to hide overlay when replay starts
- ResultsOverlay cleanup effect clears timers when isReplaying goes false externally
- PracticeViewPlugin.handleStop detects active replay and stops playback
- wasReplayingRef effect restores overlay when replay ends (naturally or via stop)
- Updated 4 tests (T008, T009, T012, T044) for new replay behavior