### PR TITLE
fix: pre-push hook e2e count parsing + ESLint lint gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -106,8 +106,10 @@ if [ "$current_branch" = "main" ] || echo "$current_branch" | grep -qE '^[0-9]+-
     e2e_exit=$?
   fi
 
-  e2e_passed=$(grep -c ' ✓ ' /tmp/e2e-prepush.log 2>/dev/null || echo 0)
-  e2e_failed=$(grep -cE '^\s+[0-9]+\) \[' /tmp/e2e-prepush.log 2>/dev/null || echo 0)
+  e2e_passed=$(grep -c ' ✓ ' /tmp/e2e-prepush.log 2>/dev/null | tr -d '[:space:]' || echo 0)
+  e2e_failed=$(grep -cE '^\s+[0-9]+\) \[' /tmp/e2e-prepush.log 2>/dev/null | tr -d '[:space:]' || echo 0)
+  e2e_passed=${e2e_passed:-0}
+  e2e_failed=${e2e_failed:-0}
 
   if [ "$e2e_exit" -eq 124 ]; then
     # Killed by the 3-min timeout

--- a/specs/078-session-practice-time-ux/graditone.code-workspace
+++ b/specs/078-session-practice-time-ux/graditone.code-workspace
@@ -1,0 +1,16 @@
+{
+	"folders": [
+		{
+			"path": "../../../../graditone"
+		},
+		{
+			"path": "../../.."
+		}
+	],
+	"settings": {
+		"chat.tools.terminal.autoApprove": {
+			".specify/scripts/bash/": true,
+			".specify/scripts/powershell/": true
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fix shell arithmetic bug in pre-push hook and add ESLint to the quality gate.

### Changes

**`.githooks/pre-push`** — fix integer expression bug:
- `grep -c` can return `'0\n'` (with trailing newline), causing `[ $var -gt 0 ]` to fail with *integer expression expected*
- Fix: pipe through `| tr -d '[:space:]'` + fallback `${var:-0}`

**`.githooks/pre-push`** — add ESLint step:
- Runs `npm run lint` in `frontend/` before the build step

**`.githooks/pre-commit`** — broaden TS file pattern:
- Was `^frontend/src/.*\.ts`; now `^frontend/.*\.ts` — covers `plugins/` too

**Spec artifacts / i18n / loop-lock UX** (carried from 078 branch):
- See merged PR #434 for context