### PR TITLE
feat(065): Sessions Calendar View — design docs

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -138,6 +138,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-06
 - localStorage for master volume preference (follows existing `graditone:tempo:{scoreId}` pattern) (063-midi-volume-control)
 - Markdown (documentation only — no code changes) + None (references existing Rust backend, TypeScript frontend, and WASM bridge) (064-musicxml-processing-docs)
 - N/A (static markdown file in `docs/` directory) (064-musicxml-processing-docs)
+- TypeScript ~5.9.3, React 19.2.0 + React 19, Vite 7.2.4, existing sessions plugin (`plugins-external/sessions-plugin/`) (065-sessions-calendar-view)
+- IndexedDB (`sessions` store via `loadAllSessionsFromIndexedDB()`) + localStorage (`graditone-sessions-index`) (065-sessions-calendar-view)
 
 - Rust (latest stable 1.75+) + serde 1.0+, serde_json 1.0+ (serialization), thiserror 1.0+ (errors); web framework TBD in contracts phase (axum or actix-web) (001-score-model)
 
@@ -158,9 +160,9 @@ cargo test [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECH
 Rust (latest stable 1.75+): Follow standard conventions
 
 ## Recent Changes
+- 065-sessions-calendar-view: Added TypeScript ~5.9.3, React 19.2.0 + React 19, Vite 7.2.4, existing sessions plugin (`plugins-external/sessions-plugin/`)
 - 064-musicxml-processing-docs: Added Markdown (documentation only — no code changes) + None (references existing Rust backend, TypeScript frontend, and WASM bridge)
 - 063-midi-volume-control: Added Rust stable (backend/WASM) + TypeScript 5.x (frontend React) + wasm-bindgen, wasm-pack (backend→WASM); Tone.js, React 18+ (frontend)
-- 062-score-phrase-detection: Added Rust (latest stable) for backend phrase detection; TypeScript + React 18 for frontend visualization + serde (serialization), wasm-bindgen (WASM bindings), React (frontend UI)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/065-sessions-calendar-view/checklists/requirements.md
+++ b/specs/065-sessions-calendar-view/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Sessions Calendar View
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-03-30  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed on first validation iteration.
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/065-sessions-calendar-view/contracts/component-contracts.md
+++ b/specs/065-sessions-calendar-view/contracts/component-contracts.md
@@ -1,0 +1,122 @@
+# Component Contracts: Sessions Calendar View
+
+**Feature**: 065-sessions-calendar-view | **Date**: 2026-03-30
+
+This feature is frontend-only with no REST/GraphQL API. Contracts define the React component interfaces (props) that serve as internal boundaries.
+
+## CalendarView (Main Orchestrator)
+
+```typescript
+interface CalendarViewProps {
+  /** All sessions loaded from IndexedDB. Passed from parent to avoid re-fetching. */
+  readonly sessions: Session[]
+}
+```
+
+**Responsibilities**: Manages `CalendarViewState`, computes `Map<string, DaySummary>`, renders view selector (week/month/year), navigation controls, period summary, and delegates to the active sub-view.
+
+## CalendarMonthView
+
+```typescript
+interface CalendarMonthViewProps {
+  /** Aggregated day data for lookup */
+  readonly daySummaries: ReadonlyMap<string, DaySummary>
+  /** The month to display (any date in that month) */
+  readonly referenceDate: Date
+  /** Called when user clicks a day cell */
+  readonly onDayClick: (date: string) => void
+}
+```
+
+**Renders**: 6×7 grid (weeks × days), Monday-first. Day cells show activity count + formatted time if `DaySummary` exists for that date.
+
+## CalendarWeekView
+
+```typescript
+interface CalendarWeekViewProps {
+  /** Aggregated day data for lookup */
+  readonly daySummaries: ReadonlyMap<string, DaySummary>
+  /** The week to display (any date in that week) */
+  readonly referenceDate: Date
+  /** Called when user clicks a day column */
+  readonly onDayClick: (date: string) => void
+}
+```
+
+**Renders**: 7 day columns (Monday–Sunday). Each column shows day name, date, activity count, and formatted time.
+
+## CalendarYearView
+
+```typescript
+interface CalendarYearViewProps {
+  /** Aggregated day data for lookup */
+  readonly daySummaries: ReadonlyMap<string, DaySummary>
+  /** The year to display (any date in that year) */
+  readonly referenceDate: Date
+  /** Called when user clicks a month cell (navigates to month view) */
+  readonly onMonthClick: (date: Date) => void
+}
+```
+
+**Renders**: 4×3 grid of month cells. Each cell shows month name, total activity count, and total formatted time for that month.
+
+## CalendarDayOverlay
+
+```typescript
+interface CalendarDayOverlayProps {
+  /** The selected day's summary data */
+  readonly daySummary: DaySummary
+  /** Called when user closes the overlay */
+  readonly onClose: () => void
+  /** Maps taskId → task name for resolving task labels */
+  readonly taskNameMap: ReadonlyMap<string, string>
+}
+```
+
+**Renders**: Modal overlay with:
+1. **Summary header**: date, total activities, total time, average practice score
+2. **Activity list** (scrollable): For each activity — score title, practice name, practice score, note accuracy (correct/total), duration, completion status, optional task name
+
+## CalendarPeriodSummary
+
+```typescript
+interface CalendarPeriodSummaryProps {
+  /** Aggregated period data */
+  readonly summary: PeriodSummary
+}
+```
+
+**Renders**: Single line showing period label, total activities, and total formatted time.
+
+## Utility Functions (calendarUtils.ts)
+
+```typescript
+/** Group all activities across sessions into a day-keyed map */
+function aggregateByDay(sessions: readonly Session[]): Map<string, DaySummary>
+
+/** Compute summary for a date range */
+function computePeriodSummary(
+  daySummaries: ReadonlyMap<string, DaySummary>,
+  startDate: Date,
+  endDate: Date,
+  label: string
+): PeriodSummary
+
+/** Get Monday-aligned start of week for a given date */
+function getWeekStart(date: Date): Date
+
+/** Get all dates in a month grid (6 weeks × 7 days, may include prev/next month padding) */
+function getMonthGrid(year: number, month: number): Date[]
+
+/** Format milliseconds as human-readable duration */
+function formatDuration(ms: number): string
+
+/** Convert ISO string to local YYYY-MM-DD date key */
+function toLocalDateKey(isoString: string): string
+
+/** Build lookup map from taskId to task name across all sessions */
+function buildTaskNameMap(sessions: readonly Session[]): Map<string, string>
+
+/** Calculate average practice score for a list of activities */
+function averagePracticeScore(activities: readonly SessionActivity[]): number
+```

--- a/specs/065-sessions-calendar-view/data-model.md
+++ b/specs/065-sessions-calendar-view/data-model.md
@@ -1,0 +1,150 @@
+# Data Model: Sessions Calendar View
+
+**Feature**: 065-sessions-calendar-view | **Date**: 2026-03-30
+
+## Existing Entities (No Changes)
+
+### SessionActivity (read-only, from `sessionTypes.ts`)
+
+The calendar reads from existing `SessionActivity` records. No modifications needed.
+
+```typescript
+interface SessionActivity {
+  readonly id: string
+  readonly type: 'score-practice'
+  readonly createdAt: string              // ISO 8601 — used as calendar day key
+  readonly savedPracticeId: string
+  readonly practiceName: string
+  readonly scoreTitle: string
+  readonly completionStatus: 'complete' | 'partial'
+  readonly practiceScore: number          // 0–100
+  readonly correctCount: number
+  readonly totalNotes: number
+  readonly practiceTimeMs: number         // wall-clock duration in milliseconds
+  readonly taskId?: string                // optional link to session task
+}
+```
+
+### Session (read-only, from `sessionTypes.ts`)
+
+```typescript
+interface Session {
+  readonly id: string
+  readonly name: string
+  readonly createdAt: string
+  readonly status: 'active' | 'closed'
+  readonly tasks: SessionTask[]
+  readonly activities: SessionActivity[]
+}
+```
+
+## New Presentation Entities
+
+These are frontend-only view models derived from session data. They are not persisted.
+
+### DaySummary
+
+Aggregated data for a single calendar day. Keyed by ISO date string (YYYY-MM-DD).
+
+```typescript
+interface DaySummary {
+  readonly date: string                   // ISO date: "2026-03-15"
+  readonly activityCount: number          // total activities completed this day
+  readonly totalTimeMs: number            // sum of practiceTimeMs for all activities
+  readonly activities: SessionActivity[]  // full activity records for overlay detail
+}
+```
+
+**Derivation**: Group all `SessionActivity` records across all sessions by the date portion of `createdAt` (converted to local timezone). Sum counts and durations per day.
+
+### CalendarViewState
+
+Current view state managed by the CalendarView component.
+
+```typescript
+type CalendarGrouping = 'week' | 'month' | 'year'
+
+interface CalendarViewState {
+  readonly grouping: CalendarGrouping     // active view mode
+  readonly referenceDate: Date            // anchor date for current view period
+}
+```
+
+**Navigation**:
+- `month` view: `referenceDate` determines which month to display (any date in that month)
+- `week` view: `referenceDate` determines which week to display (any date in that week, Monday-aligned)
+- `year` view: `referenceDate` determines which year to display
+
+### DayOverlayState
+
+State for the day detail overlay.
+
+```typescript
+interface DayOverlayState {
+  readonly isOpen: boolean
+  readonly selectedDate: string | null    // ISO date of the selected day, or null if closed
+}
+```
+
+### PeriodSummary
+
+Aggregated data for the currently visible time period (week/month/year).
+
+```typescript
+interface PeriodSummary {
+  readonly label: string                  // e.g., "March 2026", "Week of Mar 23", "2026"
+  readonly activityCount: number          // total activities in period
+  readonly totalTimeMs: number            // sum of all practice time in period
+}
+```
+
+## Data Flow
+
+```
+IndexedDB (sessions store)
+    │
+    ▼
+loadAllSessionsFromIndexedDB()  ──→  Session[]
+    │
+    ▼
+aggregateByDay(sessions)  ──→  Map<string, DaySummary>
+    │                           key: "YYYY-MM-DD"
+    │
+buildTaskNameMap(sessions) ──→  Map<string, string>
+    │                           key: taskId, value: task name
+    ▼
+CalendarView component
+    │
+    ├── filterByPeriod(map, viewState) ──→ DaySummary[] for visible period
+    │                                      + PeriodSummary
+    ├── MonthView / WeekView / YearView renders day cells
+    │
+    └── onClick(day) ──→ DayOverlay with DaySummary.activities + taskNameMap
+```
+
+## Aggregation Logic (calendarUtils.ts)
+
+### `aggregateByDay(sessions: Session[]): Map<string, DaySummary>`
+
+1. Iterate all sessions, then all activities within each session.
+2. For each activity, extract the local date from `createdAt` (ISO string → `Date` → local YYYY-MM-DD).
+3. Group into `Map<string, DaySummary>` — accumulate counts and durations; collect activity references.
+
+### `computePeriodSummary(daySummaries: Map<string, DaySummary>, startDate: Date, endDate: Date, label: string): PeriodSummary`
+
+1. Filter map entries where date falls within [startDate, endDate] inclusive.
+2. Sum activity counts and total time across matching days.
+3. Use the provided `label` (e.g., "March 2026", "Week of Mar 23") for the PeriodSummary label field.
+
+### `buildTaskNameMap(sessions: Session[]): Map<string, string>`
+
+1. Iterate all sessions, then all tasks within each session.
+2. Map `task.id → task.name` into a `Map<string, string>`.
+3. Used by CalendarDayOverlay to resolve taskId to display name.
+
+### `formatDuration(ms: number): string`
+
+Convert milliseconds to human-readable format:
+- `< 60000` → "< 1 min"
+- `< 3600000` → "{N} min"
+- `≥ 3600000` → "{H}h {M}min"

--- a/specs/065-sessions-calendar-view/plan.md
+++ b/specs/065-sessions-calendar-view/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: Sessions Calendar View
+
+**Branch**: `065-sessions-calendar-view` | **Date**: 2026-03-30 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/065-sessions-calendar-view/spec.md`
+
+## Summary
+
+Add a Calendar tab to the Sessions plugin that visualizes practice history. The calendar aggregates existing `SessionActivity` records by day (using the existing `createdAt` timestamp) and displays them in week/month/year views with period summaries. Clicking a day opens a detail overlay with activity-level data. Built entirely in the frontend React/TypeScript layer with no backend or data model changes — reads from existing IndexedDB/localStorage session storage.
+
+## Technical Context
+
+**Language/Version**: TypeScript ~5.9.3, React 19.2.0
+**Primary Dependencies**: React 19, Vite 7.2.4, existing sessions plugin (`plugins-external/sessions-plugin/`)
+**Storage**: IndexedDB (`sessions` store via `loadAllSessionsFromIndexedDB()`) + localStorage (`graditone-sessions-index`)
+**Testing**: Vitest 4.0.18 (unit), Playwright 1.58.2 (e2e), @testing-library/react 16.3.2
+**Target Platform**: Tablet devices (iPad/Surface/Android tablets) — PWA, Chrome 57+, Safari 11+, Edge 16+
+**Project Type**: Web (monorepo: `frontend/` + `plugins-external/sessions-plugin/`)
+**Performance Goals**: Calendar tab loads and aggregates all sessions (<50) in <200ms; 60fps UI interactions
+**Constraints**: Max 50 sessions in storage; offline-first; touch targets ≥44×44px; read-only view (no writes)
+**Scale/Scope**: Up to 50 sessions × ~20 activities each = ~1000 activities max to aggregate
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Domain-Driven Design | ✅ PASS | Uses existing domain entities (Session, SessionActivity). New DaySummary and CalendarView are presentation-layer aggregates, not domain entities. |
+| II. Hexagonal Architecture | ✅ PASS | Calendar is a frontend presentation feature. Reads from storage adapters via existing `sessionStorage.ts` functions. No backend or domain changes needed. |
+| III. Progressive Web Application | ✅ PASS | Runs entirely client-side from cached data. Offline-capable. Tablet-optimized touch targets. |
+| IV. Precision & Fidelity | ✅ N/A | Calendar does not perform music timing calculations. `practiceTimeMs` is wall-clock duration (integers). |
+| V. Test-First Development | ✅ PASS | Will follow TDD: unit tests for aggregation logic, component tests for views, e2e for navigation flows. |
+| VI. Layout Engine Authority | ✅ N/A | Calendar is UI chrome, not score layout. No spatial geometry or notation rendering involved. |
+| VII. Regression Prevention | ✅ PASS | Any bugs found during implementation will get regression tests before fixes. |
+
+**Gate result: PASS — No violations. Proceeding to Phase 0.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/065-sessions-calendar-view/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+plugins-external/sessions-plugin/
+├── index.tsx                     # Plugin registration (add Calendar tab support)
+├── sessionTypes.ts               # No changes needed (createdAt already exists)
+├── sessionStorage.ts             # No changes needed (loadAllSessionsFromIndexedDB already exists)
+├── SessionsPlugin.tsx            # Add Sessions/Calendar tab toggle
+├── SessionsPlugin.css            # Styles for tab toggle + calendar
+├── CalendarView.tsx              # NEW — Main calendar component (week/month/year switcher + navigation)
+├── CalendarMonthView.tsx         # NEW — Month grid component
+├── CalendarWeekView.tsx          # NEW — Week columns component
+├── CalendarYearView.tsx          # NEW — Year grid component
+├── CalendarDayOverlay.tsx        # NEW — Day detail overlay with activity list
+├── CalendarPeriodSummary.tsx     # NEW — Period summary line component
+├── calendarUtils.ts              # NEW — Date math, aggregation logic, formatting helpers
+├── calendarUtils.test.ts         # NEW — Unit tests for aggregation and date logic
+└── calendarView.test.tsx         # NEW — Component tests for calendar views
+```
+
+**Structure Decision**: All new code lives within the existing `plugins-external/sessions-plugin/` directory, following the established plugin structure pattern. No new top-level directories or projects needed. Calendar components are co-located with the sessions plugin they extend.
+
+## Complexity Tracking
+
+No constitution violations — this section is not needed.

--- a/specs/065-sessions-calendar-view/quickstart.md
+++ b/specs/065-sessions-calendar-view/quickstart.md
@@ -1,0 +1,78 @@
+# Quickstart: Sessions Calendar View
+
+**Feature**: 065-sessions-calendar-view | **Date**: 2026-03-30
+
+## Prerequisites
+
+- Node.js with npm/pnpm installed
+- Working Graditone frontend dev environment
+
+## Development Setup
+
+```bash
+# Checkout feature branch
+git checkout 065-sessions-calendar-view
+
+# Install frontend dependencies (if not already done)
+cd frontend && npm install
+
+# Start dev server with hot reload
+npm run dev
+```
+
+## Where to Write Code
+
+All new code goes in `plugins-external/sessions-plugin/`:
+
+| File | Purpose |
+|------|---------|
+| `calendarUtils.ts` | Date math, aggregation, formatting (start here — TDD) |
+| `calendarUtils.test.ts` | Unit tests for all utility functions |
+| `CalendarView.tsx` | Main orchestrator: tab content, view switcher, navigation |
+| `CalendarMonthView.tsx` | Month grid (6×7 calendar) |
+| `CalendarWeekView.tsx` | Week columns (7-day row) |
+| `CalendarYearView.tsx` | Year grid (12 month cells) |
+| `CalendarDayOverlay.tsx` | Day detail modal overlay |
+| `CalendarPeriodSummary.tsx` | Period summary line |
+| `SessionsPlugin.tsx` | Add Sessions/Calendar tab toggle (modify existing) |
+| `SessionsPlugin.css` | Add calendar styles (modify existing) |
+
+## Existing Files to Read (Not Modify)
+
+- `sessionTypes.ts` — `SessionActivity`, `Session`, `SessionTask` interfaces
+- `sessionStorage.ts` — `loadAllSessionsFromIndexedDB()` function
+- `useSessionManager.ts` — React hook for session state
+- `index.tsx` — Plugin registration pattern
+
+## Running Tests
+
+```bash
+# Unit tests (from frontend directory)
+cd frontend && npx vitest run --reporter=verbose
+
+# Watch mode for TDD
+cd frontend && npx vitest --watch
+
+# Run only calendar tests
+cd frontend && npx vitest run calendarUtils
+```
+
+## Implementation Order (TDD)
+
+1. **calendarUtils.ts**: Write tests first for `toLocalDateKey`, `aggregateByDay`, `formatDuration`, `getWeekStart`, `getMonthGrid`, `computePeriodSummary`, `averagePracticeScore`
+2. **CalendarView.tsx**: Wire up data loading from `loadAllSessionsFromIndexedDB()` and view state
+3. **CalendarMonthView.tsx**: Month grid with day cells
+4. **SessionsPlugin.tsx**: Add tab toggle to switch between Sessions list and Calendar
+5. **CalendarDayOverlay.tsx**: Day detail overlay with summary header + activity list
+6. **CalendarWeekView.tsx**: Week columns view
+7. **CalendarYearView.tsx**: Year grid view
+8. **CalendarPeriodSummary.tsx**: Period summary line component
+
+## Key Design Decisions
+
+- **No date library**: Use native `Date` API with custom utilities
+- **No data model changes**: Existing `SessionActivity.createdAt` is sufficient
+- **Load-once strategy**: All sessions loaded on Calendar tab activation, aggregated in memory
+- **Monday-first weeks**: ISO 8601 standard, hardcoded
+- **CSS conventions**: Use `--ls-` CSS variables, `.calendar-` class prefix
+- **Overlay pattern**: Follow `ListDialog` modal pattern from existing codebase

--- a/specs/065-sessions-calendar-view/research.md
+++ b/specs/065-sessions-calendar-view/research.md
@@ -1,0 +1,83 @@
+# Research: Sessions Calendar View
+
+**Feature**: 065-sessions-calendar-view | **Date**: 2026-03-30
+
+## Research Tasks & Findings
+
+### R1: Activity Timestamp Strategy
+
+**Question**: How to attribute activities to calendar days when `SessionActivity` already has `createdAt` but no `completedAt`?
+
+**Finding**: `SessionActivity` already has `readonly createdAt: string` (ISO 8601 format), set via `new Date().toISOString()` at the moment the practice is saved. This timestamp effectively represents when the activity was completed (it's set when `PracticeSavedEvent` fires after practice ends).
+
+**Decision**: Rename the spec's concept of `completedAt` to use the existing `createdAt` field directly — it already captures completion time. No new field or backfill needed.
+
+**Rationale**: The `createdAt` field in `SessionActivity` is set when the practice finishes (via `PracticeSavedEvent`), not when the session starts. This is functionally equivalent to "completed at" and already exists on every activity.
+
+**Alternatives considered**:
+- Add a separate `completedAt` field → Rejected: redundant with existing `createdAt` which already captures completion time
+- Use session-level `createdAt` → Rejected: less precise; a session may contain activities from different practice completion times
+
+### R2: Date Library Choice
+
+**Question**: Should we use a date library for calendar date math (week boundaries, month grids, navigation)?
+
+**Finding**: The frontend has no date library dependency. All existing code uses native `Date` and `toISOString()`.
+
+**Decision**: Use native `Date` API with custom utility functions in `calendarUtils.ts`.
+
+**Rationale**: Calendar date math (start-of-week, days-in-month, month grid generation) is well-defined and doesn't require a library for this scope. Adding `date-fns` would increase bundle size for ~5 utility functions. The 50-session/1000-activity scale doesn't need optimized date parsing.
+
+**Alternatives considered**:
+- `date-fns` → Good tree-shaking but adds a dependency for simple operations
+- `dayjs` → Lightweight but still an unnecessary dependency for this scope
+
+### R3: Tab/Toggle UI Pattern
+
+**Question**: How to implement the Sessions/Calendar tab toggle?
+
+**Finding**: No dedicated tab component exists. Existing patterns use button groups with `aria-pressed` and bottom-border active indicators (see `DesignNavbar.css`).
+
+**Decision**: Create a simple two-button tab bar within the `SessionsPlugin` component using `aria-selected` attributes and the existing `--ls-` CSS variable system. Follow the `DesignNavbar.css` bottom-border pattern for active state.
+
+**Rationale**: Consistent with existing project patterns. Two tabs don't warrant a generic TabBar component — a dedicated inline implementation is simpler.
+
+### R4: Day Detail Overlay Pattern
+
+**Question**: How to implement the day detail overlay (modal/dialog)?
+
+**Finding**: Multiple modal/dialog patterns exist: `ListDialog`, `PluginManagerDialog`, `LoadScoreDialog`, `IOSInstallModal`. `ListDialog` is the closest match — it provides a generic scrollable list with header and footer.
+
+**Decision**: Follow the `ListDialog` pattern (React state + CSS backdrop overlay) but create a purpose-built `CalendarDayOverlay` component. The overlay will have a summary header (total activities, total time, average score) and a scrollable activity list.
+
+**Rationale**: `ListDialog` demonstrates the established overlay pattern but is specific to its use case. The calendar day overlay has unique layout requirements (summary header + activity cards) that justify its own component while following the same CSS/structural conventions.
+
+### R5: Data Loading & Aggregation Strategy
+
+**Question**: How to efficiently load and aggregate session data for the calendar?
+
+**Finding**: `loadAllSessionsFromIndexedDB()` returns `Promise<Session[]>` — loads all sessions at once. Max 50 sessions. Each session has an `activities: SessionActivity[]` array. Activities have `createdAt` (ISO string) and `practiceTimeMs` (integer milliseconds).
+
+**Decision**: Load all sessions once on Calendar tab activation. Build an in-memory `Map<string, DaySummary>` keyed by ISO date string (YYYY-MM-DD), grouping activities by their `createdAt` date. Keep the map in React state while the Calendar tab is open. Recompute only when tab is re-activated.
+
+**Rationale**: With max ~1000 activities, in-memory aggregation is fast (<10ms). No need for lazy loading, pagination, or pre-computed caches. The one-time IndexedDB read + aggregation fits well within the 200ms load target.
+
+### R6: CSS Styling Conventions
+
+**Question**: What CSS patterns to follow for calendar components?
+
+**Finding**: Sessions plugin uses plain CSS (not CSS modules) with `--ls-` prefixed CSS custom properties. Key tokens: `--ls-bg`, `--ls-navbar-bg`, `--ls-cta-bg`, `--ls-heading`, `--ls-body`, `--color-border`, `--ls-font-body`, `--ls-font-heading`.
+
+**Decision**: Add calendar styles to `SessionsPlugin.css` using the existing `--ls-` variable system. Use `.calendar-` prefixed class names for namespacing.
+
+**Rationale**: Consistent with the existing sessions plugin styling approach. Keeps all plugin styles in one file. Calendar should visually match the sessions list view.
+
+### R7: Week Start Convention
+
+**Question**: The spec says Monday start (ISO 8601). Need to verify this aligns with existing locale handling.
+
+**Finding**: No locale-specific week start logic exists in the codebase. The spec explicitly states "Week starts on Monday (ISO 8601 standard)."
+
+**Decision**: Hardcode Monday as week start. Use `getDay()` with adjustment (Sunday=0 mapped to 7) for consistent Monday-first week calculations.
+
+**Rationale**: Spec requirement. ISO 8601 standard. Simpler than locale-aware week starts.

--- a/specs/065-sessions-calendar-view/spec.md
+++ b/specs/065-sessions-calendar-view/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Sessions Calendar View
+
+**Feature Branch**: `065-sessions-calendar-view`  
+**Created**: 2026-03-30  
+**Status**: Draft  
+**Input**: User description: "Sessions Calendar view: Show in a calendar the number of activities done each day and the total time. Click on calendar day data to show an overlay window with activity details. Support week, month, year grouping for different time period reports."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Monthly Calendar Overview (Priority: P1)
+
+A musician opens the Sessions Calendar view and sees a monthly calendar grid. Each day cell that has recorded practice activities displays a summary badge showing the number of activities completed and the total practice time for that day. Days without activity appear empty. The user can quickly scan the month to understand their practice consistency and identify gaps.
+
+**Why this priority**: The monthly calendar is the core visual representation that delivers immediate value — users can see their practice habits at a glance without navigating away or clicking anything.
+
+**Independent Test**: Can be fully tested by creating sessions with activities on several dates, opening the calendar view, and verifying that each day cell shows the correct activity count and total time.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has completed 3 activities totaling 45 minutes on March 15, **When** they open the Sessions Calendar in month view for March, **Then** the cell for March 15 displays "3 activities · 45 min".
+2. **Given** the user has no recorded activities on March 10, **When** they view the month calendar, **Then** the cell for March 10 appears empty (no badge or summary).
+3. **Given** the user opens the calendar for the first time with no session data, **When** the month view loads, **Then** the current month is displayed with all day cells empty and a message indicating no practice data is available.
+4. **Given** the user is viewing March 2026, **When** they navigate to a previous or next month, **Then** the calendar updates to show the selected month with the correct daily summaries.
+5. **Given** the user is viewing March 2026 with activities across several days, **When** the month view loads, **Then** a period summary line at the top shows the total activities and total time for the entire month.
+
+---
+
+### User Story 2 - Day Detail Overlay (Priority: P2)
+
+A musician sees an interesting day on the calendar (e.g., a day with many activities) and clicks on that day's cell to learn more. An overlay window appears showing the full list of activities for that day, including for each activity: the score title, practice name, practice score (0–100), note accuracy (correct/total), practice duration, and completion status. The user can close the overlay to return to the calendar.
+
+**Why this priority**: The day detail overlay transforms the calendar from a read-only summary into an interactive exploration tool, letting users review their practice history in depth for any specific day.
+
+**Independent Test**: Can be fully tested by clicking on a day cell that has activities and verifying the overlay displays correct, complete activity details.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is viewing the month calendar and March 15 has 3 activities, **When** they click on the March 15 cell, **Then** an overlay window appears listing all 3 activities with score title, practice name, practice score, note accuracy, duration, and completion status for each.
+2. **Given** the day detail overlay is open, **When** the user clicks the close button or clicks outside the overlay, **Then** the overlay closes and the calendar view is visible again.
+3. **Given** the user clicks on a day with no activities, **Then** no overlay is shown (or the click has no effect).
+4. **Given** an activity is linked to a session task, **When** the overlay is displayed, **Then** the task name is shown alongside the activity details.
+
+---
+
+### User Story 3 - Week Grouping View (Priority: P3)
+
+A musician wants a more granular view of their recent practice. They switch to the week view, which shows the 7 days of the current week as columns. Each day column shows the activity count and total time, similar to the month view cells. The user can navigate to previous or next weeks.
+
+**Why this priority**: Week view provides a focused short-term perspective that complements the monthly overview, ideal for tracking weekly goals or recent activity.
+
+**Independent Test**: Can be fully tested by switching to week view and verifying the 7-day columns display correct summaries and navigation works.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user switches to week view, **When** the view loads, **Then** the current week (Monday–Sunday) is displayed with each day showing activity count and total time, plus a period summary line at the top for the week total.
+2. **Given** the user is in week view, **When** they navigate to the previous week, **Then** the displayed week shifts back 7 days with updated summaries.
+3. **Given** the user clicks on a day in week view, **When** that day has activities, **Then** the same day detail overlay opens as in month view.
+
+---
+
+### User Story 4 - Year Grouping View (Priority: P4)
+
+A musician wants to see their long-term practice patterns over an entire year. They switch to the year view, which displays all 12 months in a grid. Each month cell shows the total number of activities and total practice time for that month. Clicking on a month cell navigates the user to the month view for that specific month.
+
+**Why this priority**: Year view enables long-term pattern recognition and motivation tracking, but depends on users having accumulated enough data to be meaningful.
+
+**Independent Test**: Can be fully tested by switching to year view and verifying each month cell shows correct aggregated totals, and clicking a month navigates to month view.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user switches to year view for 2026, **When** the view loads, **Then** all 12 months are displayed, each showing total activity count and total time for that month, plus a period summary line at the top for the year total.
+2. **Given** the user clicks on a month cell in year view, **When** that month has activities, **Then** the calendar switches to month view for that specific month.
+3. **Given** the user is in year view, **When** they navigate to the previous or next year, **Then** the year updates with correct aggregated data.
+
+---
+
+### Edge Cases
+
+- What happens when sessions span midnight (an activity started before midnight and ended after)? The activity is attributed to the day of its `createdAt` timestamp (set at practice completion time).
+- What happens when the user has sessions but all activities have zero duration? The day cell shows the activity count with "< 1 min" for the time (consistent with the formatDuration rule for durations under 60 seconds).
+- What happens when the user deletes a session that had activities? The calendar recalculates and no longer shows those activities for the affected days.
+- How does the calendar handle different time zones? The calendar uses the user's local time zone for all date grouping.
+- What happens when the user has a very large number of activities on one day (e.g., 50+)? The day detail overlay should be scrollable to accommodate long activity lists.
+
+## Clarifications
+
+### Session 2026-03-30
+
+- Q: How should the calendar determine which day an activity belongs to? → A: Use the existing `createdAt` field on SessionActivity, which is already set at practice completion time (when `PracticeSavedEvent` fires). No new field or backfill needed.
+- Q: How should the user access the calendar view within the Sessions plugin? → A: A tab/toggle at the top of the Sessions panel switching between "Sessions" list and "Calendar" view.
+- Q: When should the calendar load and aggregate session activity data? → A: Load all sessions once when Calendar tab is activated; keep aggregated data in memory while tab is open.
+- Q: Should the day detail overlay include a summary header with day-level aggregates? → A: Yes — summary header with total activities, total time, and average practice score.
+- Q: Should each view (week/month/year) display a total summary for the visible time period? → A: Yes — a period summary line (total activities + total time) displayed at the top of each view.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST display a calendar view accessible via a tab/toggle at the top of the Sessions plugin panel, alongside the existing Sessions list view. The calendar shows practice activity data aggregated by day.
+- **FR-002**: Each day cell in the calendar MUST display the total number of activities completed and the total practice time for that day.
+- **FR-003**: Users MUST be able to switch between week, month, and year grouping views using a view selector control.
+- **FR-004**: The month view MUST display a standard calendar grid (rows of weeks, columns for days Monday–Sunday) for the selected month.
+- **FR-005**: The week view MUST display 7 day columns (Monday–Sunday) for the selected week.
+- **FR-006**: The year view MUST display all 12 months for the selected year, each showing aggregated activity count and total time.
+- **FR-007**: Users MUST be able to navigate forward and backward in time (previous/next week, month, or year depending on the active view).
+- **FR-008**: When a user clicks on a day cell that has activities (in week or month view), the system MUST display an overlay window with the detailed list of activities for that day.
+- **FR-009**: The day detail overlay MUST display a summary header at the top showing total activities, total practice time, and average practice score for that day. Below the header, it MUST list each activity with: score title, practice name, practice score (0–100), note accuracy (correct notes / total notes), practice duration, completion status, and task name (when the activity is linked to a session task).
+- **FR-010**: The day detail overlay MUST be dismissible by clicking a close button or clicking outside the overlay area.
+- **FR-011**: When a user clicks on a month cell in year view, the system MUST navigate to the month view for that specific month.
+- **FR-012**: The calendar MUST aggregate activity data from all sessions stored in the sessions index, reading activity details from persisted session data. All session data is loaded once when the Calendar tab is activated and kept in memory while the tab remains open.
+- **FR-013**: The calendar MUST default to the month view showing the current month when first opened.
+- **FR-014**: Practice time MUST be displayed in a human-readable format (e.g., "1h 23min" for durations over an hour, "45 min" for shorter durations).
+- **FR-015**: The day detail overlay MUST be scrollable when the number of activities exceeds the visible area.
+- **FR-016**: Days without any activities MUST appear visually distinct from days with activities (no badge, no summary text).
+- **FR-017**: Each view (week, month, year) MUST display a period summary line at the top showing the total number of activities and total practice time for the currently visible time period.
+
+### Key Entities
+
+- **DaySummary**: Represents the aggregated data for a single calendar day — includes the date, total activity count, and total practice time. Derived by grouping all SessionActivity records by their completion date.
+- **ActivityDetail**: Represents a single practice activity displayed in the day overlay — includes score title, practice name, practice score, note accuracy, duration, completion status, and optional task linkage. Maps directly to the existing SessionActivity data. Each activity is attributed to the calendar day based on its `createdAt` timestamp.
+- **CalendarView**: Represents the current view state — includes the active grouping mode (week/month/year), the selected time period, and the navigation position.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can identify which days they practiced and how much time they spent within 5 seconds of opening the calendar view.
+- **SC-002**: Users can access the full activity details for any specific day within 2 clicks (one to open calendar, one to click the day).
+- **SC-003**: Users can switch between week, month, and year views within 1 click using the view selector.
+- **SC-004**: The calendar correctly aggregates and displays data from all stored sessions (up to the 50-session storage cap) without data loss or miscounting.
+- **SC-005**: Users can navigate to any past time period to review historical practice data with no more than one click per period shift.
+- **SC-006**: The day detail overlay displays all activity fields (score title, practice name, score, accuracy, duration, status) for 100% of activities on the selected day.
+
+## Assumptions
+
+- The calendar reads from existing session and activity data — no changes to the session data model are required.
+- Each SessionActivity's existing `createdAt` field (set at practice completion time) is used for calendar date grouping. The user's local time zone is used for date grouping.
+- The calendar view is accessed via a tab/toggle at the top of the Sessions plugin panel (switching between "Sessions" and "Calendar"), not as a separate top-level view.
+- Week starts on Monday (ISO 8601 standard).
+- The calendar is read-only — it does not allow creating, editing, or deleting sessions or activities.
+

--- a/specs/065-sessions-calendar-view/tasks.md
+++ b/specs/065-sessions-calendar-view/tasks.md
@@ -1,0 +1,246 @@
+# Tasks: Sessions Calendar View
+
+**Input**: Design documents from `/specs/065-sessions-calendar-view/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Tests are included as this project follows TDD per Constitution Principle V.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Plugin directory**: `plugins-external/sessions-plugin/`
+- All new files created inside the existing sessions plugin directory
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Utility module with date math, aggregation logic, and formatting — the foundation all views depend on
+
+- [x] T001 [P] Create `toLocalDateKey()` tests in `plugins-external/sessions-plugin/calendarUtils.test.ts` — test ISO string to YYYY-MM-DD conversion using local timezone
+- [x] T002 [P] Create `formatDuration()` tests in `plugins-external/sessions-plugin/calendarUtils.test.ts` — test <1min, minutes, hours+minutes formatting
+- [x] T003 [P] Create `averagePracticeScore()` tests in `plugins-external/sessions-plugin/calendarUtils.test.ts` — test empty array, single activity, multiple activities averaging
+- [x] T004 Create `toLocalDateKey()`, `formatDuration()`, and `averagePracticeScore()` implementations in `plugins-external/sessions-plugin/calendarUtils.ts` — ensure T001–T003 tests pass
+- [x] T005 Create `getWeekStart()` tests in `plugins-external/sessions-plugin/calendarUtils.test.ts` — test Monday alignment for each day of the week
+- [x] T006 Create `getMonthGrid()` tests in `plugins-external/sessions-plugin/calendarUtils.test.ts` — test grid generation returns 42 dates (6 weeks × 7 days), Monday-first, with correct prev/next month padding
+- [x] T007 Create `getWeekStart()` and `getMonthGrid()` implementations in `plugins-external/sessions-plugin/calendarUtils.ts` — ensure T005–T006 tests pass
+- [x] T008 Create `aggregateByDay()` tests in `plugins-external/sessions-plugin/calendarUtils.test.ts` — test empty sessions, single session with multiple activities on same/different days, multiple sessions merging
+- [x] T009 Create `computePeriodSummary()` tests in `plugins-external/sessions-plugin/calendarUtils.test.ts` — test date range filtering and sum correctness
+- [x] T010 Create `aggregateByDay()` and `computePeriodSummary()` implementations in `plugins-external/sessions-plugin/calendarUtils.ts` — ensure T008–T009 tests pass
+
+**Checkpoint**: All utility functions tested and implemented. Calendar views can now be built.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared calendar shell component and tab toggle — must be complete before any user story view work
+
+**⚠️ CRITICAL**: No user story view work can begin until this phase is complete
+
+- [x] T011 Create `CalendarPeriodSummary` component in `plugins-external/sessions-plugin/CalendarPeriodSummary.tsx` — renders period label, total activities, and formatted total time using PeriodSummary props
+- [x] T012 Create `CalendarView` orchestrator component in `plugins-external/sessions-plugin/CalendarView.tsx` — manages CalendarViewState (grouping + referenceDate), computes aggregateByDay from sessions prop, renders view selector (week/month/year buttons), navigation controls (prev/next), CalendarPeriodSummary, and placeholder content for sub-views
+- [x] T013 Add Sessions/Calendar tab toggle to `plugins-external/sessions-plugin/SessionsPlugin.tsx` — add two-button tab bar at top of panel with aria-selected, toggle between existing sessions list and CalendarView; load all sessions via `loadAllSessionsFromIndexedDB()` when Calendar tab is activated and pass to CalendarView
+- [x] T014 Add calendar CSS styles to `plugins-external/sessions-plugin/SessionsPlugin.css` — tab toggle styles (bottom-border active indicator per DesignNavbar pattern), view selector buttons, navigation controls, period summary line, calendar grid layout, all using `--ls-` CSS variables and `.calendar-` class prefix
+
+**Checkpoint**: Tab toggle works, CalendarView shell renders with view switcher, navigation, and period summary. Sub-views show placeholders.
+
+---
+
+## Phase 3: User Story 1 — Monthly Calendar Overview (Priority: P1) 🎯 MVP
+
+**Goal**: Display a monthly calendar grid where each day cell shows activity count and total practice time. Includes month navigation and period summary.
+
+**Independent Test**: Open Calendar tab → see current month grid → verify day cells show correct activity count + time → navigate months → verify period summary updates.
+
+### Tests for User Story 1
+
+- [x] T015 [P] [US1] Create CalendarMonthView component test in `plugins-external/sessions-plugin/calendarView.test.tsx` — test renders 42 day cells in 6×7 grid, Monday-first; day cells with activities show count + formatted time; empty days render without badge; month/year header is correct
+- [x] T016 [P] [US1] Create CalendarMonthView navigation test in `plugins-external/sessions-plugin/calendarView.test.tsx` — test prev/next month changes referenceDate; period summary updates with new month's aggregated data
+
+### Implementation for User Story 1
+
+- [x] T017 [US1] Create `CalendarMonthView` component in `plugins-external/sessions-plugin/CalendarMonthView.tsx` — render 6×7 grid using `getMonthGrid()`, look up each date in daySummaries map, display activity count + `formatDuration()` in cells with data, apply distinct style for empty vs active days, call `onDayClick` on cell click
+- [x] T018 [US1] Wire CalendarMonthView into CalendarView in `plugins-external/sessions-plugin/CalendarView.tsx` — replace month placeholder with CalendarMonthView, connect daySummaries, referenceDate, and onDayClick handler; compute month period summary using `computePeriodSummary()` with month date range
+- [x] T019 [US1] Add month grid CSS to `plugins-external/sessions-plugin/SessionsPlugin.css` — 7-column grid layout, day cell sizing (≥44×44px touch targets), active day cell badge styling, weekday header row, current-day highlight, empty cell styling
+- [x] T020 [US1] Handle empty state in CalendarMonthView in `plugins-external/sessions-plugin/CalendarMonthView.tsx` — when no activities exist for any day in the month, display a message indicating no practice data is available
+
+**Checkpoint**: Monthly calendar is fully functional — day cells show correct data, navigation works, period summary is accurate, empty state handled. MVP is usable.
+
+---
+
+## Phase 4: User Story 2 — Day Detail Overlay (Priority: P2)
+
+**Goal**: Click a day cell to open an overlay showing a summary header (total activities, total time, average score) and scrollable list of individual activity details.
+
+**Independent Test**: Click a day with activities → overlay opens showing summary header + activity list with all fields → click close or outside → overlay dismisses → clicking empty day does nothing.
+
+### Tests for User Story 2
+
+- [x] T021 [P] [US2] Create CalendarDayOverlay component test in `plugins-external/sessions-plugin/calendarView.test.tsx` — test summary header shows date, total activities, total time, average practice score; activity list shows score title, practice name, practice score, note accuracy (correct/total), duration, completion status for each activity; scrollable container renders
+- [x] T022 [P] [US2] Create CalendarDayOverlay dismissal test in `plugins-external/sessions-plugin/calendarView.test.tsx` — test close button calls onClose; clicking backdrop calls onClose; Escape key calls onClose
+
+### Implementation for User Story 2
+
+- [x] T023 [US2] Create `CalendarDayOverlay` component in `plugins-external/sessions-plugin/CalendarDayOverlay.tsx` — modal overlay with backdrop; summary header showing date, total activities, `formatDuration(totalTimeMs)`, `averagePracticeScore(activities)`; scrollable activity list rendering each activity's scoreTitle, practiceName, practiceScore, correctCount/totalNotes, `formatDuration(practiceTimeMs)`, completionStatus, and optional task name (resolved via `taskNameMap` prop); close button; click-outside-to-dismiss
+- [x] T024 [US2] Wire CalendarDayOverlay into CalendarView in `plugins-external/sessions-plugin/CalendarView.tsx` — manage DayOverlayState; on day click, look up DaySummary and open overlay if activities exist (ignore clicks on empty days); compute `buildTaskNameMap(sessions)` and pass as `taskNameMap` prop along with onClose to dismiss
+- [x] T025 [US2] Add overlay CSS to `plugins-external/sessions-plugin/SessionsPlugin.css` — backdrop with semi-transparent background, centered overlay panel, summary header styling, scrollable activity list with max-height, activity card layout, close button positioning, responsive sizing for tablet
+
+**Checkpoint**: Day detail overlay is functional — opens with correct data, shows summary + activity list, dismisses correctly. Works with month view from US1.
+
+---
+
+## Phase 5: User Story 3 — Week Grouping View (Priority: P3)
+
+**Goal**: Show 7-day columns (Monday–Sunday) for the selected week with activity count and total time per day. Supports navigation and day click overlay.
+
+**Independent Test**: Switch to week view → see 7 day columns for current week → verify activity data per day → navigate weeks → click day opens overlay.
+
+### Tests for User Story 3
+
+- [x] T026 [P] [US3] Create CalendarWeekView component test in `plugins-external/sessions-plugin/calendarView.test.tsx` — test renders 7 day columns Monday–Sunday; each column shows day name, date, activity count + formatted time; week period summary is correct; navigation shifts by 7 days
+
+### Implementation for User Story 3
+
+- [x] T027 [US3] Create `CalendarWeekView` component in `plugins-external/sessions-plugin/CalendarWeekView.tsx` — render 7 day columns using `getWeekStart()` to find Monday, iterate 7 days; look up each date in daySummaries map; display day name, date number, activity count + `formatDuration()`; call `onDayClick` on column click
+- [x] T028 [US3] Wire CalendarWeekView into CalendarView in `plugins-external/sessions-plugin/CalendarView.tsx` — replace week placeholder; compute week period summary using week start/end date range; connect navigation to shift by 7 days
+- [x] T029 [US3] Add week view CSS to `plugins-external/sessions-plugin/SessionsPlugin.css` — 7-column equal-width layout, day column styling, date header, touch-friendly column sizing
+
+**Checkpoint**: Week view is functional — 7-day columns, correct data, navigation, overlay integration work.
+
+---
+
+## Phase 6: User Story 4 — Year Grouping View (Priority: P4)
+
+**Goal**: Show 12 month cells in a grid for the selected year with aggregated activity count and total time per month. Click a month to navigate to month view.
+
+**Independent Test**: Switch to year view → see 12 month cells → verify per-month aggregates → click a month → navigates to month view for that month → navigate years.
+
+### Tests for User Story 4
+
+- [x] T030 [P] [US4] Create CalendarYearView component test in `plugins-external/sessions-plugin/calendarView.test.tsx` — test renders 12 month cells (4×3 grid); each cell shows month name, total activity count + formatted time; year period summary is correct; clicking month calls onMonthClick with correct date
+
+### Implementation for User Story 4
+
+- [x] T031 [US4] Create `CalendarYearView` component in `plugins-external/sessions-plugin/CalendarYearView.tsx` — render 4×3 grid of month cells; for each month, aggregate all DaySummary entries within that month's date range; display month name, activity count + `formatDuration()`; call `onMonthClick` on cell click
+- [x] T032 [US4] Wire CalendarYearView into CalendarView in `plugins-external/sessions-plugin/CalendarView.tsx` — replace year placeholder; on month click, set grouping to 'month' and referenceDate to first day of clicked month; compute year period summary
+- [x] T033 [US4] Add year view CSS to `plugins-external/sessions-plugin/SessionsPlugin.css` — 3-column or 4×3 grid layout, month cell sizing with touch-friendly targets, hover/active states
+
+**Checkpoint**: Year view is functional — 12 month cells with correct aggregates, month-click navigation, year period summary. All 4 user stories complete.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [x] T034 [P] Add keyboard accessibility to CalendarView in `plugins-external/sessions-plugin/CalendarView.tsx` — ensure tab toggle, view selector, navigation, and day/month cells are keyboard-navigable with proper aria attributes
+- [x] T035 [P] Add empty calendar state to `plugins-external/sessions-plugin/CalendarView.tsx` — when no sessions exist at all, show a helpful message across all views
+- [x] T036 Run quickstart.md validation — follow steps in `specs/065-sessions-calendar-view/quickstart.md` end-to-end to verify dev setup, test commands, and implementation order work as documented
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (calendarUtils) — BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Phase 2 — delivers MVP
+- **User Story 2 (Phase 4)**: Depends on Phase 2 — can run in parallel with US1 but integrates after
+- **User Story 3 (Phase 5)**: Depends on Phase 2 — can run in parallel with US1/US2
+- **User Story 4 (Phase 6)**: Depends on Phase 2 — can run in parallel with US1/US2/US3
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (Monthly Calendar)**: Independent after Phase 2 — core MVP
+- **US2 (Day Detail Overlay)**: Independent after Phase 2 — but uses onDayClick from US1/US3 views
+- **US3 (Week View)**: Independent after Phase 2 — shares CalendarView shell
+- **US4 (Year View)**: Independent after Phase 2 — month click navigates to month view (US1)
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Component creation before wiring into CalendarView
+- Wiring before CSS styling
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- **Phase 1**: T001, T002, T003 can run in parallel (independent test files for different functions)
+- **Phase 1**: T005, T006 can run in parallel after T004
+- **Phase 1**: T008, T009 can run in parallel after T007
+- **Phase 2**: T011 can run in parallel with T012 (different files)
+- **Phase 3+**: All test tasks marked [P] within a story can run in parallel
+- **Cross-story**: US1 and US2 tests (T015–T016 and T021–T022) can be written in parallel
+- **Cross-story**: US3 and US4 can be implemented in parallel after Phase 2
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch tests for US1 together:
+Task T015: "CalendarMonthView component test in calendarView.test.tsx"
+Task T016: "CalendarMonthView navigation test in calendarView.test.tsx"
+
+# After tests fail, implement sequentially:
+Task T017: "Create CalendarMonthView component"
+Task T018: "Wire CalendarMonthView into CalendarView"
+Task T019: "Add month grid CSS"
+Task T020: "Handle empty state"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (calendarUtils — T001–T010)
+2. Complete Phase 2: Foundational (CalendarView shell + tab toggle — T011–T014)
+3. Complete Phase 3: User Story 1 (Monthly Calendar — T015–T020)
+4. **STOP and VALIDATE**: Test monthly calendar independently
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Shell ready
+2. Add User Story 1 (Month view) → Test → Deploy/Demo (MVP!)
+3. Add User Story 2 (Day overlay) → Test → Deploy/Demo
+4. Add User Story 3 (Week view) → Test → Deploy/Demo
+5. Add User Story 4 (Year view) → Test → Deploy/Demo
+6. Polish → Final validation
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: User Story 1 (Month view)
+   - Developer B: User Story 2 (Day overlay)
+3. After US1+US2 integrate:
+   - Developer A: User Story 3 (Week view)
+   - Developer B: User Story 4 (Year view)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- All CSS uses `--ls-` variables and `.calendar-` class prefix
+- Touch targets must be ≥44×44px for tablet compliance


### PR DESCRIPTION
## Summary

Add design artifacts for feature 065: Sessions Calendar View.

Implementation is in the sessions-plugin repo: https://github.com/aylabs/graditone-pro-plugins/pull/13

## Design documents added

- spec.md: 4 user stories (month view, day overlay, week view, year view)
- plan.md: architecture, tech stack, file structure
- data-model.md: DaySummary, PeriodSummary, CalendarGrouping types
- contracts/component-contracts.md: component interfaces and props
- research.md: technical decisions and constraints
- quickstart.md: development setup guide
- tasks.md: 36 tasks across 7 phases (all completed)
- checklists/requirements.md: 16/16 requirements verified
