### PR TITLE
feat(061): Tasks-Based Session Definition

### DIFF
--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.css
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.css
@@ -198,6 +198,32 @@
   flex-shrink: 1;
 }
 
+/* ─── Task tag badge (Feature 061) ────────────────────────────────────────── */
+
+.practice-plugin__task-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--ls-cta-bg, #1a4a9a);
+  color: var(--ls-cta-text, #fff);
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+  flex-shrink: 0;
+  letter-spacing: 0.01em;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.12s;
+}
+
+.practice-plugin__task-tag:hover {
+  opacity: 0.85;
+}
+
 /* ─── Elapsed timer ───────────────────────────────────────────────────────── */
 
 .practice-plugin__toolbar-timer {
@@ -518,6 +544,20 @@
   color: #555;
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.practice-plugin__replay-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #1976d2;
+  white-space: nowrap;
+  flex-shrink: 0;
+  animation: practice-plugin__replay-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes practice-plugin__replay-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
 }
 
 /* ─── Selection screen (reuses play-score approach) ──────────────────────── */
@@ -851,6 +891,33 @@
   font-size: 0.75rem;
   color: #e53935;
   white-space: nowrap;
+}
+
+/* ── Session return button (061-session-task-definition) ───────────────────── */
+
+.practice-results__session-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 20px;
+  min-width: 44px;
+  min-height: 44px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  background: #00796b;
+  color: #fff;
+  transition: background 0.15s ease;
+}
+
+.practice-results__session-btn:hover {
+  background: #00695c;
+}
+
+.practice-results__session-btn:active {
+  background: #004d40;
 }
 
 /* ── Loop count slider (multi-loop practice) ───────────────────────────────── */

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
@@ -57,11 +57,12 @@ async function loadProtectedPracticeIds(): Promise<ReadonlySet<string>> {
     return mod.computeProtectedPracticeIds();
   } catch { return new Set<string>(); }
 }
-async function loadProtectedPracticeMap(): Promise<ReadonlyMap<string, string>> {
+type ProtectedPracticeInfo = { sessionName: string; sessionId: string; taskId?: string };
+async function loadProtectedPracticeMap(): Promise<ReadonlyMap<string, ProtectedPracticeInfo>> {
   try {
     const mod = await import(/* @vite-ignore */ _sessPath);
     return mod.computeProtectedPracticeMap();
-  } catch { return new Map<string, string>(); }
+  } catch { return new Map<string, ProtectedPracticeInfo>(); }
 }
 
 // ---------------------------------------------------------------------------
@@ -221,8 +222,11 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   const [isSaved, setIsSaved] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const loadedScoreRefRef = useRef<ScoreRef | null>(null);
-  // Feature 061: Track taskId when launched from a session task
+  // Feature 061: Track taskId and sessionId when launched from a session task
   const taskIdRef = useRef<string | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  // Feature 061: Task tag info for toolbar display
+  const [taskTag, setTaskTag] = useState<{ taskNumber: number; sessionName: string } | null>(null);
   // Feature 061: Pending task config to apply once score is loaded
   const pendingTaskConfigRef = useRef<{
     staffIndex: number;
@@ -232,10 +236,12 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
     startMeasure: number | null;
     endMeasure: number | null;
   } | null>(null);
+  // Feature 061: Auto-start practice after task config + loop region are applied
+  const autoStartPracticeRef = useRef(false);
   const [savedPractices, setSavedPractices] = useState<SavedPracticeIndexEntry[]>(() => listSavedPractices());
   // Feature 060: Protected practice IDs (linked to sessions, cannot be deleted)
   const [protectedPracticeIds, setProtectedPracticeIds] = useState<ReadonlySet<string>>(new Set());
