### PR TITLE
feat(practice): save and load practice sessions

### DIFF
--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.css
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.css
@@ -806,6 +806,53 @@
   background: #1b5e20;
 }
 
+/* ── Save button (056-save-load-practices) ─────────────────────────────────── */
+
+.practice-results__save-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 20px;
+  min-width: 44px;
+  min-height: 44px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  background: #6a1b9a;
+  color: #fff;
+  transition: background 0.15s ease;
+}
+
+.practice-results__save-btn:hover {
+  background: #4a148c;
+}
+
+.practice-results__save-btn:active {
+  background: #38006b;
+}
+
+.practice-results__save-btn--saved {
+  background: #7cb342;
+  cursor: default;
+}
+
+.practice-results__save-btn--saved:hover {
+  background: #7cb342;
+}
+
+.practice-results__save-btn:disabled {
+  opacity: 0.85;
+  cursor: default;
+}
+
+.practice-results__save-error {
+  font-size: 0.75rem;
+  color: #e53935;
+  white-space: nowrap;
+}
+
 /* ── Loop count slider (multi-loop practice) ───────────────────────────────── */
 
 .practice-results__loop-slider-row {

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
@@ -26,8 +26,8 @@ import type {
   PluginPlaybackStatus,
   MetronomeState,
   MetronomeSubdivision,
-  PluginPracticeNoteEntry,
 } from '../../src/plugin-api/index';
+import type { PluginPracticeNoteEntry } from '../../src/plugin-api/types';
 import { PracticeToolbar } from './practiceToolbar';
 import { reduce } from './practiceEngine';
 import { INITIAL_PRACTICE_STATE } from './practiceEngine.types';
@@ -39,6 +39,9 @@ import { usePracticeHighlights } from './usePracticeHighlights';
 import { usePhantomTempo } from './usePhantomTempo';
 import { useHoldProgress } from './useHoldProgress';
 import { ResultsOverlay } from './ResultsOverlay';
+import type { ScoreRef, SavedPractice, SavedPerformanceData, SavedPracticeIndexEntry } from '../../src/plugin-api/index';
+import { savePracticeToIndexedDB, generatePracticeName, loadPracticeFromIndexedDB, deletePracticeFromIndexedDB } from '../../src/plugin-api/index';
+import { addSavedPracticeIndex, listSavedPractices, removeSavedPracticeIndex } from '../../src/plugin-api/index';
 import './PracticeViewPlugin.css';
 
 // ---------------------------------------------------------------------------
@@ -173,6 +176,78 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   // ─── Partial results on Stop (US7, 053-fix-lacandeur-practice) ─────────────
   const [partialPerformanceRecord, setPartialPerformanceRecord] = useState<PartialPerformanceRecord | null>(null);
 
+  // ─── Feature 056: Saved practice state ─────────────────────────────────────
+  const [isSaved, setIsSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const loadedScoreRefRef = useRef<ScoreRef | null>(null);
+  const [savedPractices, setSavedPractices] = useState<SavedPracticeIndexEntry[]>(() => listSavedPractices());
+  // Pending saved practice to restore once the score finishes loading
+  const pendingSavedPracticeRef = useRef<SavedPractice | null>(null);
+
+  // Feature 056: Apply pending saved practice once the score is ready.
+  // This runs in a useEffect so the state updates happen in the same React
+  // render cycle as the playerState transition to 'ready', avoiding the race
+  // where setResultsOverlayVisible(true) fires before the score view mounts.
+  useEffect(() => {
+    const saved = pendingSavedPracticeRef.current;
+    if (!saved || playerState.status !== 'ready') return;
+    pendingSavedPracticeRef.current = null;
+
+    setSelectedStaffIndex(saved.staffIndex);
+    setTempoMultiplier(saved.tempoMultiplier);
+    context.scorePlayer.setTempoMultiplier(saved.tempoMultiplier);
+    setLoopCount(saved.loopCount);
+
+    // Re-extract fresh notes from the newly loaded score so that noteIds
+    // (opaque DOM IDs) are valid for the current rendering. The saved notes
+    // have stale noteIds from the original session.
+    let freshNotes: PluginPracticeNoteEntry[] = saved.performanceData.notes as PluginPracticeNoteEntry[];
+    const staffIndex = saved.staffIndex;
+    if (staffIndex === -1) {
+      // Both Clefs: merge from all staves
+      const all: PluginPracticeNoteEntry[] = [];
+      for (let s = 0; s < playerState.staffCount; s++) {
+        const p = context.scorePlayer.extractPracticeNotes(s);
+        if (p) all.push(...(p.notes as PluginPracticeNoteEntry[]));
+      }
+      freshNotes = mergePracticeNotesByTick(all);
+    } else {
+      const pitches = context.scorePlayer.extractPracticeNotes(staffIndex);
+      if (pitches && pitches.notes.length > 0) {
+        freshNotes = pitches.notes as PluginPracticeNoteEntry[];
+      }
+    }
+
+    // Build the notes array with fresh noteIds, falling back to saved entries
+    // for any index beyond what was re-extracted (shouldn't happen for same score).
+    const notesWithFreshIds = saved.performanceData.notes.map((savedNote, i) =>
+      i < freshNotes.length ? freshNotes[i] : savedNote,
+    );
+
+    if (saved.completionStatus === 'complete') {
+      setPerformanceRecord({
+        notes: notesWithFreshIds,
+        noteResults: saved.performanceData.noteResults,
+        wrongNoteEvents: saved.performanceData.wrongNoteEvents,
+        bpmAtCompletion: saved.performanceData.bpmAtCompletion,
+      });
+      setPartialPerformanceRecord(null);
+    } else {
+      setPartialPerformanceRecord({
+        notes: notesWithFreshIds,
+        noteResults: saved.performanceData.noteResults,
+        wrongNoteEvents: saved.performanceData.wrongNoteEvents,
+        bpmAtCompletion: saved.performanceData.bpmAtCompletion,
+        stoppedAtIndex: saved.performanceData.stoppedAtIndex ?? 0,
+        totalNoteCount: saved.performanceData.totalNoteCount ?? saved.performanceData.notes.length,
+      });
+      setPerformanceRecord(null);
+    }
+    setResultsOverlayVisible(true);
+    setIsSaved(true);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playerState.status]);
+
   // Practice session start time (ms since epoch) for timing analysis
   const practiceStartTimeRef = useRef(0);
 
@@ -296,6 +371,7 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   // Select a catalogue score
   const handleSelectScore = useCallback(
     (catalogueId: string) => {
+      loadedScoreRefRef.current = { type: 'preloaded', id: catalogueId };
       context.scorePlayer.loadScore({ kind: 'catalogue', catalogueId });
     },
     [context.scorePlayer],
@@ -304,6 +380,7 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   // Load a file
   const handleLoadFile = useCallback(
     (file: File) => {
+      loadedScoreRefRef.current = null; // File loads can't be reliably reloaded
       context.scorePlayer.loadScore({ kind: 'file', file });
     },
     [context.scorePlayer],
@@ -375,6 +452,8 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
 
   // Practice toggle (T031, T033, T034)
   const handlePracticeToggle = useCallback(() => {
+    setIsSaved(false); // Reset save state for new practice session
+    setSaveError(null);
     const ps = practiceStateRef.current;
 
     if (ps.mode === 'active' || ps.mode === 'waiting' || ps.mode === 'holding') {
@@ -526,6 +605,111 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [handlePracticeToggle, loopCount]);
 
+  // ─── Feature 056: Save practice handler ──────────────────────────────────────
+  const handleSave = useCallback(async () => {
+    const scoreRef = loadedScoreRefRef.current;
+    if (!scoreRef) return;
+
+    const isComplete = practiceState.mode === 'complete' && !!performanceRecord;
+    const isPartial = !!partialPerformanceRecord;
+    if (!isComplete && !isPartial) return;
+
+    const now = new Date();
+    const id = crypto.randomUUID();
+    const scoreTitle = playerState.title ?? 'Untitled';
+    const lr = loopRegion
+      ? { startTick: loopRegion.startTick, endTick: loopRegion.endTick }
+      : null;
+
+    const performanceData: SavedPerformanceData = isComplete
+      ? {
+          notes: [...performanceRecord!.notes],
+          noteResults: [...performanceRecord!.noteResults],
+          wrongNoteEvents: [...performanceRecord!.wrongNoteEvents],
+          bpmAtCompletion: performanceRecord!.bpmAtCompletion,
+          stoppedAtIndex: null,
+          totalNoteCount: null,
+        }
+      : {
+          notes: [...partialPerformanceRecord!.notes],
+          noteResults: [...partialPerformanceRecord!.noteResults],
+          wrongNoteEvents: [...partialPerformanceRecord!.wrongNoteEvents],
+          bpmAtCompletion: partialPerformanceRecord!.bpmAtCompletion,
+          stoppedAtIndex: partialPerformanceRecord!.stoppedAtIndex,
+          totalNoteCount: partialPerformanceRecord!.totalNoteCount,
+        };
+
+    const practice: SavedPractice = {
+      id,
+      name: generatePracticeName(scoreTitle, selectedStaffIndex, lr, now),
+      savedAt: now.toISOString(),
+      scoreRef,
+      scoreTitle,
+      staffIndex: selectedStaffIndex,
+      loopRegion: lr,
+      tempoMultiplier,
+      loopCount,
+      completionStatus: isComplete ? 'complete' : 'partial',
+      performanceData,
+    };
+
+    try {
+      await savePracticeToIndexedDB(practice);
+      const { evictedIds } = addSavedPracticeIndex({
+        id,
+        name: practice.name,
+        savedAt: practice.savedAt,
+        completionStatus: practice.completionStatus,
+        scoreTitle,
+      });
+      // Clean up evicted entries from IndexedDB
+      for (const evictedId of evictedIds) {
+        await deletePracticeFromIndexedDB(evictedId);
+      }
+      setIsSaved(true);
+      setSaveError(null);
+      setSavedPractices(listSavedPractices());
+    } catch (e) {
+      console.error('[PracticeViewPlugin] Failed to save practice:', e);
+      const isQuota = e instanceof DOMException && (e.name === 'QuotaExceededError' || e.code === 22);
+      setSaveError(isQuota ? 'Storage full — delete some saved practices and try again.' : 'Failed to save practice.');
+    }
+  }, [
+    practiceState.mode, performanceRecord, partialPerformanceRecord,
+    playerState.title, loopRegion, selectedStaffIndex,
+    tempoMultiplier, loopCount,
+  ]);
+
+  // ─── Feature 056: Delete saved practice handler ─────────────────────────────
+  const handleDeleteSavedPractice = useCallback(async (practiceId: string) => {
+    removeSavedPracticeIndex(practiceId);
+    await deletePracticeFromIndexedDB(practiceId);
+    setSavedPractices(listSavedPractices());
+  }, []);
+
+  // ─── Feature 056: Load saved practice handler ──────────────────────────────
+  const handleSelectSavedPractice = useCallback(async (entry: SavedPracticeIndexEntry) => {
+    const saved = await loadPracticeFromIndexedDB(entry.id);
+    if (!saved) {
+      console.warn('[PracticeViewPlugin] Saved practice not found in IndexedDB:', entry.id);
+      return;
+    }
+
+    // Track score ref for potential re-save
+    loadedScoreRefRef.current = saved.scoreRef;
+
+    // Store the saved practice for the useEffect to apply once the score is ready
+    pendingSavedPracticeRef.current = saved;
+
+    // Load the referenced score — the useEffect watching playerState.status
+    // will restore settings and show the results overlay when status becomes 'ready'.
+    if (saved.scoreRef.type === 'preloaded') {
+      context.scorePlayer.loadScore({ kind: 'catalogue', catalogueId: saved.scoreRef.id });
+    } else {
+      context.scorePlayer.loadScore({ kind: 'userScore', scoreId: saved.scoreRef.id });
+    }
+  }, [context.scorePlayer]);
+
   // ─── Highlight computation (extracted hook) ─────────────────────────────────
   const {
     targetNoteIds, confirmedNoteIds,
@@ -560,15 +744,19 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
           onLoadFile={handleLoadFile}
           onCancel={handleSelectorCancel}
           onSelectUserScore={(scoreId) => {
+            loadedScoreRefRef.current = { type: 'user', id: scoreId };
             context.scorePlayer.loadScore({ kind: 'userScore', scoreId });
           }}
+          savedPractices={savedPractices}
+          onSelectSavedPractice={handleSelectSavedPractice}
+          onDeleteSavedPractice={handleDeleteSavedPractice}
         />
       </div>
     );
   }
 
   return (
-    <div className={`practice-plugin${practiceActive ? ' practice-plugin--phantom' : ''}${(practiceState.mode === 'complete' && resultsOverlayVisible) || (partialPerformanceRecord && resultsOverlayVisible) ? ' practice-plugin--results' : ''}`}>
+    <div className={`practice-plugin${practiceActive ? ' practice-plugin--phantom' : ''}${((practiceState.mode === 'complete' || (practiceState.mode === 'inactive' && performanceRecord)) && resultsOverlayVisible) || (partialPerformanceRecord && resultsOverlayVisible) ? ' practice-plugin--results' : ''}`}>
       {/* Toolbar — top */}
       <PracticeToolbar
         scoreTitle={playerState.title}
@@ -688,6 +876,9 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
         replayHighlightedNoteIds={replayHighlightedNoteIds}
         setIsReplaying={setIsReplaying}
         setReplayHighlightedNoteIds={setReplayHighlightedNoteIds}
+        onSave={loadedScoreRefRef.current ? handleSave : undefined}
+        isSaved={isSaved}
+        saveError={saveError}
       />
     </div>
   );

--- a/frontend/plugins/practice-view-plugin/ResultsOverlay.tsx
+++ b/frontend/plugins/practice-view-plugin/ResultsOverlay.tsx
@@ -54,6 +54,12 @@ export interface ResultsOverlayProps {
   replayHighlightedNoteIds: ReadonlySet<string>;
   setIsReplaying: React.Dispatch<React.SetStateAction<boolean>>;
   setReplayHighlightedNoteIds: React.Dispatch<React.SetStateAction<ReadonlySet<string>>>;
+  /** Feature 056: Save callback — saves the current practice to storage. */
+  onSave?: () => void;
+  /** Feature 056: Whether the current practice has been saved this session. */
+  isSaved?: boolean;
+  /** Feature 056: Error message if save failed (e.g. storage full). */
+  saveError?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -74,6 +80,9 @@ export function ResultsOverlay({
   isReplaying,
   setIsReplaying,
   setReplayHighlightedNoteIds,
+  onSave,
+  isSaved,
+  saveError,
 }: ResultsOverlayProps) {
   // ─── Replay internals ────────────────────────────────────────────────────────
   const replayTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -176,7 +185,11 @@ export function ResultsOverlay({
 
   // ─── Results computation ───────────────────────────────────────────────────
   const practiceReport = useMemo(() => {
-    const results = practiceState.noteResults;
+    // Use engine state results when available (live practice);
+    // fall back to loaded performanceRecord (saved practice loaded from storage).
+    const results = practiceState.noteResults.length > 0
+      ? practiceState.noteResults
+      : performanceRecord?.noteResults ?? [];
     if (results.length === 0) return null;
 
     const totalNotes = results.length;
@@ -208,7 +221,7 @@ export function ResultsOverlay({
       scoreTimeMs,
       results,
     };
-  }, [practiceState.noteResults]);
+  }, [practiceState.noteResults, performanceRecord]);
 
   const partialReport = useMemo(() => {
     if (!partialPerformanceRecord) return null;
@@ -254,8 +267,10 @@ export function ResultsOverlay({
 
   // ─── Render ────────────────────────────────────────────────────────────────
 
-  // Complete results overlay
-  const completeOverlay = practiceState.mode === 'complete' && resultsOverlayVisible && practiceReport && (
+  // Complete results overlay — shown after practice completion OR when loading a saved complete practice
+  const showComplete = resultsOverlayVisible && practiceReport &&
+    (practiceState.mode === 'complete' || (practiceState.mode === 'inactive' && !!performanceRecord));
+  const completeOverlay = showComplete && (
     <>
       <div className="practice-results__backdrop" />
       <div
@@ -509,7 +524,7 @@ export function ResultsOverlay({
           );
         })()}
 
-        {/* Replay / Stop button */}
+        {/* Replay / Stop / Save buttons */}
         {performanceRecord && (
           <div className="practice-results__replay-row">
             <button
@@ -535,6 +550,19 @@ export function ResultsOverlay({
               >
                 ■ Stop
               </button>
+            )}
+            {onSave && (
+              <button
+                className={`practice-results__save-btn${isSaved ? ' practice-results__save-btn--saved' : ''}`}
+                onClick={onSave}
+                disabled={isSaved}
+                aria-label={isSaved ? 'Practice saved' : 'Save practice'}
+              >
+                {isSaved ? '✓ Saved' : '💾 Save'}
+              </button>
+            )}
+            {saveError && (
+              <span className="practice-results__save-error" role="alert">{saveError}</span>
             )}
           </div>
         )}
@@ -565,8 +593,8 @@ export function ResultsOverlay({
     </>
   );
 
-  // Partial results overlay (shown when Stop is pressed mid-session)
-  const partialOverlay = partialReport && resultsOverlayVisible && practiceState.mode !== 'complete' && (
+  // Partial results overlay (shown when Stop is pressed mid-session, or loading a saved partial practice)
+  const partialOverlay = partialReport && resultsOverlayVisible && !showComplete && (
     <>
       <div className="practice-results__backdrop" />
       <div

--- a/frontend/plugins/practice-view-plugin/practiceEngine.types.ts
+++ b/frontend/plugins/practice-view-plugin/practiceEngine.types.ts
@@ -6,7 +6,7 @@
  * No side effects, no coordinate calculations (Principle VI).
  */
 
-import type { PluginPracticeNoteEntry } from '../../src/plugin-api/index';
+import type { PluginPracticeNoteEntry } from '../../src/plugin-api/types';
 
 // ---------------------------------------------------------------------------
 // Re-export — PracticeNoteEntry is a direct alias for the v6 plugin API type

--- a/frontend/src/components/load-score/LoadScoreDialog.tsx
+++ b/frontend/src/components/load-score/LoadScoreDialog.tsx
@@ -7,7 +7,9 @@ import { PreloadedScoreList } from './PreloadedScoreList';
 import { ScoreGroupList } from './ScoreGroupList';
 import { UserScoreList } from './UserScoreList';
 import type { UserScore } from '../../services/userScoreIndex';
+import type { SavedPracticeIndexEntry } from '../../services/savedPractice.types';
 import { LoadNewScoreButton } from './LoadNewScoreButton';
+import { SavedPracticeList } from './SavedPracticeList';
 import './LoadScoreDialog.css';
 
 interface LoadScoreDialogProps {
@@ -24,6 +26,12 @@ interface LoadScoreDialogProps {
   onSelectUserScore?: (id: string) => void;
   /** Feature 045: Called when user deletes one of their uploaded scores. */
   onDeleteUserScore?: (id: string) => void;
+  /** Feature 056: Saved practices to show in the "Saved Practices" section. */
+  savedPractices?: ReadonlyArray<SavedPracticeIndexEntry>;
+  /** Feature 056: Called when user selects a saved practice to load. */
+  onSelectSavedPractice?: (practice: SavedPracticeIndexEntry) => void;
+  /** Feature 056: Called when user deletes a saved practice. */
+  onDeleteSavedPractice?: (id: string) => void;
 }
 
 /**
@@ -41,6 +49,9 @@ export function LoadScoreDialog({
   userScores = [],
   onSelectUserScore,
   onDeleteUserScore,
+  savedPractices = [],
+  onSelectSavedPractice,
+  onDeleteSavedPractice,
 }: LoadScoreDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
@@ -172,6 +183,15 @@ export function LoadScoreDialog({
             onSelect={(score) => onSelectUserScore?.(score.id)}
             onDelete={(id) => onDeleteUserScore?.(id)}
           />
+          {/* Feature 056: Saved Practices section */}
+          {savedPractices.length > 0 && onSelectSavedPractice && onDeleteSavedPractice && (
+            <SavedPracticeList
+              practices={savedPractices}
+              disabled={isBusy}
+              onSelect={onSelectSavedPractice}
+              onDelete={onDeleteSavedPractice}
+            />
+          )}
         </section>
 
         {/* Right panel — file picker */}

--- a/frontend/src/components/load-score/SavedPracticeList.css
+++ b/frontend/src/components/load-score/SavedPracticeList.css
@@ -1,0 +1,149 @@
+/* SavedPracticeList.css — "Saved Practices" collapsible section
+ * Feature 056: Save and Load Practices
+ * Uses --dialog-* tokens (App.css) — adapts to all landing themes.
+ * Follows UserScoreList.css pattern.
+ */
+
+/* ── Section wrapper (collapsible) ──────────────────────────────────────── */
+.saved-practice-list {
+  border-top: 1px solid var(--dialog-border);
+  padding-top: 0.5rem;
+  flex-shrink: 0;
+}
+
+.saved-practice-list__summary {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--dialog-subtext);
+  margin: 0;
+  padding: 0 1rem 0.25rem;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+
+.saved-practice-list__summary::-webkit-details-marker {
+  display: none;
+}
+
+.saved-practice-list__summary::before {
+  content: '▸ ';
+  display: inline-block;
+  transition: transform 0.15s;
+}
+
+.saved-practice-list[open] > .saved-practice-list__summary::before {
+  transform: rotate(90deg);
+}
+
+/* ── Item list ──────────────────────────────────────────────────────────── */
+.saved-practice-list__items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Each row: left button grows, right × is subtle */
+.saved-practice-item {
+  display: flex;
+  align-items: stretch;
+  padding: 0.125rem 1rem;
+  gap: 0.25rem;
+}
+
+/* ── Practice button — same pill shape as catalogue entries ─────────────── */
+.saved-practice-item__btn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  min-height: 44px;
+  padding: 0.5rem 0.75rem;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  font-family: inherit;
+  color: var(--dialog-text);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s;
+}
+
+.saved-practice-item__btn:hover:not(:disabled) {
+  background: var(--dialog-surface);
+}
+
+.saved-practice-item__btn:active:not(:disabled) {
+  background: var(--dialog-surface-hover);
+}
+
+.saved-practice-item__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.saved-practice-item__name {
+  font-size: 0.85rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  color: inherit;
+}
+
+.saved-practice-item__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.saved-practice-item__date {
+  font-size: 0.7rem;
+  color: var(--dialog-subtext);
+}
+
+/* ── Partial badge ──────────────────────────────────────────────────────── */
+.saved-practice-item__badge--partial {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  background: rgba(255, 167, 38, 0.2);
+  color: #f57c00;
+}
+
+/* ── Delete button ──────────────────────────────────────────────────────── */
+.saved-practice-item__delete-btn {
+  flex-shrink: 0;
+  align-self: center;
+  min-width: 32px;
+  min-height: 32px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+  color: var(--dialog-surface-active);
+  transition: color 0.15s, background 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.saved-practice-item__delete-btn:hover:not(:disabled) {
+  color: var(--dialog-danger-text);
+  background: var(--dialog-danger-bg);
+}
+
+.saved-practice-item__delete-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/load-score/SavedPracticeList.tsx
+++ b/frontend/src/components/load-score/SavedPracticeList.tsx
@@ -1,0 +1,76 @@
+/**
+ * SavedPracticeList.tsx — "Saved Practices" section inside the score picker.
+ * Feature 056: Save and Load Practices
+ *
+ * Presentational component: renders saved practices in a collapsible
+ * `<details>/<summary>` section, sorted by date descending (most recent first).
+ * Returns null when the practices list is empty.
+ */
+import type { SavedPracticeIndexEntry } from '../../services/savedPractice.types';
+import './SavedPracticeList.css';
+
+export interface SavedPracticeListProps {
+  practices: ReadonlyArray<SavedPracticeIndexEntry>;
+  disabled?: boolean;
+  onSelect: (practice: SavedPracticeIndexEntry) => void;
+  onDelete: (id: string) => void;
+}
+
+export function SavedPracticeList({
+  practices,
+  disabled = false,
+  onSelect,
+  onDelete,
+}: SavedPracticeListProps) {
+  if (practices.length === 0) return null;
+
+  return (
+    <details className="saved-practice-list" open>
+      <summary className="saved-practice-list__summary">
+        Saved Practices ({practices.length})
+      </summary>
+      <ul className="saved-practice-list__items" role="list">
+        {practices.map((practice) => {
+          const savedDate = new Date(practice.savedAt).toLocaleDateString(undefined, {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+          });
+          const savedTime = new Date(practice.savedAt).toLocaleTimeString(undefined, {
+            hour: '2-digit',
+            minute: '2-digit',
+          });
+          return (
+            <li key={practice.id} className="saved-practice-item">
+              <button
+                className="saved-practice-item__btn"
+                disabled={disabled}
+                onClick={() => onSelect(practice)}
+                type="button"
+              >
+                <span className="saved-practice-item__name">{practice.name}</span>
+                <span className="saved-practice-item__meta">
+                  <span className="saved-practice-item__date">{savedDate} {savedTime}</span>
+                  {practice.completionStatus === 'partial' && (
+                    <span className="saved-practice-item__badge saved-practice-item__badge--partial">
+                      Partial
+                    </span>
+                  )}
+                </span>
+              </button>
+              <button
+                className="saved-practice-item__delete-btn"
+                aria-label={`Delete ${practice.name}`}
+                disabled={disabled}
+                onClick={() => onDelete(practice.id)}
+                type="button"
+              >
+                ×
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </details>
+  );
+}

--- a/frontend/src/components/plugins/ScoreSelectorPlugin.tsx
+++ b/frontend/src/components/plugins/ScoreSelectorPlugin.tsx
@@ -18,6 +18,7 @@
 import { useRef, useMemo } from 'react';
 import type { PluginScoreSelectorProps } from '../../plugin-api/types';
 import { UserScoreList } from '../load-score/UserScoreList';
+import { SavedPracticeList } from '../load-score/SavedPracticeList';
 import { ScoreGroupList } from '../load-score/ScoreGroupList';
 import { DifficultyTag } from '../load-score/DifficultyTag';
 import { PRELOADED_CATALOG, PRELOADED_DIFFICULTY_LEVELS } from '../../data/preloadedScores';
@@ -33,6 +34,9 @@ export function ScoreSelectorPlugin({
   onLoadFile,
   onCancel,
   onSelectUserScore,
+  savedPractices,
+  onSelectSavedPractice,
+  onDeleteSavedPractice,
 }: PluginScoreSelectorProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { userScores, removeUserScore } = useUserScores();
@@ -135,6 +139,15 @@ export function ScoreSelectorPlugin({
                     removeUserScore(id);
                     deleteScoreFromIndexedDB(id).catch(() => {});
                   }}
+                />
+              )}
+
+              {/* Feature 056: Saved Practices section */}
+              {savedPractices && savedPractices.length > 0 && onSelectSavedPractice && onDeleteSavedPractice && (
+                <SavedPracticeList
+                  practices={savedPractices}
+                  onSelect={onSelectSavedPractice}
+                  onDelete={onDeleteSavedPractice}
                 />
               )}
             </div>

--- a/frontend/src/plugin-api/index.ts
+++ b/frontend/src/plugin-api/index.ts
@@ -47,3 +47,8 @@ export { PLUGIN_API_VERSION } from './types';
 // Utility classes exposed to plugins (no API version bump — additive)
 export { ChordDetector } from '../utils/chordDetector';
 export type { ChordDetectorOptions, ChordResult } from '../utils/chordDetector';
+
+// Feature 056: Saved practice types and storage services
+export type { ScoreRef, SavedPractice, SavedPerformanceData, SavedPracticeIndexEntry } from '../services/savedPractice.types';
+export { savePracticeToIndexedDB, generatePracticeName, loadPracticeFromIndexedDB, deletePracticeFromIndexedDB } from '../services/savedPracticeStorage';
+export { addSavedPracticeIndex, listSavedPractices, removeSavedPracticeIndex } from '../services/savedPracticeIndex';

--- a/frontend/src/plugin-api/types.ts
+++ b/frontend/src/plugin-api/types.ts
@@ -391,6 +391,19 @@ export interface PluginScoreSelectorProps {
    * User scores and delete are managed internally by the host component.
    */
   onSelectUserScore?: (id: string) => void;
+  /**
+   * Feature 056: Saved practices to show in the "Saved Practices" section.
+   * Lightweight index entries sorted newest-first.
+   */
+  savedPractices?: ReadonlyArray<import('../services/savedPractice.types').SavedPracticeIndexEntry>;
+  /**
+   * Feature 056: Called when the user selects a saved practice to load.
+   */
+  onSelectSavedPractice?: (practice: import('../services/savedPractice.types').SavedPracticeIndexEntry) => void;
+  /**
+   * Feature 056: Called when the user deletes a saved practice.
+   */
+  onDeleteSavedPractice?: (id: string) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/services/savedPractice.types.ts
+++ b/frontend/src/services/savedPractice.types.ts
@@ -1,0 +1,75 @@
+/**
+ * savedPractice.types.ts — Shared type definitions for saved practice feature.
+ * Feature 056: Save and Load Practices
+ *
+ * Defines the data model for persisting practice sessions.
+ * Full data is stored in IndexedDB; lightweight index entries in localStorage.
+ */
+import type { PluginPracticeNoteEntry } from '../plugin-api/types';
+import type { PracticeNoteResult, WrongNoteEvent } from '../../plugins/practice-view-plugin/practiceEngine.types';
+
+// ---------------------------------------------------------------------------
+// Score Reference
+// ---------------------------------------------------------------------------
+
+/** Reference to identify and load the original score. */
+export interface ScoreRef {
+  /** Source type of the score. */
+  type: 'preloaded' | 'user';
+  /** Filename for preloaded scores (e.g., `Beethoven_FurElise.mxl`), IndexedDB UUID for user-uploaded scores. */
+  id: string;
+}
+
+// ---------------------------------------------------------------------------
+// Performance Data
+// ---------------------------------------------------------------------------
+
+/** Serializable copy of the performance record, covering both complete and partial sessions. */
+export interface SavedPerformanceData {
+  notes: PluginPracticeNoteEntry[];
+  noteResults: PracticeNoteResult[];
+  wrongNoteEvents: WrongNoteEvent[];
+  bpmAtCompletion: number;
+  /** Non-null for partial practices. */
+  stoppedAtIndex: number | null;
+  /** Non-null for partial practices. */
+  totalNoteCount: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Full Saved Practice (IndexedDB `practices` store)
+// ---------------------------------------------------------------------------
+
+/** Complete persisted record of a practice session, including all performance data for replay. */
+export interface SavedPractice {
+  /** UUID v4. */
+  id: string;
+  /** Auto-generated: {score_name}-{hand}-{scope}-{datetime}. */
+  name: string;
+  /** ISO 8601 timestamp of when the practice was saved. */
+  savedAt: string;
+  scoreRef: ScoreRef;
+  scoreTitle: string;
+  /** 0 = RH, 1 = LH, -1 = BH. */
+  staffIndex: number;
+  loopRegion: { startTick: number; endTick: number } | null;
+  tempoMultiplier: number;
+  loopCount: number;
+  completionStatus: 'complete' | 'partial';
+  performanceData: SavedPerformanceData;
+}
+
+// ---------------------------------------------------------------------------
+// Lightweight Index Entry (localStorage)
+// ---------------------------------------------------------------------------
+
+/** Minimal metadata for fast list rendering in the load score dialog. No performance data. */
+export interface SavedPracticeIndexEntry {
+  /** Same UUID as SavedPractice.id. */
+  id: string;
+  name: string;
+  /** ISO 8601. */
+  savedAt: string;
+  completionStatus: 'complete' | 'partial';
+  scoreTitle: string;
+}

--- a/frontend/src/services/savedPracticeIndex.ts
+++ b/frontend/src/services/savedPracticeIndex.ts
@@ -1,0 +1,85 @@
+/**
+ * savedPracticeIndex.ts — Metadata index for saved practices.
+ * Feature 056: Save and Load Practices
+ *
+ * Stores lightweight display metadata in localStorage (graditone-saved-practices-index).
+ * Full practice data lives separately in IndexedDB (via savedPracticeStorage.ts).
+ * All functions are synchronous over localStorage.
+ */
+import type { SavedPracticeIndexEntry } from './savedPractice.types';
+
+/** localStorage key for the JSON-serialised SavedPracticeIndexEntry[] index. */
+export const SAVED_PRACTICES_INDEX_KEY = 'graditone-saved-practices-index';
+
+/** Maximum number of saved practices to keep. Oldest are evicted first. */
+export const MAX_SAVED_PRACTICES = 100;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function readIndex(): SavedPracticeIndexEntry[] {
+  try {
+    const raw = localStorage.getItem(SAVED_PRACTICES_INDEX_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as SavedPracticeIndexEntry[];
+  } catch {
+    return [];
+  }
+}
+
+function writeIndex(index: SavedPracticeIndexEntry[]): void {
+  localStorage.setItem(SAVED_PRACTICES_INDEX_KEY, JSON.stringify(index));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Return all saved practices, sorted descending by savedAt (newest first).
+ */
+export function listSavedPractices(): SavedPracticeIndexEntry[] {
+  const index = readIndex();
+  // Ensure sorted newest-first (should already be, but defensive)
+  index.sort((a, b) => b.savedAt.localeCompare(a.savedAt));
+  return index;
+}
+
+/**
+ * Add a new entry to the index.
+ *
+ * Eviction: if the index exceeds MAX_SAVED_PRACTICES, the oldest entries are
+ * removed. Their IDs are returned so callers can clean up IndexedDB.
+ *
+ * @returns Object with any evicted practice IDs.
+ */
+export function addSavedPracticeIndex(
+  entry: SavedPracticeIndexEntry,
+): { evictedIds: string[] } {
+  const index = readIndex();
+
+  // Insert at head (newest first)
+  index.unshift(entry);
+
+  // Re-sort newest first
+  index.sort((a, b) => b.savedAt.localeCompare(a.savedAt));
+
+  // Evict oldest entries beyond the limit
+  const evictedIds: string[] = [];
+  while (index.length > MAX_SAVED_PRACTICES) {
+    const removed = index.pop();
+    if (removed) evictedIds.push(removed.id);
+  }
+
+  writeIndex(index);
+  return { evictedIds };
+}
+
+/**
+ * Remove an entry by ID. No-op if not found.
+ */
+export function removeSavedPracticeIndex(id: string): void {
+  const index = readIndex().filter((p) => p.id !== id);
+  writeIndex(index);
+}

--- a/frontend/src/services/savedPracticeStorage.ts
+++ b/frontend/src/services/savedPracticeStorage.ts
@@ -1,0 +1,107 @@
+/**
+ * savedPracticeStorage.ts — IndexedDB storage for full practice data.
+ * Feature 056: Save and Load Practices
+ *
+ * Stores and retrieves complete SavedPractice records in the IndexedDB `practices` store.
+ * Uses the shared openDB() from local-storage.ts (DB version 2).
+ */
+import { openDB } from './storage/local-storage';
+import type { SavedPractice } from './savedPractice.types';
+
+const PRACTICES_STORE = 'practices';
+
+// ---------------------------------------------------------------------------
+// IndexedDB CRUD
+// ---------------------------------------------------------------------------
+
+/** Save full practice data to IndexedDB 'practices' store. */
+export async function savePracticeToIndexedDB(practice: SavedPractice): Promise<void> {
+  const db = await openDB();
+  try {
+    const tx = db.transaction([PRACTICES_STORE], 'readwrite');
+    const store = tx.objectStore(PRACTICES_STORE);
+    await new Promise<void>((resolve, reject) => {
+      const request = store.put(practice);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(new Error(`Failed to save practice: ${request.error?.message}`));
+    });
+    console.log(`[IndexedDB] Practice ${practice.id} saved successfully`);
+  } finally {
+    db.close();
+  }
+}
+
+/** Load full practice data by ID. Returns null if not found. */
+export async function loadPracticeFromIndexedDB(id: string): Promise<SavedPractice | null> {
+  const db = await openDB();
+  try {
+    const tx = db.transaction([PRACTICES_STORE], 'readonly');
+    const store = tx.objectStore(PRACTICES_STORE);
+    const record = await new Promise<SavedPractice | null>((resolve, reject) => {
+      const request = store.get(id);
+      request.onsuccess = () => resolve((request.result as SavedPractice) ?? null);
+      request.onerror = () => reject(new Error(`Failed to load practice: ${request.error?.message}`));
+    });
+    return record;
+  } finally {
+    db.close();
+  }
+}
+
+/** Delete a practice from IndexedDB by ID. */
+export async function deletePracticeFromIndexedDB(id: string): Promise<void> {
+  const db = await openDB();
+  try {
+    const tx = db.transaction([PRACTICES_STORE], 'readwrite');
+    const store = tx.objectStore(PRACTICES_STORE);
+    await new Promise<void>((resolve, reject) => {
+      const request = store.delete(id);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(new Error(`Failed to delete practice: ${request.error?.message}`));
+    });
+    console.log(`[IndexedDB] Practice ${id} deleted`);
+  } finally {
+    db.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Name Generation (pure function)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate the practice name per FR-002.
+ *
+ * Format: {sanitized_title}-{RH|LH|BH}-{all|region}-{YYYYMMDDTHHmmss}
+ *
+ * @param scoreTitle  - Display title of the score.
+ * @param staffIndex  - 0 = RH, 1 = LH, -1 = BH.
+ * @param loopRegion  - Non-null when a loop region is active.
+ * @param date        - Date/time of saving (local time).
+ */
+export function generatePracticeName(
+  scoreTitle: string,
+  staffIndex: number,
+  loopRegion: { startTick: number; endTick: number } | null,
+  date: Date,
+): string {
+  // Sanitize: replace spaces with underscores, remove non-alphanumeric (except underscores), truncate
+  const sanitized = scoreTitle
+    .replace(/\s+/g, '_')
+    .replace(/[^A-Za-z0-9_]/g, '')
+    .slice(0, 50);
+
+  // Map staff index to hand label
+  const hand = staffIndex === 0 ? 'RH' : staffIndex === 1 ? 'LH' : 'BH';
+
+  // Scope
+  const scope = loopRegion ? 'region' : 'all';
+
+  // Datetime in compact ISO-like local format: YYYYMMDDTHHmmss
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const datetime =
+    `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}` +
+    `T${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+
+  return `${sanitized}-${hand}-${scope}-${datetime}`;
+}

--- a/frontend/src/services/storage/local-storage.ts
+++ b/frontend/src/services/storage/local-storage.ts
@@ -4,8 +4,9 @@
 import type { Score } from '../../types/score';
 
 const DB_NAME = 'graditone-db';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const SCORES_STORE = 'scores';
+const PRACTICES_STORE = 'practices';
 
 /** Result from loadScoreFromIndexedDB when the cached schema is stale but a raw blob exists. */
 export interface StaleScoreResult {
@@ -30,7 +31,7 @@ export type ScoreLoadResult = LoadedScoreResult | StaleScoreResult | NotFoundSco
  * Initialize IndexedDB database
  * @returns Promise<IDBDatabase>
  */
-async function openDB(): Promise<IDBDatabase> {
+export async function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
 
@@ -50,6 +51,13 @@ async function openDB(): Promise<IDBDatabase> {
         const objectStore = db.createObjectStore(SCORES_STORE, { keyPath: 'id' });
         objectStore.createIndex('lastModified', 'lastModified', { unique: false });
         console.log('[IndexedDB] Scores object store created');
+      }
+
+      // Feature 056: Create practices object store if it doesn't exist
+      if (!db.objectStoreNames.contains(PRACTICES_STORE)) {
+        const practicesStore = db.createObjectStore(PRACTICES_STORE, { keyPath: 'id' });
+        practicesStore.createIndex('savedAt', 'savedAt', { unique: false });
+        console.log('[IndexedDB] Practices object store created');
       }
     };
   });

--- a/frontend/tests/components/SavedPracticeList.test.tsx
+++ b/frontend/tests/components/SavedPracticeList.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * SavedPracticeList.test.tsx — Component tests for SavedPracticeList
+ * Feature 056: Save and Load Practices (T010)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SavedPracticeList } from '../../src/components/load-score/SavedPracticeList';
+import type { SavedPracticeIndexEntry } from '../../src/services/savedPractice.types';
+
+const makePractice = (overrides: Partial<SavedPracticeIndexEntry> = {}): SavedPracticeIndexEntry => ({
+  id: crypto.randomUUID(),
+  name: 'FurElise-RH-all-20260325T140000',
+  savedAt: '2026-03-25T14:00:00.000Z',
+  completionStatus: 'complete',
+  scoreTitle: 'Für Elise',
+  ...overrides,
+});
+
+describe('SavedPracticeList', () => {
+  it('returns null when practices is empty', () => {
+    const { container } = render(
+      <SavedPracticeList practices={[]} onSelect={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders list sorted by date (most recent first when passed in order)', () => {
+    const practices = [
+      makePractice({ id: 'a', name: 'Practice-A', savedAt: '2026-03-26T10:00:00Z' }),
+      makePractice({ id: 'b', name: 'Practice-B', savedAt: '2026-03-25T10:00:00Z' }),
+    ];
+    render(<SavedPracticeList practices={practices} onSelect={vi.fn()} onDelete={vi.fn()} />);
+    const items = screen.getAllByRole('listitem');
+    expect(items[0].querySelector('.saved-practice-item__name')!.textContent).toBe('Practice-A');
+    expect(items[1].querySelector('.saved-practice-item__name')!.textContent).toBe('Practice-B');
+  });
+
+  it('fires onSelect with the practice entry when clicked', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const practice = makePractice({ name: 'My-Practice' });
+    render(<SavedPracticeList practices={[practice]} onSelect={onSelect} onDelete={vi.fn()} />);
+    await user.click(screen.getByText('My-Practice'));
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(practice);
+  });
+
+  it('fires onDelete with practice id when delete button is clicked', async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    const practice = makePractice({ name: 'Delete-Me' });
+    render(<SavedPracticeList practices={[practice]} onSelect={vi.fn()} onDelete={onDelete} />);
+    await user.click(screen.getByRole('button', { name: /Delete Delete-Me/ }));
+    expect(onDelete).toHaveBeenCalledOnce();
+    expect(onDelete).toHaveBeenCalledWith(practice.id);
+  });
+
+  it('renders partial badge for partial practices', () => {
+    const practice = makePractice({ completionStatus: 'partial' });
+    render(<SavedPracticeList practices={[practice]} onSelect={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.getByText('Partial')).toBeDefined();
+  });
+
+  it('does not render partial badge for complete practices', () => {
+    const practice = makePractice({ completionStatus: 'complete' });
+    render(<SavedPracticeList practices={[practice]} onSelect={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.queryByText('Partial')).toBeNull();
+  });
+
+  it('disables all buttons when disabled prop is true', () => {
+    const practice = makePractice();
+    render(
+      <SavedPracticeList practices={[practice]} disabled onSelect={vi.fn()} onDelete={vi.fn()} />,
+    );
+    const buttons = screen.getAllByRole('button');
+    for (const btn of buttons) {
+      expect((btn as HTMLButtonElement).disabled).toBe(true);
+    }
+  });
+
+  it('shows practice count in summary', () => {
+    const practices = [makePractice(), makePractice()];
+    render(<SavedPracticeList practices={practices} onSelect={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.getByText(/Saved Practices \(2\)/)).toBeDefined();
+  });
+});

--- a/frontend/tests/services/savedPracticeIndex.test.ts
+++ b/frontend/tests/services/savedPracticeIndex.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit Tests: savedPracticeIndex
+ * Feature 056: Save and Load Practices
+ *
+ * Constitution Principle V: Test-First Development
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  listSavedPractices,
+  addSavedPracticeIndex,
+  removeSavedPracticeIndex,
+  SAVED_PRACTICES_INDEX_KEY,
+  MAX_SAVED_PRACTICES,
+} from '../../src/services/savedPracticeIndex';
+import type { SavedPracticeIndexEntry } from '../../src/services/savedPractice.types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<SavedPracticeIndexEntry> = {}): SavedPracticeIndexEntry {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    name: overrides.name ?? 'Test-RH-all-20260325T120000',
+    savedAt: overrides.savedAt ?? new Date().toISOString(),
+    completionStatus: overrides.completionStatus ?? 'complete',
+    scoreTitle: overrides.scoreTitle ?? 'Test Score',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('savedPracticeIndex', () => {
+  beforeEach(() => {
+    localStorage.removeItem(SAVED_PRACTICES_INDEX_KEY);
+  });
+
+  describe('listSavedPractices', () => {
+    it('returns empty array when no practices saved', () => {
+      expect(listSavedPractices()).toEqual([]);
+    });
+
+    it('returns practices sorted by savedAt descending (newest first)', () => {
+      const older = makeEntry({ savedAt: '2026-03-24T10:00:00.000Z', name: 'older' });
+      const newer = makeEntry({ savedAt: '2026-03-25T10:00:00.000Z', name: 'newer' });
+      addSavedPracticeIndex(older);
+      addSavedPracticeIndex(newer);
+      const list = listSavedPractices();
+      expect(list[0].name).toBe('newer');
+      expect(list[1].name).toBe('older');
+    });
+
+    it('handles corrupted localStorage gracefully', () => {
+      localStorage.setItem(SAVED_PRACTICES_INDEX_KEY, 'not-json');
+      expect(listSavedPractices()).toEqual([]);
+    });
+  });
+
+  describe('addSavedPracticeIndex', () => {
+    it('adds an entry and persists it', () => {
+      const entry = makeEntry();
+      addSavedPracticeIndex(entry);
+      const list = listSavedPractices();
+      expect(list).toHaveLength(1);
+      expect(list[0].id).toBe(entry.id);
+    });
+
+    it('returns empty evictedIds when under limit', () => {
+      const entry = makeEntry();
+      const { evictedIds } = addSavedPracticeIndex(entry);
+      expect(evictedIds).toEqual([]);
+    });
+
+    it('evicts oldest entries when exceeding MAX_SAVED_PRACTICES', () => {
+      // Fill to max
+      const entries: SavedPracticeIndexEntry[] = [];
+      for (let i = 0; i < MAX_SAVED_PRACTICES; i++) {
+        const entry = makeEntry({
+          savedAt: new Date(2026, 0, 1, 0, 0, i).toISOString(),
+        });
+        entries.push(entry);
+        addSavedPracticeIndex(entry);
+      }
+
+      // Add one more — the oldest should be evicted
+      const newEntry = makeEntry({
+        savedAt: new Date(2026, 6, 1).toISOString(),
+      });
+      const { evictedIds } = addSavedPracticeIndex(newEntry);
+      expect(evictedIds).toHaveLength(1);
+      // The evicted entry should be the oldest one (index 0 — earliest date)
+      expect(evictedIds[0]).toBe(entries[0].id);
+
+      const list = listSavedPractices();
+      expect(list).toHaveLength(MAX_SAVED_PRACTICES);
+      // Newest should be first
+      expect(list[0].id).toBe(newEntry.id);
+    });
+  });
+
+  describe('removeSavedPracticeIndex', () => {
+    it('removes an existing entry by ID', () => {
+      const entry = makeEntry();
+      addSavedPracticeIndex(entry);
+      expect(listSavedPractices()).toHaveLength(1);
+      removeSavedPracticeIndex(entry.id);
+      expect(listSavedPractices()).toHaveLength(0);
+    });
+
+    it('is a no-op for non-existent ID', () => {
+      const entry = makeEntry();
+      addSavedPracticeIndex(entry);
+      removeSavedPracticeIndex('non-existent-id');
+      expect(listSavedPractices()).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/tests/services/savedPracticeStorage.test.ts
+++ b/frontend/tests/services/savedPracticeStorage.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit Tests: savedPracticeStorage — generatePracticeName
+ * Feature 056: Save and Load Practices
+ *
+ * Constitution Principle V: Test-First Development
+ *
+ * Note: IndexedDB CRUD tests would require fake-indexeddb or similar.
+ * This file covers the pure generatePracticeName function thoroughly.
+ */
+import { describe, it, expect } from 'vitest';
+import { generatePracticeName } from '../../src/services/savedPracticeStorage';
+
+describe('generatePracticeName', () => {
+  const fixedDate = new Date(2026, 2, 25, 14, 30, 22); // 2026-03-25T14:30:22
+
+  it('generates name for RH full score practice', () => {
+    const name = generatePracticeName('Fur Elise', 0, null, fixedDate);
+    expect(name).toBe('Fur_Elise-RH-all-20260325T143022');
+  });
+
+  it('generates name for LH full score practice', () => {
+    const name = generatePracticeName('Arabesque', 1, null, fixedDate);
+    expect(name).toBe('Arabesque-LH-all-20260325T143022');
+  });
+
+  it('generates name for BH (both hands) with region', () => {
+    const name = generatePracticeName('Arabesque', -1, { startTick: 100, endTick: 500 }, fixedDate);
+    expect(name).toBe('Arabesque-BH-region-20260325T143022');
+  });
+
+  it('sanitizes special characters from title', () => {
+    const name = generatePracticeName("Nocturne Op.9 No.2 (Chopin's)", 0, null, fixedDate);
+    expect(name).toBe('Nocturne_Op9_No2_Chopins-RH-all-20260325T143022');
+  });
+
+  it('replaces spaces with underscores', () => {
+    const name = generatePracticeName('Canon In D Major', 0, null, fixedDate);
+    expect(name).toBe('Canon_In_D_Major-RH-all-20260325T143022');
+  });
+
+  it('truncates long titles to 50 characters', () => {
+    const longTitle = 'A'.repeat(60);
+    const name = generatePracticeName(longTitle, 0, null, fixedDate);
+    const titlePart = name.split('-')[0];
+    expect(titlePart).toHaveLength(50);
+  });
+
+  it('handles empty title', () => {
+    const name = generatePracticeName('', 0, null, fixedDate);
+    expect(name).toBe('-RH-all-20260325T143022');
+  });
+
+  it('pads single-digit month/day/hour/minute/second', () => {
+    const earlyDate = new Date(2026, 0, 5, 3, 7, 9); // 2026-01-05T03:07:09
+    const name = generatePracticeName('Test', 0, null, earlyDate);
+    expect(name).toBe('Test-RH-all-20260105T030709');
+  });
+
+  it('uses region scope when loopRegion is present', () => {
+    const name = generatePracticeName('Test', 0, { startTick: 0, endTick: 100 }, fixedDate);
+    expect(name).toContain('-region-');
+  });
+
+  it('uses all scope when loopRegion is null', () => {
+    const name = generatePracticeName('Test', 0, null, fixedDate);
+    expect(name).toContain('-all-');
+  });
+});

--- a/specs/056-save-load-practices/checklists/requirements.md
+++ b/specs/056-save-load-practices/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Save and Load Practices
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-03-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Assumptions section documents all informed defaults (naming format, storage approach, 100-practice limit, section placement).
+- No [NEEDS CLARIFICATION] markers needed — the user description was sufficiently detailed and remaining gaps were filled with reasonable defaults aligned with existing codebase patterns.

--- a/specs/056-save-load-practices/contracts/saved-practice-types.md
+++ b/specs/056-save-load-practices/contracts/saved-practice-types.md
@@ -1,0 +1,143 @@
+# Contract: Saved Practice Types
+
+**Feature**: 056-save-load-practices  
+**Date**: 2026-03-25
+
+## TypeScript Interfaces
+
+```typescript
+// --- Score Reference ---
+
+interface ScoreRef {
+  /** Source type of the score */
+  type: 'preloaded' | 'user';
+  /** Filename for preloaded scores, IndexedDB UUID for user-uploaded scores */
+  id: string;
+}
+
+// --- Performance Data (serializable subset of PerformanceRecord) ---
+
+interface SavedPerformanceData {
+  notes: PluginPracticeNoteEntry[];
+  noteResults: PracticeNoteResult[];
+  wrongNoteEvents: WrongNoteEvent[];
+  bpmAtCompletion: number;
+  /** Non-null for partial practices */
+  stoppedAtIndex: number | null;
+  /** Non-null for partial practices */
+  totalNoteCount: number | null;
+}
+
+// --- Full Saved Practice (IndexedDB `practices` store) ---
+
+interface SavedPractice {
+  /** UUID v4 */
+  id: string;
+  /** Auto-generated: {score_name}-{hand}-{scope}-{datetime} */
+  name: string;
+  /** ISO 8601 timestamp */
+  savedAt: string;
+  scoreRef: ScoreRef;
+  scoreTitle: string;
+  /** 0 = RH, 1 = LH, -1 = BH */
+  staffIndex: number;
+  loopRegion: { startTick: number; endTick: number } | null;
+  tempoMultiplier: number;
+  loopCount: number;
+  completionStatus: 'complete' | 'partial';
+  performanceData: SavedPerformanceData;
+}
+
+// --- Lightweight Index Entry (localStorage) ---
+
+interface SavedPracticeIndexEntry {
+  /** Same UUID as SavedPractice.id */
+  id: string;
+  name: string;
+  /** ISO 8601 */
+  savedAt: string;
+  completionStatus: 'complete' | 'partial';
+  scoreTitle: string;
+}
+```
+
+## Service Contracts
+
+### savedPracticeIndex.ts
+
+```typescript
+/** localStorage key: 'graditone-saved-practices-index' */
+/** Maximum entries: 100 */
+
+/** List all saved practices, sorted by savedAt descending (most recent first). */
+function listSavedPractices(): SavedPracticeIndexEntry[];
+
+/** Add a new entry to the index. Returns evicted IDs if limit exceeded. */
+function addSavedPracticeIndex(
+  entry: SavedPracticeIndexEntry
+): { evictedIds: string[] };
+
+/** Remove an entry by ID. No-op if not found. */
+function removeSavedPracticeIndex(id: string): void;
+```
+
+### savedPracticeStorage.ts
+
+```typescript
+/** Save full practice data to IndexedDB 'practices' store. */
+function savePracticeToIndexedDB(practice: SavedPractice): Promise<void>;
+
+/** Load full practice data by ID. Returns null if not found. */
+function loadPracticeFromIndexedDB(id: string): Promise<SavedPractice | null>;
+
+/** Delete a practice from IndexedDB by ID. */
+function deletePracticeFromIndexedDB(id: string): Promise<void>;
+```
+
+### Name Generation
+
+```typescript
+/** Pure function to generate the practice name per FR-002. */
+function generatePracticeName(
+  scoreTitle: string,
+  staffIndex: number,
+  loopRegion: { startTick: number; endTick: number } | null,
+  date: Date
+): string;
+```
+
+## Component Contracts
+
+### SavedPracticeList
+
+```typescript
+interface SavedPracticeListProps {
+  practices: ReadonlyArray<SavedPracticeIndexEntry>;
+  disabled?: boolean;
+  onSelect: (practice: SavedPracticeIndexEntry) => void;
+  onDelete: (id: string) => void;
+}
+```
+
+### ResultsOverlay (additional props)
+
+```typescript
+// Added to existing ResultsOverlayProps:
+interface ResultsOverlayProps {
+  // ... existing props ...
+  onSave?: () => void;
+  isSaved?: boolean;
+}
+```
+
+### LoadScoreDialog (additional props)
+
+```typescript
+// Added to existing LoadScoreDialogProps:
+interface LoadScoreDialogProps {
+  // ... existing props ...
+  savedPractices?: ReadonlyArray<SavedPracticeIndexEntry>;
+  onSelectSavedPractice?: (practice: SavedPracticeIndexEntry) => void;
+  onDeleteSavedPractice?: (id: string) => void;
+}
+```

--- a/specs/056-save-load-practices/data-model.md
+++ b/specs/056-save-load-practices/data-model.md
@@ -1,0 +1,130 @@
+# Data Model: Save and Load Practices
+
+**Feature**: 056-save-load-practices  
+**Date**: 2026-03-25
+
+## Entities
+
+### SavedPractice (Full Data — stored in IndexedDB)
+
+The complete persisted record of a practice session, including all performance data needed for replay.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes | UUID v4, unique identifier (primary key in IndexedDB) |
+| `name` | `string` | Yes | Auto-generated name: `{score_name}-{hand}-{scope}-{datetime}` |
+| `savedAt` | `string` | Yes | ISO 8601 timestamp of when the practice was saved |
+| `scoreRef` | `ScoreRef` | Yes | Reference to the original score (see below) |
+| `scoreTitle` | `string` | Yes | Display title of the score at time of saving |
+| `staffIndex` | `number` | Yes | Hand selection: 0 (RH), 1 (LH), -1 (BH) |
+| `loopRegion` | `{ startTick: number; endTick: number } \| null` | Yes | Loop region boundaries, or null for full score |
+| `tempoMultiplier` | `number` | Yes | Tempo multiplier at time of practice |
+| `loopCount` | `number` | Yes | Number of loops configured |
+| `completionStatus` | `'complete' \| 'partial'` | Yes | Whether practice was finished or stopped mid-session |
+| `performanceData` | `PerformanceData` | Yes | Full performance record for replay (see below) |
+
+### ScoreRef (Embedded in SavedPractice)
+
+Reference to identify and load the original score.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'preloaded' \| 'user'` | Yes | Source type of the score |
+| `id` | `string` | Yes | Filename for preloaded scores (e.g., `Beethoven_FurElise.mxl`), IndexedDB UUID for user-uploaded scores |
+
+### PerformanceData (Embedded in SavedPractice)
+
+Serializable copy of the performance record, covering both complete and partial sessions.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `notes` | `PluginPracticeNoteEntry[]` | Yes | The ordered note sequence that was practiced |
+| `noteResults` | `PracticeNoteResult[]` | Yes | Per-note outcome data |
+| `wrongNoteEvents` | `WrongNoteEvent[]` | Yes | Wrong note attempts during practice |
+| `bpmAtCompletion` | `number` | Yes | BPM when practice ended |
+| `stoppedAtIndex` | `number \| null` | Yes | Index where practice was stopped (null if complete) |
+| `totalNoteCount` | `number \| null` | Yes | Total notes in sequence (null if complete) |
+
+### SavedPracticeIndexEntry (Lightweight metadata — stored in localStorage)
+
+Minimal metadata for fast list rendering in the load score dialog. No performance data.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes | Same UUID as the full SavedPractice in IndexedDB |
+| `name` | `string` | Yes | Auto-generated practice name |
+| `savedAt` | `string` | Yes | ISO 8601 timestamp |
+| `completionStatus` | `'complete' \| 'partial'` | Yes | For visual distinction in the list |
+| `scoreTitle` | `string` | Yes | For display context |
+
+## Relationships
+
+```
+SavedPracticeIndex (localStorage)        SavedPractice (IndexedDB)
+┌──────────────────────┐                 ┌──────────────────────────┐
+│ id ─────────────────────────────────── │ id (primary key)         │
+│ name                 │                 │ name                     │
+│ savedAt              │                 │ savedAt                  │
+│ completionStatus     │                 │ scoreRef: ScoreRef       │
+│ scoreTitle           │                 │ scoreTitle               │
+└──────────────────────┘                 │ staffIndex               │
+                                         │ loopRegion               │
+                                         │ tempoMultiplier          │
+                                         │ loopCount                │
+                                         │ completionStatus         │
+                                         │ performanceData          │
+                                         └──────────┬───────────────┘
+                                                    │
+                                                    │ scoreRef.id
+                                                    ▼
+                                         ┌──────────────────────────┐
+                                         │ Score (IndexedDB scores) │
+                                         │ OR preloaded MXL file    │
+                                         └──────────────────────────┘
+```
+
+## Validation Rules
+
+1. `id` must be a valid UUID v4 string.
+2. `name` must match the pattern `{sanitized_title}-{RH|LH|BH}-{all|region}-{YYYYMMDDTHHmmss}`.
+3. `savedAt` must be a valid ISO 8601 string.
+4. `staffIndex` must be one of: -1, 0, 1.
+5. `completionStatus` must be `'complete'` or `'partial'`.
+6. If `completionStatus === 'partial'`, then `performanceData.stoppedAtIndex` and `performanceData.totalNoteCount` must be non-null numbers.
+7. If `completionStatus === 'complete'`, then `performanceData.stoppedAtIndex` and `performanceData.totalNoteCount` must be null.
+8. `scoreRef.type` must be `'preloaded'` or `'user'`.
+9. Maximum 100 entries in the index; oldest entries are evicted on overflow.
+
+## State Transitions
+
+```
+[Practice Active] ──complete──▶ [Results Overlay: Complete]
+                   ──stop────▶ [Results Overlay: Partial]
+
+[Results Overlay] ──click Save──▶ [Saving...]
+[Saving...] ──success──▶ [Saved ✓] (button disabled)
+[Saving...] ──failure──▶ [Save Error] (button re-enabled with error message)
+
+[Load Dialog] ──select practice──▶ [Loading Score...]
+[Loading Score...] ──score found──▶ [Results Overlay with saved data]
+[Loading Score...] ──score not found──▶ [Error: score unavailable]
+
+[Load Dialog] ──delete practice──▶ [Remove from index + IndexedDB]
+```
+
+## IndexedDB Schema
+
+**Database**: `graditone-db`  
+**Version**: 2 (bumped from 1)
+
+| Store | Key Path | Indexes | Version Added |
+|-------|----------|---------|---------------|
+| `scores` | `id` | `lastModified` (non-unique) | 1 |
+| `practices` | `id` | `savedAt` (non-unique) | 2 |
+
+## localStorage Keys
+
+| Key | Shape | Max Entries |
+|-----|-------|-------------|
+| `graditone-user-scores-index` | `UserScore[]` | 20 (existing) |
+| `graditone-saved-practices-index` | `SavedPracticeIndexEntry[]` | 100 (new) |

--- a/specs/056-save-load-practices/plan.md
+++ b/specs/056-save-load-practices/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Save and Load Practices
+
+**Branch**: `056-save-load-practices` | **Date**: 2026-03-25 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/056-save-load-practices/spec.md`
+
+## Summary
+
+Add the ability to save practice sessions from the results overlay and reload them from the load score dialog. A "Save" button is added to the results overlay button row. Saved practices are persisted using a two-tier storage pattern (localStorage index + IndexedDB for full data) following the existing UserScore architecture. A new "Saved Practices" collapsible section in the load score dialog lists saved practices by date, supporting selection (load + show results overlay) and deletion.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (frontend), React 18+
+**Primary Dependencies**: React, Vitest (testing), Vite (bundler)
+**Storage**: IndexedDB (`graditone-db`, new `practices` object store) + localStorage (lightweight index)
+**Testing**: Vitest with happy-dom environment
+**Target Platform**: Tablet devices (iPad/Surface/Android) — PWA, Chrome 57+, Safari 11+, Edge 16+
+**Project Type**: Web application (frontend-only for this feature — no backend/Rust changes needed)
+**Performance Goals**: Save < 2s, list 100 entries without scroll lag, offline-capable
+**Constraints**: <100 saved practices (oldest-first eviction), client-side only storage, 44×44px minimum touch targets
+**Scale/Scope**: Single-user local storage; up to 100 saved practices per browser
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Applicable? | Status | Notes |
+|-----------|------------|--------|-------|
+| I. Domain-Driven Design | Partially | PASS | New `SavedPractice` entity uses music domain terminology (score title, hand, region). No new domain logic in music engine. |
+| II. Hexagonal Architecture | Yes | PASS | Storage service acts as an adapter; UI components consume via service interface. No domain core changes. |
+| III. PWA Architecture | Yes | PASS | All data stored client-side (IndexedDB + localStorage). Works offline. No network dependency. |
+| IV. Precision & Fidelity | N/A | PASS | No timing calculations added; existing performance data stored as-is. |
+| V. Test-First Development | Yes | PASS | Unit tests for storage service, component tests for UI. TDD workflow. |
+| VI. Layout Engine Authority | N/A | PASS | No spatial/layout calculations involved. Pure UI + storage feature. |
+| VII. Regression Prevention | Yes | PASS | Any bugs discovered during implementation will get regression tests per constitution. |
+
+**Gate Result: PASS** — No violations. Feature is frontend-only, follows existing patterns, and adds no layout logic.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/056-save-load-practices/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+├── src/
+│   ├── components/
+│   │   └── load-score/
+│   │       ├── LoadScoreDialog.tsx        # MODIFY: add SavedPracticeList
+│   │       ├── SavedPracticeList.tsx       # NEW: list component
+│   │       └── SavedPracticeList.css       # NEW: styles
+│   └── services/
+│       ├── storage/
+│       │   └── local-storage.ts           # MODIFY: add practices object store (DB v2)
+│       ├── savedPracticeIndex.ts          # NEW: localStorage index service
+│       └── savedPracticeStorage.ts        # NEW: IndexedDB full-data service
+├── plugins/
+│   └── practice-view-plugin/
+│       ├── ResultsOverlay.tsx             # MODIFY: add Save button
+│       ├── ResultsOverlay.css             # MODIFY: Save button styles
+│       └── PracticeViewPlugin.tsx         # MODIFY: wire save callback + state
+└── tests/
+    ├── services/
+    │   ├── savedPracticeIndex.test.ts     # NEW
+    │   └── savedPracticeStorage.test.ts   # NEW
+    └── components/
+        └── SavedPracticeList.test.tsx     # NEW
+```
+
+**Structure Decision**: Frontend-only web application. Follows the existing `UserScore` two-tier storage pattern (localStorage index + IndexedDB data). New components follow the `UserScoreList` pattern for the load score dialog section. The Save button is added to the existing `ResultsOverlay` component in the practice-view plugin.
+
+## Complexity Tracking
+
+No constitution violations requiring justification.

--- a/specs/056-save-load-practices/quickstart.md
+++ b/specs/056-save-load-practices/quickstart.md
@@ -1,0 +1,87 @@
+# Quickstart: Save and Load Practices
+
+**Feature**: 056-save-load-practices  
+**Date**: 2026-03-25
+
+## Overview
+
+This feature adds the ability to save practice sessions and reload them later. It involves three user-facing capabilities:
+
+1. **Save** — A button in the results overlay persists the current practice (complete or partial) to browser storage.
+2. **Load** — A new "Saved Practices" section in the load score dialog lets users select a saved practice to restore.
+3. **Delete** — Each saved practice in the list can be removed.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    React Components                      │
+│                                                          │
+│  ResultsOverlay          LoadScoreDialog                 │
+│  ┌──────────────┐       ┌──────────────────────┐        │
+│  │ Save button   │       │ SavedPracticeList     │        │
+│  │ → onSave()   │       │ → onSelect(practice)  │        │
+│  │ → isSaved    │       │ → onDelete(id)        │        │
+│  └──────┬───────┘       └──────────┬───────────┘        │
+│         │                          │                     │
+└─────────┼──────────────────────────┼─────────────────────┘
+          │                          │
+          ▼                          ▼
+┌─────────────────────────────────────────────────────────┐
+│                    Service Layer                         │
+│                                                          │
+│  savedPracticeIndex.ts     savedPracticeStorage.ts       │
+│  (localStorage metadata)   (IndexedDB full data)         │
+│                                                          │
+│  generatePracticeName()    savePracticeToIndexedDB()      │
+│  listSavedPractices()      loadPracticeFromIndexedDB()    │
+│  addSavedPracticeIndex()   deletePracticeFromIndexedDB()  │
+│  removeSavedPracticeIndex()                               │
+└─────────────────────────────────────────────────────────┘
+          │                          │
+          ▼                          ▼
+┌──────────────────┐    ┌──────────────────────┐
+│   localStorage    │    │      IndexedDB        │
+│   (index only)    │    │ graditone-db v2       │
+│                   │    │ store: practices      │
+└──────────────────┘    └──────────────────────┘
+```
+
+## Key Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `frontend/src/services/savedPracticeIndex.ts` | NEW | localStorage index CRUD |
+| `frontend/src/services/savedPracticeStorage.ts` | NEW | IndexedDB practice CRUD |
+| `frontend/src/services/storage/local-storage.ts` | MODIFY | Bump DB version to 2, add `practices` store |
+| `frontend/src/components/load-score/SavedPracticeList.tsx` | NEW | List component for load dialog |
+| `frontend/src/components/load-score/SavedPracticeList.css` | NEW | Styles for list component |
+| `frontend/src/components/load-score/LoadScoreDialog.tsx` | MODIFY | Add SavedPracticeList section + props |
+| `frontend/plugins/practice-view-plugin/ResultsOverlay.tsx` | MODIFY | Add Save button to button row |
+| `frontend/plugins/practice-view-plugin/ResultsOverlay.css` | MODIFY | Save button styles |
+| `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx` | MODIFY | Wire save logic, manage saved state |
+
+## Implementation Order
+
+1. **Storage layer** — `savedPracticeIndex.ts` + `savedPracticeStorage.ts` + DB version bump
+2. **Name generation** — `generatePracticeName()` pure function (in storage service or utility)
+3. **Save button** — Modify ResultsOverlay + PracticeViewPlugin
+4. **List component** — `SavedPracticeList.tsx`
+5. **Load dialog integration** — Modify LoadScoreDialog
+6. **Load flow** — Wire practice selection to score loading + results overlay display
+7. **Delete flow** — Wire delete button to storage removal
+
+## Testing Strategy
+
+- **Unit tests**: `savedPracticeIndex.test.ts` (localStorage mocking), `generatePracticeName` tests
+- **Unit tests**: `savedPracticeStorage.test.ts` (IndexedDB mocking via fake-indexeddb or similar)
+- **Component tests**: `SavedPracticeList.test.tsx` (render, select, delete interactions)
+- **Integration**: ResultsOverlay with Save button behavior (save → disabled state)
+- **E2E**: Full save → load → replay flow (Playwright, if applicable)
+
+## Patterns to Follow
+
+- **UserScoreList** for list component structure
+- **userScoreIndex.ts** for localStorage index service pattern
+- **local-storage.ts** for IndexedDB service pattern
+- **ScoreGroupList** for `<details>/<summary>` collapsible section pattern

--- a/specs/056-save-load-practices/research.md
+++ b/specs/056-save-load-practices/research.md
@@ -1,0 +1,100 @@
+# Research: Save and Load Practices
+
+**Feature**: 056-save-load-practices  
+**Date**: 2026-03-25  
+**Status**: Complete
+
+## Research Tasks
+
+### R1: IndexedDB Schema Migration Strategy
+
+**Context**: Adding a new `practices` object store to the existing `graditone-db` IndexedDB database requires a version bump and schema upgrade.
+
+**Decision**: Bump DB version from 1 to 2, add `practices` store in `onupgradeneeded`.
+
+**Rationale**: The existing `openDB()` function already guards store creation with `db.objectStoreNames.contains()`, so bumping the version and adding a second conditional block is safe. Existing `scores` store is untouched.
+
+**Alternatives considered**:
+- *Separate database for practices*: Rejected — adds complexity, no benefit. Single DB with multiple stores is the standard IndexedDB pattern.
+- *Store everything in localStorage*: Rejected — PerformanceRecord data (note results, wrong note events) can be large for long pieces. localStorage has a ~5MB limit; IndexedDB has much higher limits (~50MB+ depending on browser).
+
+### R2: Two-Tier Storage Pattern (Index + Data)
+
+**Context**: Need fast listing of saved practices (for the load dialog) without loading full performance data.
+
+**Decision**: Follow the existing `UserScore` pattern — lightweight metadata index in localStorage, full data in IndexedDB.
+
+**Rationale**: Proven pattern already used in the codebase (`userScoreIndex.ts` + `local-storage.ts`). localStorage reads are synchronous and fast for rendering the list. IndexedDB is async but only needed when actually loading a practice for replay.
+
+**Alternatives considered**:
+- *IndexedDB-only with cursor listing*: Rejected — requires async operations just to populate the list, adds complexity to the load dialog rendering.
+- *localStorage-only*: Rejected — PerformanceRecord data is too large for localStorage's ~5MB limit.
+
+### R3: Save Button Placement and State Management
+
+**Context**: The Save button needs to integrate into the existing ResultsOverlay button row alongside Repractice and Replay.
+
+**Decision**: Add a "Save" button as a third element in `.practice-results__replay-row`. State managed via a `savedThisSession` boolean in ResultsOverlay (reset when a new practice starts). Button transitions from "💾 Save" → "✓ Saved" (disabled) after click.
+
+**Rationale**: Inline state change (no toast/popup) matches the overlay's existing minimal UI pattern. The Repractice and Replay buttons don't use external notifications either. The `savedThisSession` flag is local to the component and resets naturally when the practice state changes to inactive then back to complete.
+
+**Alternatives considered**:
+- *Toast notification*: Rejected per clarification — inline button state preferred by user.
+- *Save button in toolbar instead of overlay*: Rejected — user explicitly requested it in the results overlay next to Replay.
+
+### R4: Practice Name Generation
+
+**Context**: Names follow `{score_name}-{hand}-{scope}-{datetime}` format.
+
+**Decision**: Implement a pure function `generatePracticeName(title, staffIndex, loopRegion, date)` that:
+1. Sanitizes score title: replace spaces with underscores, remove non-alphanumeric characters (except underscores), truncate to 50 chars.
+2. Maps staff index: 0 → "RH", 1 → "LH", -1 → "BH".
+3. Maps scope: `loopRegion !== null` → "region", otherwise → "all".
+4. Formats datetime: `YYYYMMDDTHHmmss` in local time.
+
+**Rationale**: Pure function is easily unit-testable. Truncation at 50 chars prevents excessively long names from dominating the list UI. Using local time matches the clarification that timezone indicator is unnecessary.
+
+### R5: Score Reference Strategy for Loading
+
+**Context**: When loading a saved practice, the system must find and load the original score.
+
+**Decision**: Store a `scoreRef` object containing `{ type: 'preloaded' | 'user', id: string }`. For preloaded scores, `id` is the MXL filename (e.g., `Beethoven_FurElise.mxl`). For user-uploaded scores, `id` is the UUID stored in IndexedDB.
+
+**Rationale**: Preloaded scores are always available (bundled with the app). User scores may be deleted, so the system must handle the "score not found" case gracefully per the edge case defined in the spec.
+
+**Alternatives considered**:
+- *Store only the title*: Rejected — titles can repeat (e.g., two user scores named "Practice Piece").
+- *Store full score data in the practice*: Rejected — doubles storage usage for no benefit.
+
+### R6: SavedPracticeList Component Pattern
+
+**Context**: The load score dialog needs a new collapsible section for saved practices.
+
+**Decision**: Follow the `UserScoreList` component pattern exactly:
+- Section with `<details>/<summary>` for collapse (collapsed by default, matching ScoreGroupList pattern).
+- `<ul role="list">` with list items.
+- Each item: select button (name + date + partial indicator) + delete button.
+- Returns `null` when empty (section hidden).
+
+**Rationale**: Consistent UI patterns across the load dialog. The `<details>/<summary>` pattern is already used by `ScoreGroupList` for collapsible sections. Touch targets ≥ 44×44px per constitution.
+
+### R7: Load Flow — Score Load + Results Overlay
+
+**Context**: Loading a saved practice must load the score, restore settings, and show the results overlay immediately.
+
+**Decision**: The load flow is:
+1. User selects practice from list → dialog closes.
+2. System loads the referenced score (preloaded or user).
+3. System restores hand selection (`selectedStaffIndex`) and loop region.
+4. System sets the `performanceRecord` (or `partialPerformanceRecord`) from saved data.
+5. System sets `resultsOverlayVisible = true` — results overlay appears with stats and Replay button.
+
+**Rationale**: Matches clarification answer (Option A). The `PracticeViewPlugin` already has state for `performanceRecord`, `resultsOverlayVisible`, and `loopRegion` — the load flow just needs to set these from saved data instead of from a live practice session.
+
+### R8: Maximum Practices Limit and Eviction
+
+**Context**: Spec requires max 100 practices with oldest-first eviction.
+
+**Decision**: Enforce in `addSavedPractice()` — check index length before inserting. If at limit, remove the oldest entry (last in the date-sorted list) from both localStorage index and IndexedDB. Return evicted IDs so callers can handle if needed (same pattern as `addUserScore`).
+
+**Rationale**: Follows the `addUserScore` eviction pattern exactly. 100 is generous but bounded.

--- a/specs/056-save-load-practices/spec.md
+++ b/specs/056-save-load-practices/spec.md
@@ -1,0 +1,124 @@
+# Feature Specification: Save and Load Practices
+
+**Feature Branch**: `056-save-load-practices`  
+**Created**: 2025-03-25  
+**Status**: Draft  
+**Input**: User description: "When the user ends a practice, in the results overlay a new button next to Replay must be added to save the practice. The name of the saved practice must be: score_name-RH/LH/BH-all/region-datetime. The saved practices must appear as a new collapsed section in the load score dialog. From this section, practices can be loaded to reproduce them. They can also be removed. The practices must be ordered by date."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Save a Completed Practice (Priority: P1)
+
+A user finishes practicing a piece (or a region of a piece) and wants to save the practice session so they can review it later. After the practice ends and the results overlay appears, the user clicks a "Save" button located next to the existing Replay button. The practice is saved with an automatically generated name following the convention `score_name-RH/LH/BH-all/region-datetime` and the user sees confirmation that the practice was saved.
+
+**Why this priority**: This is the foundational action—without the ability to save practices, there is nothing to load or manage. It is the core value of the feature.
+
+**Independent Test**: Can be fully tested by completing a practice session and clicking Save. Delivers immediate value by persisting the practice for future reference.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has completed a full practice of "Fur Elise" with Right Hand selected and no loop region, **When** the user clicks "Save" in the results overlay, **Then** the practice is saved with the name `Fur_Elise-RH-all-20250325T143022` and the button text changes to "✓ Saved" (disabled).
+2. **Given** the user has completed a practice of "Arabesque" with Both Hands on a specific region (measures 5–12), **When** the user clicks "Save", **Then** the practice is saved with the name `Arabesque-BH-region-20250325T150500`.
+3. **Given** the user has stopped a practice mid-session (partial results), **When** the results overlay appears, **Then** the "Save" button is available and the partial practice can be saved.
+4. **Given** the user has already saved a practice, **When** viewing the results overlay, **Then** the Save button shows "✓ Saved" in a disabled state and cannot be clicked again.
+
+---
+
+### User Story 2 - Load a Saved Practice (Priority: P2)
+
+A user wants to revisit a past practice session. They open the load score dialog and see a new collapsed section titled "Saved Practices". Upon expanding it, they see a list of previously saved practices ordered by date (most recent first). The user selects a saved practice to load it and replay the performance.
+
+**Why this priority**: Loading is the primary reason users save practices—to review past performances. Without this, saving has no purpose.
+
+**Independent Test**: Can be tested by first saving a practice, then opening the load dialog, expanding "Saved Practices", and selecting a saved practice. The practice is loaded and the user can replay it.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has previously saved at least one practice, **When** the user opens the load score dialog, **Then** a collapsed "Saved Practices" section is visible in the left panel.
+2. **Given** the "Saved Practices" section is collapsed, **When** the user clicks to expand it, **Then** a list of saved practices is shown ordered by date (most recent first), each displaying the practice name.
+3. **Given** the list of saved practices is visible, **When** the user selects a saved practice, **Then** the corresponding score is loaded with the same hand selection and region, and the results overlay appears immediately displaying the saved performance stats with the Replay button ready.
+4. **Given** no practices have been saved yet, **When** the user opens the load score dialog, **Then** the "Saved Practices" section is either hidden or shows an empty state message such as "No saved practices yet".
+
+---
+
+### User Story 3 - Delete a Saved Practice (Priority: P3)
+
+A user wants to remove an old or unwanted saved practice from their list. In the "Saved Practices" section of the load score dialog, each practice entry has a delete action. The user deletes a practice and it is removed from the list and from storage.
+
+**Why this priority**: Management of saved practices is important to prevent clutter, but it is secondary to the core save/load functionality.
+
+**Independent Test**: Can be tested by saving a practice, opening the load dialog, and deleting it. The practice should disappear from the list.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has expanded the "Saved Practices" section, **When** they click the delete action on a saved practice, **Then** the practice is removed from the list and from persistent storage.
+2. **Given** the user deletes the last remaining saved practice, **When** the deletion completes, **Then** the section shows an empty state or hides.
+3. **Given** the user accidentally deletes a practice, **Then** the deletion is immediate (no confirmation dialog is required for this initial version).
+
+---
+
+### Edge Cases
+
+- What happens when the score name contains special characters (accents, apostrophes, long names)? The name should be sanitized to replace non-alphanumeric characters with underscores, and truncated if excessively long.
+- What happens when browser storage is full? The save operation should fail gracefully with a user-visible message explaining that storage is full.
+- What happens when a saved practice references a score that has since been deleted from "My Scores"? The practice entry should still appear in the list. On load, the system matches by score type + unique ID (filename for preloaded, IndexedDB ID for user-uploaded). Preloaded scores always resolve successfully. If a user-uploaded score's ID no longer exists in IndexedDB, display a message indicating the original score is no longer available.
+- What happens when the user has many saved practices (e.g., 50+)? The list should remain scrollable and performant. An upper limit of 100 saved practices is applied, with the oldest being evicted when the limit is exceeded.
+- What happens if the user saves after a partial practice (stopped mid-session)? The partial performance record is saved and marked as partial so it is distinguishable from completed sessions.
+- What happens with the datetime component across time zones? The datetime is captured in the user's local time zone at the moment of saving.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST display a "Save" button in the results overlay, positioned in the same row as the existing Repractice and Replay buttons.
+- **FR-002**: System MUST generate the saved practice name using the format `{score_name}-{hand}-{scope}-{datetime}` where:
+  - `{score_name}` is the title of the practiced score with spaces replaced by underscores and special characters sanitized
+  - `{hand}` is one of `RH` (right hand, staff index 0), `LH` (left hand, staff index 1), or `BH` (both hands, staff index -1)
+  - `{scope}` is `all` when no loop region is active, or `region` when a loop region is active
+  - `{datetime}` is the local date and time in ISO-like compact format (e.g., `20250325T143022`)
+- **FR-003**: System MUST persist saved practices in the browser's local storage, surviving page refreshes and browser restarts.
+- **FR-004**: System MUST store the full performance data (note results, wrong note events, BPM, and timing information) for each saved practice so it can be replayed.
+- **FR-005**: System MUST store the practice context alongside each saved practice, including: score type (preloaded or user-uploaded), score unique identifier (filename for preloaded scores, IndexedDB ID for user-uploaded scores), score title, hand selection, loop region boundaries (if any), tempo multiplier, and loop count.
+- **FR-006**: System MUST display a "Saved Practices" section in the load score dialog as a collapsible section (collapsed by default) in the left panel.
+- **FR-007**: System MUST list saved practices ordered by date of saving, most recent first.
+- **FR-008**: System MUST allow users to select a saved practice from the list to load the associated score with the same hand and region configuration, and immediately display the results overlay with the saved performance stats and Replay button ready.
+- **FR-009**: System MUST allow users to delete individual saved practices from the list.
+- **FR-010**: System MUST prevent duplicate saves of the same practice session. After a successful save, the button text changes to "✓ Saved" and the button remains in a disabled state for the rest of the session.
+- **FR-011**: System MUST enforce a maximum of 100 saved practices, automatically removing the oldest entry when the limit is exceeded.
+- **FR-012**: System MUST support saving both complete and partial (stopped mid-session) practice results.
+- **FR-013**: System MUST visually distinguish partial practices from completed practices in the saved practices list (e.g., with a label or icon).
+- **FR-014**: The "Save" button MUST also be available in the partial results overlay (when a user stops practice mid-session).
+
+### Key Entities
+
+- **Saved Practice**: A persisted record of a completed or partially-completed practice session. Attributes: unique identifier, generated name, save date, score type (preloaded or user-uploaded), score unique reference (filename for preloaded, IndexedDB ID for user-uploaded), score title, hand selection, loop region (optional), performance data (notes, note results, wrong note events, BPM), tempo multiplier, loop count, completion status (complete or partial), and for partial practices the stopped-at index and total note count.
+- **Saved Practices Index**: A lightweight list of saved practice metadata (identifier, name, date, completion status) used for fast listing in the load score dialog without loading full performance data.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can save a completed practice in under 2 seconds (from clicking Save to seeing confirmation).
+- **SC-002**: Users can find and load a previously saved practice within 10 seconds of opening the load score dialog.
+- **SC-003**: The saved practices list displays correctly with up to 100 entries without noticeable delay or scroll lag.
+- **SC-004**: 100% of saved practices can be successfully loaded and replayed with the correct hand selection, region, and performance data.
+- **SC-005**: Deleting a saved practice removes it immediately from the list and frees the associated storage.
+- **SC-006**: Saved practices persist across page refreshes, browser restarts, and tab closures.
+
+## Assumptions
+
+- The practice name format (`score_name-RH/LH/BH-all/region-datetime`) is auto-generated and not user-editable. If user-editable names are desired in the future, that is a separate enhancement.
+- The "Saved Practices" section is placed below the existing sections (Preloaded Scores, Score Groups, My Scores) in the load score dialog's left panel.
+- No server-side persistence is required; all data is stored locally in the browser, consistent with the existing storage architecture.
+- The 100-practice limit with oldest-first eviction provides a reasonable balance between storage usage and user utility without requiring manual cleanup.
+- When loading a saved practice, the system loads the original score, restores the hand and region settings, and immediately shows the results overlay with the saved stats and Replay button. It does not automatically start replaying.
+- The datetime in the practice name uses the user's local time zone without explicit zone indicator, since it is for display/identification purposes only.
+
+## Clarifications
+
+### Session 2026-03-25
+
+- Q: When a user selects a saved practice from the list, what state should the app enter? → A: Show the results overlay immediately (score, stats, Replay button) after loading the score.
+- Q: How should the system identify and reference the original score when loading a saved practice? → A: Store score type (preloaded/user-uploaded) + unique ID (filename for preloaded, IndexedDB ID for user-uploaded) for precise matching on load.
+- Q: What kind of visual feedback should the user see after clicking Save? → A: Inline button state change — button text becomes "✓ Saved" and stays disabled (no toast or popup).
+

--- a/specs/056-save-load-practices/tasks.md
+++ b/specs/056-save-load-practices/tasks.md
@@ -1,0 +1,194 @@
+# Tasks: Save and Load Practices
+
+**Input**: Design documents from `/specs/056-save-load-practices/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Included — plan.md specifies TDD workflow per Constitution Principle V (Test-First Development).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Web app (frontend-only feature)**: `frontend/src/`, `frontend/tests/`, `frontend/plugins/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create shared type definitions used by all subsequent phases
+
+- [x] T001 Create shared TypeScript interfaces (ScoreRef, SavedPerformanceData, SavedPractice, SavedPracticeIndexEntry) in `frontend/src/services/savedPractice.types.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Storage layer and utility functions that ALL user stories depend on
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T002 Bump IndexedDB version from 1 to 2 and add `practices` object store in `frontend/src/services/storage/local-storage.ts`
+- [x] T003 [P] Implement `listSavedPractices()`, `addSavedPracticeIndex()`, and `removeSavedPracticeIndex()` in `frontend/src/services/savedPracticeIndex.ts`
+- [x] T004 [P] Implement `savePracticeToIndexedDB()`, `loadPracticeFromIndexedDB()`, `deletePracticeFromIndexedDB()`, and `generatePracticeName()` in `frontend/src/services/savedPracticeStorage.ts`
+- [x] T005 [P] Write unit tests for savedPracticeIndex (list, add, remove, eviction at 100 limit, date ordering) in `frontend/tests/services/savedPracticeIndex.test.ts`
+- [x] T006 [P] Write unit tests for savedPracticeStorage (save, load, delete, generatePracticeName sanitization/formatting) in `frontend/tests/services/savedPracticeStorage.test.ts`
+
+**Checkpoint**: Storage layer ready — user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 — Save a Completed Practice (Priority: P1) 🎯 MVP
+
+**Goal**: User completes a practice and clicks "Save" in the results overlay. Practice is persisted with auto-generated name. Button shows "✓ Saved" (disabled).
+
+**Independent Test**: Complete a practice session → results overlay appears → click Save → button changes to "✓ Saved" (disabled). Refresh page → practice persists in storage.
+
+### Implementation for User Story 1
+
+- [x] T007 [P] [US1] Add `onSave` and `isSaved` props to ResultsOverlay, render "Save" button (💾 Save / ✓ Saved) in `.practice-results__replay-row` in `frontend/plugins/practice-view-plugin/ResultsOverlay.tsx`
+- [x] T008 [P] [US1] Add Save button styles (44×44px touch target, disabled state) in `frontend/plugins/practice-view-plugin/ResultsOverlay.css`
+- [x] T009 [US1] Wire save callback in PracticeViewPlugin: build SavedPractice object from current practice state, call storage services, manage `isSaved` flag (reset on new practice) in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+
+**Checkpoint**: User Story 1 fully functional — save a practice from the results overlay and verify it persists in IndexedDB + localStorage index
+
+---
+
+## Phase 4: User Story 2 — Load a Saved Practice (Priority: P2)
+
+**Goal**: User opens the load score dialog, expands the "Saved Practices" section, and selects a practice to load the score with restored settings and results overlay displayed immediately.
+
+**Independent Test**: Save a practice → open load score dialog → expand "Saved Practices" → select saved practice → score loads with same hand/region → results overlay appears with saved stats and Replay button.
+
+### Tests for User Story 2
+
+- [x] T010 [P] [US2] Write component tests for SavedPracticeList (render list ordered by date, select fires callback, delete fires callback, empty state returns null, partial badge renders) in `frontend/tests/components/SavedPracticeList.test.tsx`
+
+### Implementation for User Story 2
+
+- [x] T011 [P] [US2] Create SavedPracticeList component with collapsible `<details>/<summary>` section, `<ul role="list">` sorted by date descending, select button per item, partial practice badge, returns null when empty in `frontend/src/components/load-score/SavedPracticeList.tsx`
+- [x] T012 [P] [US2] Create SavedPracticeList styles (collapsible section, list items, 44×44px touch targets, partial badge) in `frontend/src/components/load-score/SavedPracticeList.css`
+- [x] T013 [US2] Add `savedPractices`, `onSelectSavedPractice`, and `onDeleteSavedPractice` props to LoadScoreDialog and render SavedPracticeList section below existing sections in `frontend/src/components/load-score/LoadScoreDialog.tsx`
+- [x] T014 [US2] Wire load flow in PracticeViewPlugin: on saved practice selection → load referenced score (preloaded or user) → restore staffIndex, loopRegion, tempoMultiplier, loopCount → set performanceRecord from saved data → show resultsOverlay in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+
+**Checkpoint**: User Stories 1 AND 2 both work — save a practice, then load it from the dialog and see results overlay with saved stats
+
+---
+
+## Phase 5: User Story 3 — Delete a Saved Practice (Priority: P3)
+
+**Goal**: User removes unwanted practices from the "Saved Practices" list. Deletion removes from both localStorage index and IndexedDB.
+
+**Independent Test**: Save a practice → open load dialog → expand "Saved Practices" → click delete on a practice → practice disappears from list and is removed from storage. Delete last practice → section shows empty state or hides.
+
+### Implementation for User Story 3
+
+- [x] T015 [US3] Wire delete handler through PracticeViewPlugin → LoadScoreDialog → SavedPracticeList: call `removeSavedPracticeIndex()` + `deletePracticeFromIndexedDB()`, refresh list state in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+- [x] T016 [US3] Verify empty state after deleting last practice (section hides) in `frontend/src/components/load-score/SavedPracticeList.tsx`
+
+**Checkpoint**: All three user stories functional — save, load, and delete practices
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Edge case handling and final validation
+
+- [x] T017 [P] Handle edge case: saved practice references a deleted user-uploaded score — show "score unavailable" message on load attempt in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+- [x] T018 [P] Handle edge case: IndexedDB storage-full error on save — catch error, show user message, re-enable Save button in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+- [x] T019 Run quickstart.md validation: verify full save → load → replay → delete flow end-to-end
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (types from T001) — BLOCKS all user stories
+- **US1 Save (Phase 3)**: Depends on Phase 2 completion (storage services)
+- **US2 Load (Phase 4)**: Depends on Phase 2 completion (storage services). Independent of US1 code, but logically needs saved data to test
+- **US3 Delete (Phase 5)**: Depends on Phase 4 (SavedPracticeList component exists with delete button)
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (Save)**: Can start after Phase 2. No code dependencies on other stories
+- **US2 (Load)**: Can start after Phase 2. Independent of US1 code (different files). Test requires saved practices from US1 flow
+- **US3 (Delete)**: Depends on US2 (uses SavedPracticeList component). Wires delete handler that US2 renders but doesn't implement
+
+### Within Each User Story
+
+- Tests written and failing before implementation (Constitution Principle V)
+- Services/utilities before UI components
+- UI components before integration wiring
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+**Phase 2** (after T002):
+- T003, T004, T005, T006 can all run in parallel (different files, independent services)
+
+**Phase 3** (US1):
+- T007 + T008 in parallel (ResultsOverlay.tsx + ResultsOverlay.css)
+- T009 after T007 (needs new props defined)
+
+**Phase 4** (US2):
+- T010 + T011 + T012 in parallel (test file + component + CSS)
+- T013 after T011 (needs SavedPracticeList component)
+- T014 after T013 (needs LoadScoreDialog wired)
+
+**Phase 6**:
+- T017 + T018 in parallel (independent edge cases)
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+# Can run in parallel (different files):
+T007: Add Save button + props to ResultsOverlay.tsx
+T008: Add Save button styles to ResultsOverlay.css
+
+# Then sequentially:
+T009: Wire save callback in PracticeViewPlugin.tsx (depends on T007)
+```
+
+## Parallel Example: User Story 2
+
+```text
+# Can run in parallel (different files):
+T010: Write SavedPracticeList tests
+T011: Create SavedPracticeList component
+T012: Create SavedPracticeList styles
+
+# Then sequentially:
+T013: Integrate into LoadScoreDialog (depends on T011)
+T014: Wire load flow in PracticeViewPlugin (depends on T013)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001)
+2. Complete Phase 2: Foundational (T002–T006)
+3. Complete Phase 3: User Story 1 — Save (T007–T009)
+4. **STOP and VALIDATE**: Save a practice from the results overlay, verify persistence
+5. Delivers core value: practices are being saved
+
+### Incremental Delivery
+
+1. Setup + Foundational → Storage ready
+2. Add US1 (Save) → Test independently → **MVP delivered!**
+3. Add US2 (Load) → Test independently → Full save+load cycle works
+4. Add US3 (Delete) → Test independently → Complete practice management
+5. Polish → Edge cases handled, validation complete
+6. Each story adds value without breaking previous stories


### PR DESCRIPTION
## Save and Load Practice Sessions

Add ability to save completed practice sessions from the results overlay and reload them from the load score dialog.

### What it does

- **Save**: After completing a practice, a "Save" button appears in the results overlay. Clicking it persists the practice (settings + performance data) and shows "✓ Saved".
- **Load**: Saved practices appear in a collapsible "Saved Practices" section in the load score dialog. Selecting one loads the score with restored settings (hand, region, tempo, loops) and immediately displays the results overlay with saved stats and Replay capability.
- **Delete**: Each saved practice has a delete button to remove it from storage.

### Technical details

- **Storage**: Two-tier pattern — localStorage index (max 100 entries, FIFO eviction) + IndexedDB (`graditone-db` v2) for full practice data
- **Plugin boundary**: Storage services re-exported through `plugin-api/index.ts` barrel to comply with `no-restricted-imports` enforcement
- **Replay highlighting**: Load flow re-extracts fresh `noteIds` from the current score rendering to ensure replay note highlighting works across sessions (opaque DOM IDs change on each score load)

### Files changed

**New files (8):**
- `frontend/src/services/savedPractice.types.ts` — shared TypeScript interfaces
- `frontend/src/services/savedPracticeIndex.ts` — localStorage index CRUD
- `frontend/src/services/savedPracticeStorage.ts` — IndexedDB storage CRUD
- `frontend/src/components/load-score/SavedPracticeList.tsx` — collapsible list component
- `frontend/src/components/load-score/SavedPracticeList.css` — list styles
- `frontend/tests/services/savedPracticeIndex.test.ts` — 8 tests
- `frontend/tests/services/savedPracticeStorage.test.ts` — 10 tests
- `frontend/tests/components/SavedPracticeList.test.tsx` — 8 tests

**Modified files (9):**
- `frontend/src/services/storage/local-storage.ts` — DB v2 + practices store
- `frontend/src/plugin-api/index.ts` — re-export saved practice API
- `frontend/src/plugin-api/types.ts` — extended `PluginScoreSelectorProps`
- `frontend/src/components/load-score/LoadScoreDialog.tsx` — saved practices props
- `frontend/src/components/plugins/ScoreSelectorPlugin.tsx` — renders SavedPracticeList
- `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx` — save/load/delete wiring
- `frontend/plugins/practice-view-plugin/PracticeViewPlugin.css` — save button styles
- `frontend/plugins/practice-view-plugin/ResultsOverlay.tsx` — Save button + loaded practice display
- `frontend/plugins/practice-view-plugin/practiceEngine.types.ts` — import fix

### Tests

26 new tests across 3 test files. All 1690 tests pass.

Closes #056
