### PR TITLE
fix(plugin-error): pass onDismiss to V3PluginWrapper error boundary

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -614,7 +614,7 @@ function App() {
           {isV3 && proxyRefs ? (
             // v3: V3PluginWrapper calls useScorePlayerBridge() and keeps proxy refs current.
             // Must be inside TempoStateProvider (added below).
-            <V3PluginWrapper plugin={coreEntry.manifest} proxyRefs={proxyRefs}>
+            <V3PluginWrapper plugin={coreEntry.manifest} proxyRefs={proxyRefs} onDismiss={() => setActivePlugin(null)}>
               <FullScreenComponent />
             </V3PluginWrapper>
           ) : (
@@ -750,7 +750,7 @@ function App() {
                   // v3+ common plugins: wire up the score player proxy via V3PluginWrapper.
                   // Without this, getCatalogue() returns [] and loadScore() is a no-op
                   // because scorePlayerRef stays on the createNoOpScorePlayer() stub.
-                  <V3PluginWrapper plugin={entry.manifest} proxyRefs={proxyRefsCommon}>
+                  <V3PluginWrapper plugin={entry.manifest} proxyRefs={proxyRefsCommon} onDismiss={() => setActivePlugin(null)}>
                     <PluginComponent />
                   </V3PluginWrapper>
                 ) : (

--- a/frontend/src/components/plugins/PluginView.tsx
+++ b/frontend/src/components/plugins/PluginView.tsx
@@ -238,6 +238,8 @@ export interface V3PluginWrapperProps {
   plugin: PluginManifest;
   /** Proxy refs shared with App.tsx context assembly. */
   proxyRefs: V3ProxyRefs;
+  /** Called when the user clicks "Return to landing" in the error fallback. */
+  onDismiss?: () => void;
   /** Plugin component to render (coreEntry.plugin.Component). */
   children: ReactNode;
 }
@@ -254,7 +256,7 @@ export interface V3PluginWrapperProps {
  *
  * Must be rendered inside `<TempoStateProvider>`.
  */
-export function V3PluginWrapper({ plugin, proxyRefs, children }: V3PluginWrapperProps) {
+export function V3PluginWrapper({ plugin, proxyRefs, onDismiss, children }: V3PluginWrapperProps) {
   const { api, internal } = useScorePlayerBridge();
 
   // Build the real hook-backed metronome API, subscribed to the score player
@@ -275,7 +277,7 @@ export function V3PluginWrapper({ plugin, proxyRefs, children }: V3PluginWrapper
   internalRefStable.current = internal;
 
   return (
-    <PluginView plugin={plugin}>
+    <PluginView plugin={plugin} onDismiss={onDismiss}>
       {children}
     </PluginView>
   );

--- a/frontend/src/test/i18n/catalog-completeness.test.ts
+++ b/frontend/src/test/i18n/catalog-completeness.test.ts
@@ -17,12 +17,12 @@ describe('Translation catalog completeness', () => {
   const enKeys = Object.keys(enCatalog) as Array<keyof typeof enCatalog>;
   const esKeys = Object.keys(esCatalog) as Array<keyof typeof esCatalog>;
 
-  it('English catalog has exactly 332 keys', () => {
-    expect(enKeys).toHaveLength(332);
+  it('English catalog has exactly 333 keys', () => {
+    expect(enKeys).toHaveLength(333);
   });
 
-  it('Spanish catalog has exactly 332 keys', () => {
-    expect(esKeys).toHaveLength(332);
+  it('Spanish catalog has exactly 333 keys', () => {
+    expect(esKeys).toHaveLength(333);
   });
 
   it('every key in en.json exists in es.json', () => {


### PR DESCRIPTION
## Problem

V3 plugins (like Sessions) that crash at runtime only show a **Reload plugin** button in the error fallback — there's no way to return to the landing screen.

**Root cause**: `V3PluginWrapper` creates its own `<PluginView>` internally but was not forwarding the `onDismiss` prop, so the "Return to landing" button never rendered for v3 plugins.

## Changes

- Add `onDismiss` to `V3PluginWrapperProps` and forward it to `<PluginView>`
- Pass `onDismiss={() => setActivePlugin(null)}` at both `V3PluginWrapper` call sites in App.tsx (full-screen core plugins + common/overlay plugins)
- Update i18n catalog count (332 → 333) for the `return_to_landing` key added in #446