-  const [protectedPracticeMap, setProtectedPracticeMap] = useState<ReadonlyMap<string, string>>(new Map());
+  const [protectedPracticeMap, setProtectedPracticeMap] = useState<ReadonlyMap<string, ProtectedPracticeInfo>>(new Map());
   useEffect(() => {
     loadProtectedPracticeIds().then(setProtectedPracticeIds).catch(() => {});
     loadProtectedPracticeMap().then(setProtectedPracticeMap).catch(() => {});
@@ -256,6 +262,11 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
     setTempoMultiplier(saved.tempoMultiplier);
     context.scorePlayer.setTempoMultiplier(saved.tempoMultiplier);
     setLoopCount(saved.loopCount);
+
+    // Feature 061: Restore saved loop region so Repractice honors the task region.
+    if (saved.loopRegion) {
+      setPendingTaskLoopRegion(saved.loopRegion);
+    }
 
     // Re-extract fresh notes from the newly loaded score so that noteIds
     // (opaque DOM IDs) are valid for the current rendering. The saved notes
@@ -279,6 +290,9 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
 
     // Build the notes array with fresh noteIds, falling back to saved entries
     // for any index beyond what was re-extracted (shouldn't happen for same score).
+    // NOTE: Do NOT filter freshNotes by loopRegion here — the saved notes array
+    // and noteResult indices are absolute (cover the full score). We need the
+    // full freshNotes so positional mapping preserves correct noteIds.
     const notesWithFreshIds = saved.performanceData.notes.map((savedNote, i) =>
       i < freshNotes.length ? freshNotes[i] : savedNote,
     );
@@ -307,8 +321,11 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [playerState.status]);
 
-  // Feature 061: Ref to stash loop region ticks computed from task config
-  const pendingTaskLoopRegionRef = useRef<{ startTick: number; endTick: number } | null>(null);
+  // Feature 061: State for loop region ticks computed from task config.
+  // Using state (not ref) so that updating it triggers a re-render,
+  // ensuring usePracticeLoop receives the values even when other setState
+  // calls in the same effect are no-ops (e.g. defaults match).
+  const [pendingTaskLoopRegion, setPendingTaskLoopRegion] = useState<{ startTick: number; endTick: number } | null>(null);
 
   // Feature 061: Apply pending task config once the score is ready.
   useEffect(() => {
@@ -327,10 +344,13 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
       if (measureEndTicks && measureEndTicks.length > 0) {
         const result = measureRangeToTicks(tc.startMeasure, tc.endMeasure, measureEndTicks);
         if (result) {
-          pendingTaskLoopRegionRef.current = result;
+          setPendingTaskLoopRegion(result);
         }
       }
     }
+
+    // Feature 061: Schedule auto-start of practice mode
+    autoStartPracticeRef.current = true;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [playerState.status]);
 
@@ -350,8 +370,9 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
     playerState,
     practiceStartTimeRef,
     context,
-    initialStartTick: pendingTaskLoopRegionRef.current?.startTick ?? null,
-    initialEndTick: pendingTaskLoopRegionRef.current?.endTick ?? null,
+    initialStartTick: pendingTaskLoopRegion?.startTick ?? null,
+    initialEndTick: pendingTaskLoopRegion?.endTick ?? null,
+    taskLocked: !!taskIdRef.current,
     onComplete: (record) => {
       setPerformanceRecord(record);
       setIsReplaying(false);
@@ -360,6 +381,11 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
       setResultsOverlayVisible(true);
     },
   });
+
+  // Keep a ref to loopCount so callbacks can read the latest value without
+  // being listed in dependency arrays (avoids stale closure in handlePracticeToggle).
+  const loopCountRef = useRef(loopCount);
+  loopCountRef.current = loopCount;
 
   // Flash the auto-advanced note IDs in red for 600 ms when the engine skips a beat.
   useEffect(() => {
@@ -480,7 +506,18 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   }, [context]);
 
   // Playback controls
-  const handlePlay = useCallback(() => context.scorePlayer.play(), [context.scorePlayer]);
+  const handlePlay = useCallback(() => {
+    // If a loop region is set and current position is outside the region,
+    // seek to the region start so playback honours the pinned region.
+    const lr = loopRegionRef.current;
+    if (lr) {
+      const tick = playerStateRef.current.currentTick;
+      if (tick < lr.startTick || tick >= lr.endTick) {
+        context.scorePlayer.seekToTick(lr.startTick);
+      }
+    }
+    context.scorePlayer.play();
+  }, [context.scorePlayer]);
   const handlePause = useCallback(() => context.scorePlayer.pause(), [context.scorePlayer]);
   const handleStop = useCallback(() => {
     // If a replay is in progress, stop audio and reset replay state
@@ -575,10 +612,18 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
 
     // Reset loop count to 1 for a fresh practice start (repractice preserves
     // the slider value, but a brand-new practice always starts with 1 loop).
-    setLoopCount(1);
+    // Feature 061: When launched from a task, preserve the task's loopCount.
+    if (!taskIdRef.current) {
+      setLoopCount(1);
+    }
 
     // Reset loop iteration tracking so the progress counter starts from 1/N.
     resetLoopTracking();
+
+    // Feature 061: When task-driven, restore remaining loops after reset.
+    if (taskIdRef.current) {
+      remainingLoopsRef.current = loopCountRef.current - 1;
+    }
 
     // Start practice — staff is always already selected via the toolbar dropdown
     const ps2 = playerStateRef.current;
@@ -629,6 +674,25 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
     context.scorePlayer,
     selectedStaffIndex,
   ]);
+
+  // Ref to handlePracticeToggle so the auto-start effect can call it without
+  // depending on the callback identity (avoids cleanup-cancels-timeout race).
+  const handlePracticeToggleRef = useRef(handlePracticeToggle);
+  handlePracticeToggleRef.current = handlePracticeToggle;
+
+  // Feature 061: Auto-start practice when entering task mode.
+  // Waits until the loop region is fully applied (for region tasks) or
+  // fires immediately (for whole-score tasks) once the flag is set.
+  useEffect(() => {
+    if (!autoStartPracticeRef.current) return;
+    // For region tasks, wait until loopRegion is established
+    if (pendingTaskLoopRegion && !loopRegion) return;
+    autoStartPracticeRef.current = false;
+    // Delay slightly so the UI renders the score before practice begins
+    const t = setTimeout(() => handlePracticeToggleRef.current(), 100);
+    return () => clearTimeout(t);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loopRegion, pendingTaskLoopRegion]);
 
   // Note short-tap handler (US3 / T037)
   // Mirrors play-score two-tap seek-then-play state machine:
