### PR TITLE
feat(081): fix MIDI detection in practice mode

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -209,6 +209,8 @@ All features that manage, persist, or display user state MUST be profile-aware:
 
 - **Main Branch**: `main` is always deployable; protected with required reviews
 - **Feature Branches**: All work happens in `feature/###-short-description` branches
+- **Branch Base**: All new feature branches MUST be created from an up-to-date `main`. Run `git pull origin main` before creating any new branch.
+- **No Direct Commits to Main**: NEVER commit or push directly to `main`. All changes MUST go through a feature branch and a Pull Request, regardless of how small the change is. Merging without a PR is prohibited.
 - **PR Requirements**: Pull requests MUST include tests, pass CI, and update relevant specs
 
 ### Git Worktree Workflow

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx
@@ -21,6 +21,13 @@ vi.mock('../../src/services/profiles/ProfileContext', () => ({
   useProfile: () => ({ activeProfile: { id: 'test', name: 'Test' } }),
   ProfileProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
+
+// Mock useMidiConnectivity — in the test environment (happy-dom) Web MIDI API
+// is absent, so the hook would return { supported: false, connected: false },
+// disabling the Practice button and breaking all practice-related tests.
+vi.mock('./useMidiConnectivity', () => ({
+  useMidiConnectivity: () => ({ connected: true, supported: true }),
+}));
 import type {
   PluginContext,
   ScorePlayerState,

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
@@ -38,6 +38,7 @@ import { usePracticeMidi } from './usePracticeMidi';
 import { usePracticeHighlights } from './usePracticeHighlights';
 import { usePhantomTempo } from './usePhantomTempo';
 import { useHoldProgress } from './useHoldProgress';
+import { useMidiConnectivity } from './useMidiConnectivity';
 import { measureRangeToTicks } from './measureRangeToTicks';
 import { ResultsOverlay } from './ResultsOverlay';
 import type { ScoreRef, SavedPractice, SavedPerformanceData, SavedPracticeIndexEntry } from '../../src/plugin-api/index';
@@ -138,35 +139,11 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   }, [context.metronome]);
 
   // ─── MIDI connectivity tracking ────────────────────────────────────────────
-  // Use Web MIDI API for real-time connect/disconnect detection.
-  // IMPORTANT: Uses addEventListener('statechange', ...) instead of assigning
-  // access.onstatechange — the browser returns the SAME MIDIAccess singleton
-  // from every requestMIDIAccess() call, so assigning onstatechange would
-  // overwrite the host's useMidiInput handler and vice-versa, causing MIDI
-  // to stop working until browser restart.
-  // null = check pending; false = checked, no devices; true = device present.
-  const [midiConnected, setMidiConnected] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    if (typeof navigator === 'undefined' || !('requestMIDIAccess' in navigator)) return;
-    let midiAccess: MIDIAccess | null = null;
-    const nav = navigator as Navigator & { requestMIDIAccess: () => Promise<MIDIAccess> };
-    const handleStateChange = () => {
-      if (midiAccess) setMidiConnected(midiAccess.inputs.size > 0);
-    };
-    nav.requestMIDIAccess().then((access) => {
-      midiAccess = access;
-      // Reflect current state immediately
-      setMidiConnected(access.inputs.size > 0);
-      // Use addEventListener so multiple listeners can coexist on the singleton
-      access.addEventListener('statechange', handleStateChange);
-    }).catch(() => { /* MIDI permission denied or unavailable */ });
-    return () => {
-      if (midiAccess) {
-        midiAccess.removeEventListener('statechange', handleStateChange);
-      }
-    };
-  }, []);
+  // Extracted to useMidiConnectivity hook (feature 081) — fixes three bugs:
+  // 1. No timeout → requestMIDIAccess could wait forever on tablet
+  // 2. Silent catch → permission denial left state null
+  // 3. API absent → no setMidiConnected(false) call
+  const { connected: midiConnected, supported: midiSupported } = useMidiConnectivity();
 
   // ─── Two-tap seek-then-play state machine (mirrors play-score) ──────────────
   // First tap while not playing: seek + arm pendingPlay.
@@ -1054,6 +1031,7 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
         onPracticeToggle={handlePracticeToggle}
         showStaffPicker={false}
         midiConnected={midiConnected}
