### PR TITLE
fix(train): skip step-mode timing guards for MIDI discrete input — same-chord consecutive slots (#079-2)

### DIFF
--- a/frontend/plugins/train-view/TrainPlugin.test.tsx
+++ b/frontend/plugins/train-view/TrainPlugin.test.tsx
@@ -1160,3 +1160,63 @@ describe('TrainPlugin — step mode note overlap regression (Issue #1)', () => {
     expect(lastResponseNotes[0].midiNote).toBe(50);     // latest input survives
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: Issue #2 — MIDI same-pitch consecutive slots ignored
+// ---------------------------------------------------------------------------
+
+describe('TrainPlugin — step mode MIDI debounce skip (Issue #2)', () => {
+  /**
+   * After a correct MIDI note advances slot N, the old code set
+   * `stepLastPlayTimeRef = now` and `lastStepMidiRef = detectedMidi`, then
+   * blocked all MIDI input for 700 ms.  For mic input this is intentional
+   * (the pitch detector streams continuously — the held note would carry over
+   * into the next slot).  For MIDI, events are discrete note-on pulses — no
+   * carry-over is possible — so the guard incorrectly drops the player's
+   * intentional re-press within 700 ms.
+   *
+   * This catches the Arabesque M3 scenario: N1 and N2 are the same chord.
+   * After N1 is accepted, immediately playing the same chord for N2 was
+   * silently ignored.  After the fix slotN+1 accepts MIDI input immediately.
+   *
+   * Regression spec: specs/079-fix-train-note-overlap/spec.md (Issue #2)
+   */
+  it('wrong MIDI note for slot 1 is processed immediately after slot 0 advances — no 700 ms wait', async () => {
+    const ctx = makeMockContext();
+    render(<TrainPlugin context={ctx} />, { wrapper: TestWrapper });
+
+    // Flush mount effects — applyComplexityLevel('low') sets mode: 'step', bpm: 40
+    await act(async () => { vi.advanceTimersByTime(0); });
+
+    // Start the step-mode exercise
+    await act(async () => { fireEvent.click(screen.getByTestId('train-play-btn')); });
+
+    // Advance past the 700 ms initial guard set in handleStartStep
+    await act(async () => { vi.advanceTimersByTime(800); });
+
+    // Play slot 0 correctly: C4 (MIDI 60) in the C-major scale.
+    // This advances the slot and (with old code) sets a 700 ms block.
+    await act(async () => {
+      ctx._midiSubscribers.forEach(h =>
+        h({ type: 'attack', midiNote: 60, timestamp: Date.now(), durationMs: 500 }),
+      );
+    });
+
+    // Slot 1 expects D4 (MIDI 62).  Fire a wrong note (MIDI 50) IMMEDIATELY —
+    // no vi.advanceTimersByTime, so Date.now() - stepLastPlayTime == 0 ms.
+    //
+    // Old code: Guard 1 fires (0 < 700 ms) → BLOCKED → no hint rendered.
+    // New code: Guard 1 is skipped for MIDI discrete events → hint is rendered.
+    await act(async () => {
+      ctx._midiSubscribers.forEach(h =>
+        h({ type: 'attack', midiNote: 50, timestamp: Date.now(), durationMs: 500 }),
+      );
+    });
+
+    // The wrong-note hint element must be present — the input was NOT blocked.
+    const hint = screen.getByRole('status');
+    expect(hint).toBeInTheDocument();
+    // The hint must reference the next expected pitch (D4 = slot 1 target).
+    expect(hint.textContent).toContain('D4');
+  });
+});

--- a/frontend/plugins/train-view/TrainPlugin.tsx
+++ b/frontend/plugins/train-view/TrainPlugin.tsx
@@ -561,8 +561,16 @@ export function TrainPlugin({ context }: TrainPluginProps) {
   const handleStepInput = useCallback((detectedMidi: number) => {
     if (configRef.current.mode !== 'step') return;
     if (phaseRef.current !== 'playing') return;
-    if (Date.now() - stepLastPlayTimeRef.current < STEP_INPUT_DELAY_MS) return;
-    if (detectedMidi === lastStepMidiRef.current) return; // debounce
+    // These two guards protect against mic continuous-pitch carry-over: the pitch
+    // detector streams the same value while a note is held, so without them slot N could
+    // auto-advance into slot N+1 while the player is still holding the key.
+    // MIDI and virtual-keyboard fire discrete note-on events — no carry-over is possible,
+    // so the guards are skipped.  They were causing same-pitch consecutive slots (e.g.
+    // repeated chords in Arabesque M3) to be silently missed (Issue #2).
+    if (inputSourceRef.current === 'mic') {
+      if (Date.now() - stepLastPlayTimeRef.current < STEP_INPUT_DELAY_MS) return;
+      if (detectedMidi === lastStepMidiRef.current) return;
+    }
 
     lastStepMidiRef.current = detectedMidi;
     const stepIdx = stepIndexRef.current;

--- a/specs/079-fix-train-note-overlap/tasks.md
+++ b/specs/079-fix-train-note-overlap/tasks.md
@@ -39,3 +39,13 @@
 
 - [x] T004 Run `npx vitest run` in `frontend/` — the new regression test (T002) must pass green, and all pre-existing tests must remain green.
 - [x] T005 Run `npm run build` in `frontend/` — zero TypeScript errors.
+
+---
+
+## Phase 5: Issue #2 — MIDI same-pitch consecutive slots silently dropped
+
+**Root cause**: The `stepLastPlayTimeRef` and `lastStepMidiRef` debounce guards in `handleStepInput` were applied to all input sources. Designed for mic continuous-pitch carry-over protection, they incorrectly blocked discrete MIDI events within 700 ms of a slot advance (e.g. Arabesque M3 N1→N2 same chord).
+
+- [x] T006 Wrap the two guards in `inputSourceRef.current === 'mic'` so they only fire for the continuous mic pitch-stream case. MIDI / virtual-keyboard discrete events bypass them.
+- [x] T007 Add regression test: 'wrong MIDI note for slot 1 is processed immediately after slot 0 advances — no 700 ms wait'.
+- [x] T008 Run `npx vitest run` — 1851 tests pass (0 failures).


### PR DESCRIPTION
## Summary

After a correct MIDI note advances slot N, two debounce guards blocked subsequent input for 700 ms:

1. **Timing guard**: `Date.now() - stepLastPlayTimeRef.current < STEP_INPUT_DELAY_MS`
2. **Same-pitch guard**: `detectedMidi === lastStepMidiRef.current`

These guards exist for **mic** input only — the pitch detector streams continuously while a note is held, so without them the sustained pitch would auto-advance into the next slot.

For **MIDI** and **virtual-keyboard**, events are discrete note-on pulses. No carry-over is possible. The 700 ms window incorrectly dropped intentional re-presses, causing same-pitch consecutive slots to be silently missed.

**Observed symptom** (Arabesque M3 left-hand, N1→N2 same chord): N1 accepted correctly, N2 silently ignored, N3+ worked (natural retry pause exceeded 700 ms).

## Fix

Wrap both guards in `inputSourceRef.current === 'mic'` — mic input keeps full protection, MIDI/virtual-keyboard bypasses them.

## Testing

- Regression test: `wrong MIDI note for slot 1 is processed immediately after slot 0 advances — no 700 ms wait`
- 1851 Vitest tests pass (+1 new)
- TypeScript build clean

Follows: #439 (Issue #1 — wrong-note visual overlap)