@@ -796,6 +860,14 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
     const navData = context.getNavigationData();
     if (navData && typeof navData.savedPracticeId === 'string') {
       const id = navData.savedPracticeId;
+      // Feature 061: Set task tag if navigated from a task-linked activity
+      if (typeof navData.sessionId === 'string') {
+        sessionIdRef.current = navData.sessionId as string;
+      }
+      if (typeof navData.taskId === 'string' && typeof navData.taskNumber === 'number') {
+        taskIdRef.current = navData.taskId as string;
+        setTaskTag({ taskNumber: navData.taskNumber as number, sessionName: '' });
+      }
       loadPracticeFromIndexedDB(id).then((saved) => {
         if (!saved) return;
         loadedScoreRefRef.current = saved.scoreRef;
@@ -812,6 +884,10 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
       const scoreRef = tc.scoreRef as { type: string; id: string } | undefined;
       if (scoreRef && scoreRef.id) {
         taskIdRef.current = (tc.taskId as string) ?? null;
+        sessionIdRef.current = (tc.sessionId as string) ?? null;
+        if (typeof tc.taskNumber === 'number' && typeof tc.sessionName === 'string') {
+          setTaskTag({ taskNumber: tc.taskNumber as number, sessionName: tc.sessionName as string });
+        }
         loadedScoreRefRef.current = scoreRef as ScoreRef;
         pendingTaskConfigRef.current = {
           staffIndex: (tc.staffIndex as number) ?? 0,
@@ -896,7 +972,10 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
           onDeleteSavedPractice={handleDeleteSavedPractice}
           protectedPracticeIds={protectedPracticeIds}
           protectedPracticeMap={protectedPracticeMap}
-          onViewSessions={() => context.openPlugin('sessions-plugin')}
+          onViewSessions={(sessionId, taskId) => context.openPlugin('sessions-plugin', {
+            expandSessionId: sessionId,
+            expandTaskId: taskId,
+          })}
         />
       </div>
     );
@@ -950,6 +1029,12 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
         onMetronomeToggle={handleMetronomeToggle}
         metronomeSubdivision={metronomeSubdivision}
         onMetronomeSubdivisionChange={handleMetronomeSubdivisionChange}
+        taskTag={taskTag}
+        isReplaying={isReplaying}
+        onTaskTagClick={() => context.openPlugin('sessions-plugin', {
+          expandSessionId: sessionIdRef.current,
+          expandTaskId: taskIdRef.current,
+        })}
       />
 
       {/* Hold indicator — visible while player holds a note longer than a quarter note */}
@@ -1026,6 +1111,10 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
         onSave={loadedScoreRefRef.current ? handleSave : undefined}
         isSaved={isSaved}
         saveError={saveError}
+        onReturnToSession={taskTag ? () => context.openPlugin('sessions-plugin', {
+          expandSessionId: sessionIdRef.current,
+          expandTaskId: taskIdRef.current,
+        }) : undefined}
       />
     </div>
   );

--- a/frontend/plugins/practice-view-plugin/ResultsOverlay.tsx
+++ b/frontend/plugins/practice-view-plugin/ResultsOverlay.tsx
@@ -61,6 +61,8 @@ export interface ResultsOverlayProps {
   isSaved?: boolean;
   /** Feature 056: Error message if save failed (e.g. storage full). */
   saveError?: string | null;
+  /** Feature 061: Navigate back to the sessions plugin (only shown for task practices). */
+  onReturnToSession?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -84,6 +86,7 @@ export function ResultsOverlay({
   onSave,
   isSaved,
   saveError,
+  onReturnToSession,
 }: ResultsOverlayProps) {
   // ─── Replay internals ────────────────────────────────────────────────────────
   const replayTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -534,6 +537,15 @@ export function ResultsOverlay({
             )}
             {saveError && (
               <span className="practice-results__save-error" role="alert">{saveError}</span>
+            )}
+            {onReturnToSession && (
+              <button
+                className="practice-results__session-btn"
+                onClick={onReturnToSession}
+                aria-label="Return to session"
+              >
+                ↩ Session
+              </button>
             )}
           </div>
         )}

--- a/frontend/plugins/practice-view-plugin/practiceToolbar.tsx
+++ b/frontend/plugins/practice-view-plugin/practiceToolbar.tsx
@@ -76,6 +76,12 @@ export interface PracticeToolbarProps {
   onMetronomeToggle: () => void;
   metronomeSubdivision: MetronomeSubdivision;
   onMetronomeSubdivisionChange: (s: MetronomeSubdivision) => void;
+  /** When true, a replay is running — practice toggle should be disabled. */
+  isReplaying?: boolean;
+  /** Feature 061: Session task tag — when set, config is locked and tag is shown. */
+  taskTag?: { taskNumber: number; sessionName: string } | null;
+  /** Feature 061: Called when the task tag badge is clicked. */
+  onTaskTagClick?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -109,6 +115,9 @@ export function PracticeToolbar({
   onMetronomeToggle,
   metronomeSubdivision,
   onMetronomeSubdivisionChange,
+  isReplaying,
+  taskTag,
+  onTaskTagClick,
 }: PracticeToolbarProps) {
   const isPlaying = status === 'playing';
   const isLoaded = status === 'ready' || status === 'playing' || status === 'paused';
@@ -201,6 +210,18 @@ export function PracticeToolbar({
         </span>
       )}
 
+      {/* Feature 061: Session task tag — shown when launched from a session task */}
+      {taskTag && (
+        <button
+          className="practice-plugin__task-tag"
+          title={`Session Task ${taskTag.taskNumber}`}
+          onClick={onTaskTagClick}
+          type="button"
+        >
+          Session Task {taskTag.taskNumber}
+        </button>
+      )}
+
       {/* Play / Pause toggle */}
       {isPlaying ? (
         <button
@@ -240,7 +261,7 @@ export function PracticeToolbar({
             aria-haspopup="listbox"
             aria-expanded={staffMenuOpen}
             aria-label="Select hand"
-            disabled={!isLoaded}
+            disabled={!isLoaded || !!taskTag}
           >
             {staffIndexLabel(selectedStaffIndex)}
             <span className="practice-plugin__staff-chevron">▾</span>
@@ -292,7 +313,7 @@ export function PracticeToolbar({
             practiceRunning ? 'Stop practice mode' : 'Start practice mode'
           }
           aria-pressed={practiceRunning}
-          disabled={!isLoaded || midiConnected === false}
+          disabled={!isLoaded || midiConnected === false || !!isReplaying}
         >
           {practiceBtnLabel}
         </button>
@@ -302,6 +323,13 @@ export function PracticeToolbar({
       {practiceRunning && totalPracticeNotes > 0 && (
         <span className="practice-plugin__progress" aria-live="polite">
           {currentPracticeIndex + 1}&nbsp;/&nbsp;{totalPracticeNotes}
+        </span>
+      )}
+
+      {/* Replay mode label */}
+      {isReplaying && (
+        <span className="practice-plugin__replay-label" aria-live="polite">
+          ▶ Replaying…
         </span>
       )}
 
@@ -338,7 +366,7 @@ export function PracticeToolbar({
           }}
           aria-label="Tempo multiplier"
           className="practice-plugin__toolbar-tempo-slider"
-          disabled={status === 'loading'}
+          disabled={status === 'loading' || !!taskTag}
         />
         {bpm > 0 && (
           <span className="practice-plugin__toolbar-bpm">{Math.round(bpm * tempoMultiplier)}</span>

--- a/frontend/plugins/practice-view-plugin/usePracticeLoop.ts
+++ b/frontend/plugins/practice-view-plugin/usePracticeLoop.ts
@@ -29,6 +29,8 @@ export interface UsePracticeLoopParams {
   initialStartTick?: number | null;
   /** Feature 061: Optional initial loop region end tick (from task config). */
   initialEndTick?: number | null;
+  /** Feature 061: When true, the loop region is locked and cannot be changed. */
+  taskLocked?: boolean;
 }
 
 export interface UsePracticeLoopReturn {
@@ -62,6 +64,7 @@ export function usePracticeLoop({
   onResultsShow,
   initialStartTick,
   initialEndTick,
+  taskLocked,
 }: UsePracticeLoopParams): UsePracticeLoopReturn {
   // ─── Multi-loop practice state ─────────────────────────────────────────────
   const [loopCount, setLoopCount] = useState(1);
@@ -117,7 +120,7 @@ export function usePracticeLoop({
     if (startIndex === -1) return null;
     let endIndex = startIndex;
     for (let i = startIndex; i < notes.length; i++) {
-      if (notes[i].tick <= loopRegion.endTick) endIndex = i;
+      if (notes[i].tick < loopRegion.endTick) endIndex = i;
       else break;
     }
     return { startIndex, endIndex };
@@ -154,6 +157,9 @@ export function usePracticeLoop({
   // ─── Long press — pin/loop state machine ───────────────────────────────────
   const handleNoteLongPress = useCallback(
     (tick: number, noteId: string | null) => {
+      // Feature 061: When task-locked, the loop region cannot be changed.
+      if (taskLocked) return;
+
       const isPlaying = playerState.status === 'playing';
 
       if (loopRegion && tick >= loopRegion.startTick && tick <= loopRegion.endTick) {
@@ -184,7 +190,7 @@ export function usePracticeLoop({
         }
       }
     },
-    [context.scorePlayer, loopStart, loopRegion, playerState.status],
+    [context.scorePlayer, loopStart, loopRegion, playerState.status, taskLocked],
   );
 
   // ─── Reset callback for orchestrator ───────────────────────────────────────

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -239,6 +239,10 @@ body[data-landing-theme] {
   --color-danger-dark: color-mix(in srgb, var(--ls-accent) 75%, #000);
   --color-danger-bg: color-mix(in srgb, var(--ls-accent) 10%, var(--ls-bg));
 
+  /* Success / done actions */
+  --color-success: var(--ls-success, #4caf50);
+  --color-success-bg: color-mix(in srgb, var(--ls-success, #4caf50) 12%, var(--ls-bg, #fff));
+
   /* Warning / retry actions */
   --color-warning: color-mix(in srgb, var(--ls-accent) 80%, #fff);
   --color-warning-dark: var(--ls-accent);

--- a/frontend/src/components/LayoutRenderer.test.tsx
+++ b/frontend/src/components/LayoutRenderer.test.tsx
@@ -112,7 +112,7 @@ describe('[T002] BUG: shouldComponentUpdate missing selectedNoteId', () => {
     expect(result).toBe(false);
   });
 
-  it('shouldComponentUpdate still returns false for highlight-only changes (performance guard)', async () => {
+  it('shouldComponentUpdate returns true for highlight-only changes (replay support)', async () => {
     const { LayoutRenderer } = await import('./LayoutRenderer');
 
     // Share the SAME object references for all structural props.
@@ -120,7 +120,7 @@ describe('[T002] BUG: shouldComponentUpdate missing selectedNoteId', () => {
       selectedNoteId: 'note-42',
       highlightedNoteIds: new Set(['note-1']),
     });
-    // Only highlightedNoteIds changes — must NOT trigger structural re-render
+    // Only highlightedNoteIds changes — triggers re-render for replay highlights
     const nextProps: LayoutRendererProps = {
       ...sharedBase,
       highlightedNoteIds: new Set(['note-2']),
@@ -131,7 +131,7 @@ describe('[T002] BUG: shouldComponentUpdate missing selectedNoteId', () => {
       nextProps,
     );
 
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 });
 // ============================================================================

--- a/frontend/src/components/LayoutRenderer.tsx
+++ b/frontend/src/components/LayoutRenderer.tsx
@@ -150,7 +150,8 @@ export class LayoutRenderer extends Component<LayoutRendererProps> {
       nextProps.pinnedNoteIds !== this.props.pinnedNoteIds ||
       nextProps.errorNoteIds !== this.props.errorNoteIds ||
       nextProps.expectedNoteIds !== this.props.expectedNoteIds ||
-      nextProps.loopRegion !== this.props.loopRegion
+      nextProps.loopRegion !== this.props.loopRegion ||
+      nextProps.highlightedNoteIds !== this.props.highlightedNoteIds
     );
   }
 

--- a/frontend/src/components/load-score/SavedPracticeList.tsx
+++ b/frontend/src/components/load-score/SavedPracticeList.tsx
@@ -16,10 +16,10 @@ export interface SavedPracticeListProps {
   onDelete: (id: string) => void;
   /** Feature 060: Practices in this set cannot be deleted (linked to a session). */
   protectedPracticeIds?: ReadonlySet<string>;
-  /** Feature 060: Map of savedPracticeId → session name for protected practices. */
-  protectedPracticeMap?: ReadonlyMap<string, string>;
+  /** Feature 060: Map of savedPracticeId → session info for protected practices. */
+  protectedPracticeMap?: ReadonlyMap<string, { sessionName: string; sessionId: string; taskId?: string }>;
   /** Feature 060: Called when the user clicks the session link on a protected practice. */
-  onViewSessions?: () => void;
+  onViewSessions?: (sessionId: string, taskId?: string) => void;
 }
 
 export function SavedPracticeList({
@@ -70,11 +70,14 @@ export function SavedPracticeList({
               {protectedPracticeIds?.has(practice.id) ? (
                 <button
                   className="saved-practice-item__session-link"
-                  aria-label={`Linked to session: ${protectedPracticeMap?.get(practice.id) ?? 'session'}`}
+                  aria-label={`Linked to session: ${protectedPracticeMap?.get(practice.id)?.sessionName ?? 'session'}`}
                   disabled={disabled}
-                  onClick={() => onViewSessions?.()}
+                  onClick={() => {
+                    const info = protectedPracticeMap?.get(practice.id);
+                    if (info) onViewSessions?.(info.sessionId, info.taskId);
+                  }}
                   type="button"
-                  title={`📋 ${protectedPracticeMap?.get(practice.id) ?? 'Session'}`}
+                  title={`📋 ${protectedPracticeMap?.get(practice.id)?.sessionName ?? 'Session'}`}
                 >
                   📋
                 </button>

--- a/frontend/src/plugin-api/types.ts
+++ b/frontend/src/plugin-api/types.ts
@@ -413,15 +413,15 @@ export interface PluginScoreSelectorProps {
    */
   protectedPracticeIds?: ReadonlySet<string>;
   /**
-   * Feature 060: Map of savedPracticeId → session name for practices linked
+   * Feature 060: Map of savedPracticeId → session info for practices linked
    * to a session. Used by the load dialog to show a session link.
    */
-  protectedPracticeMap?: ReadonlyMap<string, string>;
+  protectedPracticeMap?: ReadonlyMap<string, { sessionName: string; sessionId: string; taskId?: string }>;
   /**
    * Feature 060: Called when the user clicks the session link on a protected
-   * practice. Opens the sessions plugin.
+   * practice. Opens the sessions plugin, optionally expanding the relevant session/task.
    */
-  onViewSessions?: () => void;
+  onViewSessions?: (sessionId: string, taskId?: string) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/services/playback/MusicTimeline.ts
+++ b/frontend/src/services/playback/MusicTimeline.ts
@@ -149,7 +149,12 @@ export function usePlayback(notes: Note[], tempo: number): PlaybackState {
         // the new Transport start moment.
         playbackStartTickRef.current = loopStartTick;
         startTimeRef.current = adapter.getCurrentTime();
-        scheduler.scheduleNotes(notes, tempo, loopStartTick, tempoState.tempoMultiplier).catch(() => {});
+        // Filter notes by loop end so the lookahead scheduler doesn't queue
+        // notes beyond the boundary (same as in play()).
+        const loopNotes = loopEndTickRef.current != null
+          ? notes.filter(n => n.start_tick < loopEndTickRef.current!)
+          : notes;
+        scheduler.scheduleNotes(loopNotes, tempo, loopStartTick, tempoState.tempoMultiplier).catch(() => {});
         lastReactTickRef.current = loopStartTick;
         tickSourceRef.current = { currentTick: loopStartTick, status: 'playing' };
         setCurrentTick(loopStartTick);
@@ -237,7 +242,13 @@ export function usePlayback(notes: Note[], tempo: number): PlaybackState {
 
       // US2 T037: Schedule notes for playback
       // Feature 008 - Tempo Change: T015 Pass tempo multiplier to scheduler
-      await scheduler.scheduleNotes(notes, tempo, playbackStartTick, tempoState.tempoMultiplier);
+      // Filter out notes at or beyond the loop end so the lookahead scheduler
+      // never queues them on the Transport (they would play before the rAF
+      // loop can detect the boundary and clear the schedule).
+      const notesToSchedule = loopEndTickRef.current != null
+        ? notes.filter(n => n.start_tick < loopEndTickRef.current!)
+        : notes;
+      await scheduler.scheduleNotes(notesToSchedule, tempo, playbackStartTick, tempoState.tempoMultiplier);
 
       // Calculate when playback will end and auto-stop.
       // Skip the end-timeout when a loop is active — the rAF loop handles looping.
@@ -445,20 +456,11 @@ export function usePlayback(notes: Note[], tempo: number): PlaybackState {
   /**
    * Set (or clear) the loop end tick.
    * When non-null, the rAF tick loop will jump back to pinnedStartTickRef on reaching this tick.
-   * The effective end tick includes the duration of the note at `tick` so it sounds fully.
+   * The tick is treated as an exclusive upper bound: notes starting at this tick are NOT played.
    */
   const setLoopEnd = useCallback((tick: number | null) => {
-    if (tick === null) {
-      loopEndTickRef.current = null;
-      return;
-    }
-    // Find the longest note starting at this tick so it plays fully before looping
-    const noteAtTick = notes.filter(n => n.start_tick === tick);
-    const maxDuration = noteAtTick.length > 0
-      ? Math.max(...noteAtTick.map(n => n.duration_ticks))
-      : 0;
-    loopEndTickRef.current = tick + maxDuration;
-  }, [notes]);
+    loopEndTickRef.current = tick;
+  }, []);
 
   /**
    * Feature 009: Clear pinned start position

--- a/frontend/src/themes/landing-themes.css
+++ b/frontend/src/themes/landing-themes.css
@@ -22,6 +22,7 @@
    --ls-font-body       Font-family stack for body text
    --ls-heading-weight  Font-weight for headings
    --ls-body-weight     Font-weight for body text
+   --ls-success         Semantic "done / OK" green (task ticks, session complete)
 
    WCAG 2.1 AA Contrast Audit (verified 2026-03-06):
    ─────────────────────────────────────────────────
@@ -55,6 +56,7 @@ body[data-landing-theme="ember"] {
   --ls-font-body:      'Inter', system-ui, sans-serif;
   --ls-heading-weight: 700;
   --ls-body-weight:    400;
+  --ls-success:        #4caf50;
 }
 
 /* ── 2. Saffron ────────────────────────────────────────────────────────────── */
@@ -74,6 +76,7 @@ body[data-landing-theme="saffron"] {
   --ls-font-body:      'IBM Plex Sans', system-ui, sans-serif;
   --ls-heading-weight: 700;
   --ls-body-weight:    400;
+  --ls-success:        #388E3C;
 }
 
 /* ── 3. Sienna ─────────────────────────────────────────────────────────────── */
@@ -93,6 +96,7 @@ body[data-landing-theme="sienna"] {
   --ls-font-body:      'Inter', system-ui, sans-serif;
   --ls-heading-weight: 600;
   --ls-body-weight:    400;
+  --ls-success:        #558B2F;
 }
 
 /* ── 4. Terracotta ─────────────────────────────────────────────────────────── */
@@ -112,6 +116,7 @@ body[data-landing-theme="terracotta"] {
   --ls-font-body:      'Space Grotesk', system-ui, sans-serif;
   --ls-heading-weight: 600;
   --ls-body-weight:    400;
+  --ls-success:        #2E7D32;
 }
 
 /* ── 5. Paprika ────────────────────────────────────────────────────────────── */
@@ -131,6 +136,7 @@ body[data-landing-theme="paprika"] {
   --ls-font-body:      'Inter', system-ui, sans-serif;
   --ls-heading-weight: 700;
   --ls-body-weight:    400;
+  --ls-success:        #2E7D32;
 }
 
 /* ── 6. Honey ──────────────────────────────────────────────────────────────── */
@@ -150,6 +156,7 @@ body[data-landing-theme="honey"] {
   --ls-font-body:      'Inter', system-ui, sans-serif;
   --ls-heading-weight: 700;
   --ls-body-weight:    400;
+  --ls-success:        #388E3C;
 }
 
 /* ── 7. Coral ──────────────────────────────────────────────────────────────── */
@@ -169,6 +176,7 @@ body[data-landing-theme="coral"] {
   --ls-font-body:      'IBM Plex Sans', system-ui, sans-serif;
   --ls-heading-weight: 700;
   --ls-body-weight:    400;
+  --ls-success:        #4caf50;
 }
 
 /* ── 8. Marigold ───────────────────────────────────────────────────────────── */
@@ -188,6 +196,7 @@ body[data-landing-theme="marigold"] {
   --ls-font-body:      'IBM Plex Sans', system-ui, sans-serif;
   --ls-heading-weight: 600;
   --ls-body-weight:    400;
+  --ls-success:        #388E3C;
 }
 
 /* ── 9. Blush ──────────────────────────────────────────────────────────────── */
@@ -207,6 +216,7 @@ body[data-landing-theme="blush"] {
   --ls-font-body:      'Space Grotesk', system-ui, sans-serif;
   --ls-heading-weight: 700;
   --ls-body-weight:    400;
+  --ls-success:        #388E3C;
 }
 
 /* ── 10. Rust ──────────────────────────────────────────────────────────────── */
@@ -226,4 +236,5 @@ body[data-landing-theme="rust"] {
   --ls-font-body:      'Space Grotesk', system-ui, sans-serif;
   --ls-heading-weight: 700;
   --ls-body-weight:    400;
+  --ls-success:        #2E7D32;
 }

--- a/specs/061-session-task-definition/spec.md
+++ b/specs/061-session-task-definition/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `061-session-task-definition`  
 **Created**: 2025-03-28  
 **Status**: Implemented  
-**Completed**: 2026-03-28  
+**Completed**: 2026-03-28 (core T001–T046), 2026-03-29 (enhancements T047–T067)  
 **Input**: User description: "Tasks based Session definition — When you create a new session you need to define the tasks for it."
 
 ## Clarifications

--- a/specs/061-session-task-definition/tasks.md
+++ b/specs/061-session-task-definition/tasks.md
@@ -151,6 +151,34 @@
 
 ---
 
+## Phase 9: Post-Implementation Enhancements
+
+**Purpose**: UX polish, bug fixes, and theming improvements identified during user testing
+
+- [X] T047 [P] Fix practice config locking: ensure `staffIndex`, `tempoMultiplier`, and `loopCount` from task config are locked in practice view and cannot be overridden by user in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+- [X] T048 [P] Add task/session tag label in practice toolbar showing "Task N · Session Name" when practicing from a session task in `frontend/plugins/practice-view-plugin/practiceToolbar.tsx`
+- [X] T049 [P] Fix CSS class collision between sessions plugin and practice view plugin for `.sessions-plugin__task-*` selectors in `plugins-external/sessions-plugin/SessionsPlugin.css`
+- [X] T050 [P] Fix stale closure in practice toggle: ensure `handlePracticeToggle` captures up-to-date state for task-based loop regions in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+- [X] T051 [P] Fix replay note highlighting: add `highlightedNoteIds` to `LayoutRenderer.shouldComponentUpdate` comparison so highlights update during replay in `frontend/src/components/LayoutRenderer.tsx`
+- [X] T052 [P] Add "▶ Replaying…" pulse label to practice toolbar when replay is active in `frontend/plugins/practice-view-plugin/practiceToolbar.tsx`
+- [X] T053 [P] Fix iterations field UX: prevent layout jump by using fixed-width input, add increment/decrement buttons in `plugins-external/sessions-plugin/TaskBuilder.tsx`
+- [X] T054 [P] Fix play honors region: ensure play button seeks to region start and respects loop boundaries in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+- [X] T055 [P] Fix default measures: auto-populate start/end measure from score's measure count when region type is "measures" in `plugins-external/sessions-plugin/TaskBuilder.tsx`
+- [X] T056 [P] Add Session return button: navigate back to sessions plugin from practice toolbar when practicing a session task in `frontend/plugins/practice-view-plugin/practiceToolbar.tsx`
+- [X] T057 [P] Fix Session button visibility: only show session return button when `sessionIdRef` is set in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+- [X] T058 [P] Add auto-start practice: automatically begin practice when opening from a session task in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+- [X] T059 [P] Session tree expansion with navigation data: expand session and task rows when returning from practice via `getNavigationData()` in `plugins-external/sessions-plugin/SessionsPlugin.tsx`
+- [X] T060 [P] Fix session tree expansion from saved practices: set `sessionIdRef` when opening saved practices from sessions plugin, pass `sessionId` in nav data in `plugins-external/sessions-plugin/TaskRow.tsx` and `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+- [X] T061 [P] Fix repractice honors task region: restore saved `loopRegion` via `setPendingTaskLoopRegion` when opening a saved practice in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+- [X] T062 [P] Fix extra measure playback: filter notes by `loopEndTickRef` before scheduling in `play()` and loop-back, simplify `setLoopEnd` to exclusive boundary, revert `measureRangeToTicks` `-1` hack in `frontend/src/services/playback/MusicTimeline.ts` and `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`
+- [X] T063 [P] Task row full-click expand/collapse: make entire task row clickable to toggle expansion instead of only the small arrow in `plugins-external/sessions-plugin/TaskRow.tsx`
+- [X] T064 [P] Show notes correct/total and duration in linked practices: extend `TaskLinkedPractice` with `correctCount`, `totalNotes`, `practiceTimeMs` and display in task detail in `plugins-external/sessions-plugin/sessionTypes.ts`, `plugins-external/sessions-plugin/sessionStorage.ts`, `plugins-external/sessions-plugin/TaskRow.tsx`
+- [X] T065 [P] Green tick for fully completed sessions: show ✓ icon next to session title when all tasks are done, using `allTasksDone` flag in `SessionIndexEntry` for instant display in `plugins-external/sessions-plugin/SessionsPlugin.tsx`, `plugins-external/sessions-plugin/sessionTypes.ts`, `plugins-external/sessions-plugin/sessionStorage.ts`
+- [X] T066 [P] Move close button to active session row and remove "Session Active" disabled button from actions bar in `plugins-external/sessions-plugin/SessionsPlugin.tsx`
+- [X] T067 [P] Add `--ls-success` theme token to all 10 landing themes and wire through `--color-success` bridge for green done indicators in `frontend/src/themes/landing-themes.css` and `frontend/src/App.css`
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies


### PR DESCRIPTION
## Tasks-Based Session Definition

Implements task-based session planning for the Sessions plugin. Musicians can now define structured practice sessions with specific tasks, each specifying a score, region, hands, iterations, tempo, and minimum result threshold.

### Core Implementation (T001–T046)
- **Task Builder UI**: Add/remove/reorder tasks with score picker, region selector, hand/tempo/iterations/min-result fields
- **Task Status Engine**: Automatic progression through todo → in-progress → done/failed based on practice results
- **Session Storage**: Full CRUD for sessions with tasks, activity tracking, and index management
- **Practice Integration**: Linked practices flow data back to tasks, updating status and tracking iterations
- **Restore & Inherit**: Create new sessions inheriting task configurations from previous sessions (FR-006)

### UX Enhancements (T047–T067)
- Practice config locking when launched from a task (T047)
- Tag labels and CSS collision fixes (T048–T049)
- Stale closure fixes in practice callbacks (T050)
- Replay note highlights and toolbar labels (T051, T061)
- Iterations field UX improvements (T052)
- Play honors region boundaries (T053)
- Default measure range handling (T054)
- Session return button and visibility fixes (T055–T056)
- Auto-start practice from task (T057)
- Session tree expansion with navigation data (T058–T059)
- Repractice honors task region (T060)
- Extra measure playback fix (T062)
- Full task-row click expand/collapse (T063)
- Linked practice shows notes correct/total and duration (T064)
- Green tick for fully completed sessions (T065)
- Close button moved to active session row (T066)
- `--ls-success` theme token across all 10 landing themes (T067)

### Technical Notes
- Sessions plugin is fully decoupled — app works correctly without it
- All 1690 frontend tests pass (25 skipped)
- All 461 Rust backend tests pass
- TypeScript compilation clean, production build succeeds

### Companion PR
- Sessions plugin repo: `061-session-task-definition` branch pushed to `graditone-pro-plugins`