+        midiSupported={midiSupported}
         metronomeActive={metronomeState.active}
         metronomeBeatIndex={metronomeState.beatIndex}
         metronomeIsDownbeat={metronomeState.isDownbeat}

--- a/frontend/plugins/practice-view-plugin/practiceToolbar.test.tsx
+++ b/frontend/plugins/practice-view-plugin/practiceToolbar.test.tsx
@@ -281,3 +281,33 @@ describe('PracticeToolbar — Play/Stop controls', () => {
     expect(onStop).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// T010 — MIDI not supported message (Feature 081)
+// ---------------------------------------------------------------------------
+
+describe('PracticeToolbar — MIDI not supported', () => {
+  it('renders "MIDI not supported" message when midiSupported={false}', () => {
+    render(
+      <PracticeToolbar {...makeDefaultProps({ midiSupported: false })} />,
+      { wrapper: TestWrapper },
+    );
+    expect(screen.getByText(/MIDI is not supported/i)).toBeTruthy();
+  });
+
+  it('does not render "MIDI not supported" message when midiSupported is true', () => {
+    render(
+      <PracticeToolbar {...makeDefaultProps({ midiSupported: true, midiConnected: true })} />,
+      { wrapper: TestWrapper },
+    );
+    expect(screen.queryByText(/MIDI is not supported/i)).toBeNull();
+  });
+
+  it('does not render "MIDI not supported" message when midiSupported is not provided (default)', () => {
+    render(
+      <PracticeToolbar {...makeDefaultProps()} />,
+      { wrapper: TestWrapper },
+    );
+    expect(screen.queryByText(/MIDI is not supported/i)).toBeNull();
+  });
+});

--- a/frontend/plugins/practice-view-plugin/practiceToolbar.tsx
+++ b/frontend/plugins/practice-view-plugin/practiceToolbar.tsx
@@ -71,6 +71,11 @@ export interface PracticeToolbarProps {
    * Shows indicator in toolbar.
    */
   midiConnected: boolean | null;
+  /**
+   * Whether the Web MIDI API is available in this browser.
+   * When false, shows "MIDI not supported" message instead of "no MIDI device".
+   */
+  midiSupported?: boolean;
   // Metronome
   metronomeActive: boolean;
   metronomeBeatIndex: number;
@@ -111,6 +116,7 @@ export function PracticeToolbar({
   onPracticeToggle,
   showStaffPicker,
   midiConnected,
+  midiSupported = true,
   metronomeActive,
   metronomeBeatIndex,
   metronomeIsDownbeat,
@@ -313,10 +319,16 @@ export function PracticeToolbar({
         </span>
       )}
 
-      {/* Practice toggle button — disabled when no MIDI device connected */}
+      {/* Practice toggle button — disabled when no MIDI device connected or unsupported */}
       <span
         className="practice-plugin__practice-btn-wrapper"
-        title={midiConnected === false ? t('practice.toolbar.no_midi_device') : undefined}
+        title={
+          !midiSupported
+            ? t('practice.toolbar.midi_not_supported')
+            : midiConnected === false
+              ? t('practice.toolbar.no_midi_device')
+              : undefined
+        }
       >
         <button
           className={practiceBtnClass}
@@ -325,7 +337,7 @@ export function PracticeToolbar({
             practiceRunning ? t('practice.toolbar.practice_mode_stop_aria') : t('practice.toolbar.practice_mode_start_aria')
           }
           aria-pressed={practiceRunning}
-          disabled={!isLoaded || midiConnected === false || !!isReplaying}
+          disabled={!isLoaded || midiConnected === false || !midiSupported || !!isReplaying}
         >
           {practiceBtnLabel}
         </button>
@@ -346,9 +358,16 @@ export function PracticeToolbar({
       )}
 
       {/* No-MIDI notice — shown when practice is active but MIDI is disconnected */}
-      {practiceRunning && midiConnected === false && (
+      {practiceRunning && midiConnected === false && midiSupported && (
         <span className="practice-plugin__no-midi-notice" role="alert">
           {t('practice.toolbar.connect_midi')}
+        </span>
+      )}
+
+      {/* MIDI not supported notice — shown when Web MIDI API is unavailable */}
+      {!midiSupported && (
+        <span className="practice-plugin__no-midi-notice" role="alert">
+          {t('practice.toolbar.midi_not_supported')}
         </span>
       )}
 

--- a/frontend/plugins/practice-view-plugin/useMidiConnectivity.test.ts
+++ b/frontend/plugins/practice-view-plugin/useMidiConnectivity.test.ts
@@ -1,0 +1,196 @@
+/**
+ * useMidiConnectivity — Unit Tests
+ * Feature 081: Fix MIDI Detection in Tablet in Practice Mode
+ *
+ * TDD: Tests written before implementation, verified red, then implementation makes them green.
+ *
+ * Tests:
+ *   US1 — API absent → { supported: false, connected: false }
+ *   US1 — Device present at mount → connected transitions null → true
+ *   US1 — No devices at mount → connected transitions null → false
+ *   US2 — requestMIDIAccess never resolves → connected = false after 8s timeout
+ *   US2 — requestMIDIAccess rejects → connected = false
+ *   US3 — Hot-plug connect → connected updates to true
+ *   US3 — Hot-plug disconnect → connected updates to false
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  mockMidiSupported,
+  mockMidiUnsupported,
+  createMockMidiAccess,
+  createMockMidiInput,
+  fireMidiStateChange,
+} from '../../src/test/mockMidi';
+import { useMidiConnectivity, MIDI_CONNECTIVITY_TIMEOUT_MS } from './useMidiConnectivity';
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+describe('useMidiConnectivity', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ─── US1: API absent ────────────────────────────────────────────────────────
+
+  describe('US1 — API absent (iOS Safari, etc.)', () => {
+    it('returns { supported: false, connected: false } synchronously', () => {
+      mockMidiUnsupported();
+
+      const { result } = renderHook(() => useMidiConnectivity());
+
+      expect(result.current.supported).toBe(false);
+      expect(result.current.connected).toBe(false);
+    });
+  });
+
+  // ─── US1: Device present at mount ──────────────────────────────────────────
+
+  describe('US1 — MIDI device present at mount', () => {
+    it('connected transitions from null to true', async () => {
+      const input = createMockMidiInput('Piano');
+      const access = createMockMidiAccess([input]);
+      mockMidiSupported(access);
+
+      const { result } = renderHook(() => useMidiConnectivity());
+
+      // Initially null (check pending) — supported is true synchronously
+      expect(result.current.supported).toBe(true);
+
+      // Flush the resolved promise
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(result.current.connected).toBe(true);
+    });
+  });
+
+  // ─── US1: No devices at mount ─────────────────────────────────────────────
+
+  describe('US1 — No MIDI devices at mount', () => {
+    it('connected transitions from null to false', async () => {
+      const access = createMockMidiAccess([]);
+      mockMidiSupported(access);
+
+      const { result } = renderHook(() => useMidiConnectivity());
+
+      expect(result.current.supported).toBe(true);
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(result.current.connected).toBe(false);
+    });
+  });
+
+  // ─── US2: Timeout ─────────────────────────────────────────────────────────
+
+  describe('US2 — requestMIDIAccess never resolves (slow permission)', () => {
+    it('connected resolves to false after MIDI_CONNECTIVITY_TIMEOUT_MS', async () => {
+      // Stub requestMIDIAccess to return a promise that never resolves
+      const neverResolve = new Promise<never>(() => {});
+      Object.defineProperty(globalThis.navigator, 'requestMIDIAccess', {
+        value: vi.fn().mockReturnValue(neverResolve),
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useMidiConnectivity());
+
+      expect(result.current.supported).toBe(true);
+      expect(result.current.connected).toBe(null); // still pending
+
+      // Advance past the timeout
+      await act(async () => {
+        vi.advanceTimersByTime(MIDI_CONNECTIVITY_TIMEOUT_MS);
+        // Flush microtasks from Promise.race resolution
+        await vi.runAllTimersAsync();
+      });
+
+      expect(result.current.connected).toBe(false);
+    });
+  });
+
+  // ─── US2: Permission denied ───────────────────────────────────────────────
+
+  describe('US2 — requestMIDIAccess rejects (permission denied)', () => {
+    it('connected transitions to false (not stuck at null)', async () => {
+      Object.defineProperty(globalThis.navigator, 'requestMIDIAccess', {
+        value: vi.fn().mockRejectedValue(new DOMException('User denied', 'NotAllowedError')),
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useMidiConnectivity());
+
+      expect(result.current.supported).toBe(true);
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(result.current.connected).toBe(false);
+    });
+  });
+
+  // ─── US3: Hot-plug connect ────────────────────────────────────────────────
+
+  describe('US3 — MIDI device connected after mount (hot-plug)', () => {
+    it('connected updates from false to true', async () => {
+      const access = createMockMidiAccess([]); // no devices initially
+      mockMidiSupported(access);
+
+      const { result } = renderHook(() => useMidiConnectivity());
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(result.current.connected).toBe(false);
+
+      // Simulate hot-plug connect
+      const newInput = createMockMidiInput('Piano');
+      act(() => {
+        fireMidiStateChange(access, newInput, 'connected');
+      });
+
+      expect(result.current.connected).toBe(true);
+    });
+  });
+
+  // ─── US3: Hot-plug disconnect ──────────────────────────────────────────────
+
+  describe('US3 — MIDI device disconnected after mount', () => {
+    it('connected updates from true to false', async () => {
+      const input = createMockMidiInput('Piano');
+      const access = createMockMidiAccess([input]);
+      mockMidiSupported(access);
+
+      const { result } = renderHook(() => useMidiConnectivity());
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(result.current.connected).toBe(true);
+
+      // Simulate disconnect — remove from inputs map and fire event
+      act(() => {
+        access.inputs.delete(input.id);
+        fireMidiStateChange(access, input, 'disconnected');
+      });
+
+      expect(result.current.connected).toBe(false);
+    });
+  });
+});

--- a/frontend/plugins/practice-view-plugin/useMidiConnectivity.ts
+++ b/frontend/plugins/practice-view-plugin/useMidiConnectivity.ts
@@ -1,0 +1,108 @@
+/**
+ * useMidiConnectivity — MIDI connectivity detection hook for Practice View.
+ * Feature 081: Fix MIDI Detection in Tablet in Practice Mode
+ *
+ * Replaces the inline useEffect in PracticeViewPlugin.tsx that had three bugs:
+ * 1. No timeout — requestMIDIAccess() could wait forever on tablet
+ * 2. Silent catch — permission denial left state as null
+ * 3. API absent path returned early without setting state to false
+ *
+ * Uses addEventListener('statechange', ...) — never onstatechange assignment —
+ * to avoid clobbering useMidiInput's handler on the shared MIDIAccess singleton.
+ */
+
+import { useState, useEffect } from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MidiConnectivityState {
+  /**
+   * Whether at least one MIDI input device is currently connected.
+   * - null  → check pending (resolves within MIDI_CONNECTIVITY_TIMEOUT_MS)
+   * - true  → one or more MIDI inputs present
+   * - false → check completed, no inputs (or permission denied / timeout)
+   */
+  connected: boolean | null;
+
+  /**
+   * Whether the Web MIDI API is available in this browser.
+   * - true  → navigator.requestMIDIAccess exists
+   * - false → API absent (iOS Safari without bridge, etc.)
+   * Set synchronously on mount — never changes after mount.
+   */
+  supported: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Timeout for MIDI access request — generous for tablet permission prompts. */
+export const MIDI_CONNECTIVITY_TIMEOUT_MS = 8000;
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useMidiConnectivity(): MidiConnectivityState {
+  // Synchronous API detection
+  const apiAvailable =
+    typeof navigator !== 'undefined' &&
+    'requestMIDIAccess' in navigator &&
+    typeof navigator.requestMIDIAccess === 'function';
+
+  const [connected, setConnected] = useState<boolean | null>(
+    apiAvailable ? null : false,
+  );
+
+  useEffect(() => {
+    if (!apiAvailable) return;
+
+    let cancelled = false;
+    let midiAccess: MIDIAccess | null = null;
+
+    const handleStateChange = () => {
+      if (!cancelled && midiAccess) {
+        setConnected(midiAccess.inputs.size > 0);
+      }
+    };
+
+    const nav = navigator as Navigator & {
+      requestMIDIAccess: (options?: { sysex?: boolean }) => Promise<MIDIAccess>;
+    };
+
+    // Timeout promise — resolves to null after MIDI_CONNECTIVITY_TIMEOUT_MS
+    const timeoutPromise = new Promise<null>((resolve) => {
+      setTimeout(() => resolve(null), MIDI_CONNECTIVITY_TIMEOUT_MS);
+    });
+
+    Promise.race([nav.requestMIDIAccess({ sysex: false }), timeoutPromise])
+      .then((result) => {
+        if (cancelled) return;
+        if (result === null) {
+          // Timeout — set connected to false
+          setConnected(false);
+          return;
+        }
+        const access = result;
+        midiAccess = access;
+        setConnected(access.inputs.size > 0);
+        access.addEventListener('statechange', handleStateChange);
+      })
+      .catch(() => {
+        // Permission denied or other error — definitive "not connected"
+        if (!cancelled) setConnected(false);
+      });
+
+    return () => {
+      cancelled = true;
+      if (midiAccess) {
+        midiAccess.removeEventListener('statechange', handleStateChange);
+      }
+    };
+  }, [apiAvailable]);
+
+  return { connected, supported: apiAvailable };
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -290,6 +290,7 @@
   "practice.toolbar.tempo_aria": "Tempo multiplier",
   "practice.toolbar.metronome_aria": "Toggle metronome",
   "practice.toolbar.metronome_sub_aria": "Metronome subdivision",
+  "practice.toolbar.midi_not_supported": "MIDI is not supported in this browser",
   "practice.toolbar.midi_connected_title": "MIDI keyboard detected",
   "practice.toolbar.midi_connected_aria": "MIDI keyboard connected",
   "practice.plugin.untitled": "Untitled",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -289,6 +289,7 @@
   "practice.toolbar.tempo_aria": "Multiplicador de tempo",
   "practice.toolbar.metronome_aria": "Activar/desactivar metrónomo",
   "practice.toolbar.metronome_sub_aria": "Subdivisión del metrónomo",
+  "practice.toolbar.midi_not_supported": "MIDI no está disponible en este navegador",
   "practice.toolbar.midi_connected_title": "Teclado MIDI detectado",
   "practice.toolbar.midi_connected_aria": "Teclado MIDI conectado",
   "practice.plugin.untitled": "Sin título",

--- a/frontend/src/test/i18n/catalog-completeness.test.ts
+++ b/frontend/src/test/i18n/catalog-completeness.test.ts
@@ -17,12 +17,12 @@ describe('Translation catalog completeness', () => {
   const enKeys = Object.keys(enCatalog) as Array<keyof typeof enCatalog>;
   const esKeys = Object.keys(esCatalog) as Array<keyof typeof esCatalog>;
 
-  it('English catalog has exactly 333 keys', () => {
-    expect(enKeys).toHaveLength(333);
+  it('English catalog has exactly 334 keys', () => {
+    expect(enKeys).toHaveLength(334);
   });
 
-  it('Spanish catalog has exactly 333 keys', () => {
-    expect(esKeys).toHaveLength(333);
+  it('Spanish catalog has exactly 334 keys', () => {
+    expect(esKeys).toHaveLength(334);
   });
 
   it('every key in en.json exists in es.json', () => {


### PR DESCRIPTION
## Summary

Extract `useMidiConnectivity` hook replacing the inline MIDI `useEffect` in `PracticeViewPlugin` that had three bugs:

1. **No timeout** — `requestMIDIAccess()` could hang forever on tablets
2. **Silent `.catch()`** — permission denial left `midiConnected` as `null`, UI stuck in limbo
3. **API-absent path** — returned early without setting `connected = false` (iOS Safari showed incorrect state)

## Changes

- **New**: `useMidiConnectivity` hook with 8s timeout, proper `.catch()`, synchronous API detection
- Uses `addEventListener('statechange')` for hot-plug — not `onstatechange` assignment (would clobber `useMidiInput`'s handler on the shared `MIDIAccess` singleton)
- Passes `{sysex: false}` explicitly for tablet browser compatibility
- **New**: `midiSupported` prop on `PracticeToolbar` — shows "MIDI not supported" notice and disables Practice button when API is absent
- **New**: `midi_not_supported` i18n keys (en + es)
- **Tests**: 7 TDD tests covering all 3 user stories (API absent, timeout, hot-plug)

## Root cause (tablet)

Observed `InvalidStateError: Platform dependent initialization failed` on Android tablet in low-battery state — Android restricts the MIDI subsystem under power saving mode. The fix ensures this case is handled gracefully (shows "not connected" rather than hanging).
