### PR TITLE
feat(083): Tempo slider precision & metronome deferred start

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -167,6 +167,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-06
 - IndexedDB (`graditone-db` v4 with stores: scores, practices, sessions, goals; `plugin-registry` v1 with stores: manifests, assets) + localStorage (9 keys) (080-user-profile-support)
 - HTML, TypeScript, React 19 / Vite + Plausible Analytics script (frontend injection) (082-gdpr-logging)
 - N/A (strictly no cookies, no localStorage for analytics identifiers) (082-gdpr-logging)
+- TypeScript 5.x (strict), Rust 1.x WASM (no backend changes required) + React 19.2, Tone.js 14.9, Vite 6.x, Vitest 3.x, @testing-library/react, Playwrigh (083-tempo-metronome-practice)
+- React component state (transient); `SavedPractice.tempoMultiplier` in IndexedDB (persisted — clamped on load) (083-tempo-metronome-practice)
 
 - Rust (latest stable 1.75+) + serde 1.0+, serde_json 1.0+ (serialization), thiserror 1.0+ (errors); web framework TBD in contracts phase (axum or actix-web) (001-score-model)
 
@@ -187,9 +189,9 @@ cargo test [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECH
 Rust (latest stable 1.75+): Follow standard conventions
 
 ## Recent Changes
+- 083-tempo-metronome-practice: Added TypeScript 5.x (strict), Rust 1.x WASM (no backend changes required) + React 19.2, Tone.js 14.9, Vite 6.x, Vitest 3.x, @testing-library/react, Playwrigh
 - 082-gdpr-logging: Added HTML, TypeScript, React 19 / Vite + Plausible Analytics script (frontend injection)
 - 080-user-profile-support: Added TypeScript 5.x (frontend), React 18+ (UI) + React 18, Vite, vitest, Playwright (e2e)
-- 078-session-practice-time-ux: Added [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -34,7 +34,7 @@ A tablet-native app for interactive scores, designed for practice and performanc
 - **Audio playback** with Web Audio API
 - **Auto-scroll** during playback
 - **Note highlighting** - Visual feedback showing current position
-- **Tempo control** - Adjust playback speed for practice
+- **Tempo control** - Adjust playback speed for practice from 10% to 200% with 1% precision (Feature 083)
 - **Score-defined tempo** - Playback starts at the tempo marked in the score (e.g. 60 BPM for Chopin Nocturne) instead of a fixed 120 BPM default; snap-to-score-tempo action resets both BPM and multiplier to the score's marked tempo
 - **Repeat/navigation** - Jump to any point in the score
 - **Tied note playback** - Tied notes sound as a single sustained note with combined duration, no re-attack at tie boundaries; chords with partial ties sustain only the tied pitch
@@ -115,7 +115,7 @@ The **Play Score** plugin is a built-in full-screen plugin that lets users load,
 - **Note seeking**: Short-tap a note to seek playback to that tick
 - **Pin & loop**: Long-press a note to set a loop start pin; long-press a second note to create a loop region; long-press inside the loop to clear it
 - **Return to start**: Dedicated button seeks to tick 0 (or to the pinned loop start if set)
-- **Tempo control**: Slider adjusts playback speed from 0.5× to 2.0×; snap-to-score-tempo resets to the score's marked BPM
+- **Tempo control**: Slider adjusts playback speed from 10% to 200% in 1% increments; BPM floor ensures minimum playback is always ≥10 BPM; ±3% snap zone at 100%; snap-to-score-tempo resets to the score's marked BPM (Feature 083)
 - **WASM loading state**: All controls are disabled while the audio engine initialises
 - **Audio teardown**: All audio stops automatically when the plugin is closed or the page navigates away (SC-005)
 
@@ -221,3 +221,25 @@ Completes internationalization (i18n) for all 5 internal builtin plugins: **Play
 
 **Spec**: `specs/075-core-plugins-i18n/`  
 **Updated**: June 2025
+
+
+---
+
+## Tempo Slider Precision & Metronome Deferred Start — Feature 083
+
+Extends tempo control precision for both Play Score and Practice View, and adds a smart metronome "armed" mode for practice sessions.
+
+### Capabilities
+
+- **Extended tempo range**: Slider minimum lowered from 50% to **10%** (was 0.5× → now 0.1×); maximum remains 200% (2.0×)
+- **1% step granularity**: Slider step reduced from 5% to **1%** (step=0.01) for fine-grained speed control
+- **BPM floor protection**: When the score's original tempo is slow, the slider minimum rises proportionally so playback never drops below **10 BPM** (e.g. 40 BPM score → min slider = 25%)
+- **Recalibrated 100% snap zone**: Snap-to-100% triggers within **±3 steps** (±3pp) of 1.0×, tightened from ±5pp for more precise control at normal speed
+- **Tick mark at 100%**: The 100% position is marked via `<datalist>` for browser snap UI hints
+- **BPM floor tooltip**: When the effective minimum is above 10% due to the BPM floor, the slider shows a tooltip explaining "Min. speed limited to 10 BPM"
+- **Metronome armed state** (Practice View only): Toggling the metronome button while practice is in "waiting" mode arms it — the metronome does **not** start immediately; instead it waits for the first MIDI note attack and starts in sync with the player's first note
+- **Armed visual indicator**: The metronome button shows a pulsing amber glow while armed (`--armed` CSS modifier)
+- **Auto-disarm on stop**: If the user stops practice before playing any note, the armed state is cleared automatically
+
+**Spec**: `specs/083-tempo-metronome-practice/`  
+**Updated**: July 2025

--- a/frontend/e2e/play-score-plugin.spec.ts
+++ b/frontend/e2e/play-score-plugin.spec.ts
@@ -122,7 +122,7 @@ test.describe('Feature 033: Play Score Plugin', () => {
 
     const slider = page.getByRole('slider', { name: /tempo/i });
     await expect(slider).toBeVisible();
-    await expect(slider).toHaveAttribute('min', '0.5');
+    await expect(slider).toHaveAttribute('min', '0.1');
     await expect(slider).toHaveAttribute('max', '2');
   });
 });

--- a/frontend/e2e/tempo.spec.ts
+++ b/frontend/e2e/tempo.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Feature 083: Tempo Slider Precision & Extended Range — E2E Tests
+ * T012 — Tempo slider has 1% step, ±3pp snap zone, 10%–200% range
+ * T023 — Max 200% is accessible and shows correct BPM
+ *
+ * E2E scope: UI-level slider interactions in Play Score and Practice views.
+ * Requires a running dev server (npm run dev).
+ */
+
+import { test, expect } from '@playwright/test';
+
+// ─── Shared helpers ───────────────────────────────────────────────────────────
+
+async function stubMxlFetch(page: import('@playwright/test').Page): Promise<void> {
+  await page.route('**/*.mxl', route =>
+    route.fulfill({
+      status: 200,
+      body: '',
+      contentType: 'application/octet-stream',
+    })
+  );
+}
+
+// ─── T012 — Play Score: Tempo slider precision ────────────────────────────────
+
+test.describe('Feature 083 / T012: Tempo slider precision in Play Score', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubMxlFetch(page);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.getByTestId('plugin-launch-play-score').click();
+    await page.getByText('Bach — Invention No. 1').click();
+  });
+
+  test('tempo slider has step attribute of 0.01 (1% granularity)', async ({ page }) => {
+    const slider = page.getByRole('slider', { name: /tempo/i });
+    await expect(slider).toBeVisible();
+    const step = await slider.getAttribute('step');
+    expect(parseFloat(step ?? '')).toBeCloseTo(0.01);
+  });
+
+  test('tempo slider has a datalist with a 100% tick mark', async ({ page }) => {
+    const slider = page.getByRole('slider', { name: /tempo/i });
+    const listId = await slider.getAttribute('list');
+    expect(listId).toBeTruthy();
+    const datalist = page.locator(`datalist#${listId}`);
+    await expect(datalist).toBeAttached();
+    const option = datalist.locator('option[value="1.0"]');
+    await expect(option).toBeAttached();
+  });
+
+  test('tempo slider min is 0.1 for a standard 120 BPM score', async ({ page }) => {
+    const slider = page.getByRole('slider', { name: /tempo/i });
+    await expect(slider).toBeVisible();
+    const min = await slider.getAttribute('min');
+    expect(parseFloat(min ?? '')).toBeCloseTo(0.1);
+  });
+
+  test('max is 2.0 (200%) and slider can reach it', async ({ page }) => {
+    const slider = page.getByRole('slider', { name: /tempo/i });
+    await expect(slider).toBeVisible();
+    const max = await slider.getAttribute('max');
+    expect(parseFloat(max ?? '')).toBeCloseTo(2.0);
+  });
+});
+
+// ─── T023 — Max 200% is selectable and BPM display is correct ─────────────────
+
+test.describe('Feature 083 / T023: 200% max tempo in Play Score', () => {
+  test('BPM display reflects 200% when slider is at max', async ({ page }) => {
+    await stubMxlFetch(page);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.getByTestId('plugin-launch-play-score').click();
+    await page.getByText('Bach — Invention No. 1').click();
+
+    const slider = page.getByRole('slider', { name: /tempo/i });
+    await expect(slider).toBeVisible();
+
+    // Set the slider to 200% via JavaScript evaluation
+    await slider.evaluate((el: HTMLInputElement) => {
+      el.value = '2.0';
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    // BPM display should now show approximately 2× the original BPM
+    // (exact value depends on the score's BPM — just verify the element exists)
+    const bpmDisplay = page.locator('.play-score__toolbar-bpm');
+    await expect(bpmDisplay).toBeVisible();
+  });
+});

--- a/frontend/plugins/play-score/playbackToolbar.test.tsx
+++ b/frontend/plugins/play-score/playbackToolbar.test.tsx
@@ -152,3 +152,86 @@ describe('PlaybackToolbar — metronome button (Feature 035)', () => {
     expect(btn.getAttribute('aria-pressed')).toBe('true');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Feature 083 — Tempo slider precision: 1% steps, ±0.03 snap (T002)
+// ---------------------------------------------------------------------------
+
+describe('PlaybackToolbar — tempo slider precision (Feature 083)', () => {
+  it('slider step is 0.01 (1% granularity)', () => {
+    render(<PlaybackToolbar {...makeDefaultProps({ status: 'ready' })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo/i }) as HTMLInputElement;
+    expect(slider.step).toBe('0.01');
+  });
+
+  it('slider has a datalist providing the 100% snap tick mark', () => {
+    render(<PlaybackToolbar {...makeDefaultProps({ status: 'ready' })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo/i }) as HTMLInputElement;
+    expect(slider.getAttribute('list')).toBeTruthy();
+    const datalist = document.getElementById(slider.getAttribute('list')!);
+    expect(datalist).not.toBeNull();
+    expect(datalist?.querySelector('option[value="1.0"]')).not.toBeNull();
+  });
+
+  it('snap zone is ±0.03: onChange at 0.96 does NOT snap to 1.0', () => {
+    const onTempoChange = vi.fn();
+    render(<PlaybackToolbar {...makeDefaultProps({ status: 'ready', onTempoChange })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo/i });
+    fireEvent.change(slider, { target: { value: '0.96' } });
+    expect(onTempoChange).toHaveBeenCalledWith(0.96);
+  });
+
+  it('snap zone is ±0.03: onChange at 0.97 snaps to 1.0', () => {
+    const onTempoChange = vi.fn();
+    render(<PlaybackToolbar {...makeDefaultProps({ status: 'ready', onTempoChange })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo/i });
+    fireEvent.change(slider, { target: { value: '0.97' } });
+    expect(onTempoChange).toHaveBeenCalledWith(1.0);
+  });
+
+  it('snap zone is ±0.03: onChange at 1.03 snaps to 1.0', () => {
+    const onTempoChange = vi.fn();
+    render(<PlaybackToolbar {...makeDefaultProps({ status: 'ready', onTempoChange })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo/i });
+    fireEvent.change(slider, { target: { value: '1.03' } });
+    expect(onTempoChange).toHaveBeenCalledWith(1.0);
+  });
+
+  it('snap zone is ±0.03: onChange at 1.04 does NOT snap to 1.0', () => {
+    const onTempoChange = vi.fn();
+    render(<PlaybackToolbar {...makeDefaultProps({ status: 'ready', onTempoChange })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo/i });
+    fireEvent.change(slider, { target: { value: '1.04' } });
+    expect(onTempoChange).toHaveBeenCalledWith(1.04);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feature 083 — Tempo slider dynamic minimum (FR-014) (T007)
+// ---------------------------------------------------------------------------
+
+describe('PlaybackToolbar — tempo slider dynamic minimum (Feature 083 FR-014)', () => {
+  it('slider min is 0.1 when bpm=120 (BPM floor not triggered)', () => {
+    render(<PlaybackToolbar {...makeDefaultProps({ status: 'ready', bpm: 120 })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo/i }) as HTMLInputElement;
+    expect(parseFloat(slider.min)).toBeCloseTo(0.1);
+  });
+
+  it('slider min is ~0.25 when bpm=40 (10 BPM floor: 10/40=0.25)', () => {
+    render(<PlaybackToolbar {...makeDefaultProps({ status: 'ready', bpm: 40 })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo/i }) as HTMLInputElement;
+    expect(parseFloat(slider.min)).toBeCloseTo(0.25);
+  });
+
+  it('shows BPM-floor tooltip on slider when effective min > 0.1 (bpm=40)', () => {
+    render(<PlaybackToolbar {...makeDefaultProps({ status: 'ready', bpm: 40 })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo/i }) as HTMLInputElement;
+    expect(slider.getAttribute('title')).toMatch(/10\s*BPM/i);
+  });
+
+  it('does NOT show BPM-floor tooltip when effective min equals 0.1 (bpm=120)', () => {
+    render(<PlaybackToolbar {...makeDefaultProps({ status: 'ready', bpm: 120 })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo/i }) as HTMLInputElement;
+    expect(slider.getAttribute('title') ?? '').not.toMatch(/BPM/i);
+  });
+});

--- a/frontend/plugins/play-score/playbackToolbar.tsx
+++ b/frontend/plugins/play-score/playbackToolbar.tsx
@@ -17,7 +17,7 @@
 import { useState, useRef, useEffect } from 'react';
 import type { PluginPlaybackStatus } from '../../src/plugin-api/index';
 import type { MetronomeSubdivision } from '../../src/plugin-api/index';
-import { ProfileIcon } from '../../src/plugin-api/index';
+import { ProfileIcon, computeEffectiveMinMultiplier, MIN_TEMPO_MULTIPLIER, ABSOLUTE_BPM_FLOOR } from '../../src/plugin-api/index';
 import { useTranslation } from '../../src/i18n';
 
 // Mirror of PlaybackScheduler.PPQ — no host imports in plugin code
@@ -186,22 +186,38 @@ export function PlaybackToolbar({
       {/* Tempo control */}
       <div className="play-score__toolbar-tempo">
         <span className="play-score__toolbar-tempo-label">{t('play_score.toolbar.tempo')}</span>
-        <input
-          id="play-score-tempo"
-          type="range"
-          min={0.5}
-          max={2.0}
-          step={0.05}
-          value={tempoMultiplier}
-          onChange={e => {
-            const raw = parseFloat(e.target.value);
-            // Snap to 100% when within one step (±0.05) of 1.0
-            onTempoChange(Math.abs(raw - 1.0) <= 0.05 ? 1.0 : raw);
-          }}
-          aria-label={t('play_score.toolbar.tempo_aria')}
-          className="play-score__toolbar-tempo-slider"
-          disabled={status === 'loading'}
-        />
+        {(() => {
+          // bpm prop is the effective BPM (scoreTempo × multiplier); derive original for floor calc
+          const originalBpm = tempoMultiplier > 0 ? bpm / tempoMultiplier : bpm;
+          const effectiveMin = computeEffectiveMinMultiplier(originalBpm);
+          const showFloorTooltip = effectiveMin > MIN_TEMPO_MULTIPLIER;
+          const floorTooltip = showFloorTooltip ? `Min. speed limited to ${ABSOLUTE_BPM_FLOOR} BPM` : undefined;
+          return (
+            <>
+              <input
+                id="play-score-tempo"
+                type="range"
+                min={effectiveMin}
+                max={2.0}
+                step={0.01}
+                value={tempoMultiplier}
+                onChange={e => {
+                  const raw = Math.round(parseFloat(e.target.value) * 100) / 100;
+                  // Snap to 100% when within ±3 steps (±3pp) of 1.0
+                  onTempoChange(Math.round(Math.abs(raw - 1.0) * 100) <= 3 ? 1.0 : raw);
+                }}
+                aria-label={t('play_score.toolbar.tempo_aria')}
+                className="play-score__toolbar-tempo-slider"
+                disabled={status === 'loading'}
+                list="play-score-tempo-ticks"
+                title={floorTooltip}
+              />
+              <datalist id="play-score-tempo-ticks">
+                <option value="1.0" />
+              </datalist>
+            </>
+          );
+        })()}
         {bpm > 0 && (
           <span className="play-score__toolbar-bpm">{bpm}</span>
         )}

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.css
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.css
@@ -403,6 +403,19 @@
   animation: practice-metro-pulse-down 0.14s ease-out;
 }
 
+/* Armed state: metronome will start on the first MIDI note attack */
+.practice-plugin__metro-btn--armed,
+.practice-plugin__metro-btn--armed:hover {
+  color: #c8a000;
+  border-color: #c8a000;
+  animation: practice-metro-armed-pulse 0.5s ease-in-out infinite alternate;
+}
+
+@keyframes practice-metro-armed-pulse {
+  0%   { opacity: 0.4; }
+  100% { opacity: 1.0; }
+}
+
 @keyframes practice-metro-pulse {
   0% { filter: brightness(1.6); }
   100% { filter: brightness(1); }

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx
@@ -1724,3 +1724,125 @@ describe('[US7] Feature 053: partial results on Stop', () => {
     expect(screen.getByText(/no notes played/i)).toBeTruthy();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Feature 083 — Metronome deferred start (US3) (T014)
+// ---------------------------------------------------------------------------
+
+describe('PracticeViewPlugin — metronome deferred start (Feature 083 US3)', () => {
+  const notes = [
+    { midiPitches: [60], noteIds: ['n1'], tick: 0, durationTicks: 960, sustainedPitches: [] },
+    { midiPitches: [62], noteIds: ['n2'], tick: 960, durationTicks: 960, sustainedPitches: [] },
+  ];
+
+  it('toggling metronome outside practice mode calls toggle immediately', async () => {
+    const ctx = createMockContext({ status: 'ready', staffCount: 1 });
+    render(<PracticeViewPlugin context={ctx.context} />, { wrapper: TestWrapper });
+
+    // Clear initial subscription calls
+    vi.mocked(ctx.context.metronome.toggle).mockClear();
+
+    // Click metronome toggle — practice is NOT running
+    fireEvent.click(screen.getByRole('button', { name: /toggle metronome/i }));
+
+    expect(ctx.context.metronome.toggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggling metronome during practice waiting mode does NOT call toggle (arms instead)', async () => {
+    const ctx = createMockContext({ status: 'ready', staffCount: 1 });
+    ctx.mockExtractPracticeNotes.mockReturnValue({
+      notes,
+      totalAvailable: notes.length,
+      clef: 'Treble',
+    });
+
+    render(<PracticeViewPlugin context={ctx.context} />, { wrapper: TestWrapper });
+
+    // Start practice (enters 'waiting' mode)
+    fireEvent.click(screen.getByRole('button', { name: /start practice/i }));
+
+    // Clear the toggle mock — practice-start may have called toggle 0 times
+    vi.mocked(ctx.context.metronome.toggle).mockClear();
+
+    // Click metronome toggle while practice is in waiting mode
+    fireEvent.click(screen.getByRole('button', { name: /toggle metronome/i }));
+
+    // Should NOT have started metronome yet (deferred until first MIDI note)
+    expect(ctx.context.metronome.toggle).not.toHaveBeenCalled();
+
+    // Metronome button should have the --armed CSS class
+    expect(screen.getByRole('button', { name: /toggle metronome/i }).className)
+      .toContain('practice-plugin__metro-btn--armed');
+  });
+
+  it('first MIDI note while armed fires toggle to start metronome', async () => {
+    const ctx = createMockContext({ status: 'ready', staffCount: 1 });
+    ctx.mockExtractPracticeNotes.mockReturnValue({
+      notes,
+      totalAvailable: notes.length,
+      clef: 'Treble',
+    });
+
+    render(<PracticeViewPlugin context={ctx.context} />, { wrapper: TestWrapper });
+
+    // Start practice + arm metronome
+    fireEvent.click(screen.getByRole('button', { name: /start practice/i }));
+    vi.mocked(ctx.context.metronome.toggle).mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /toggle metronome/i }));
+    expect(ctx.context.metronome.toggle).not.toHaveBeenCalled(); // still armed
+
+    // Simulate first MIDI note attack
+    act(() => {
+      ctx.simulateMidiEvent({ type: 'attack', midiNote: 60 });
+    });
+
+    // toggle should have been called once (deferred start)
+    expect(ctx.context.metronome.toggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('starting practice while metronome is active stops it and arms it', async () => {
+    // Capture the metronome subscriber so we can simulate state changes
+    let metronomeHandler: ((state: { active: boolean; beatIndex: number; isDownbeat: boolean; bpm: number; subdivision: number }) => void) | null = null;
+    const ctx = createMockContext({ status: 'ready', staffCount: 1 });
+    (ctx.context.metronome.subscribe as ReturnType<typeof vi.fn>).mockImplementation((handler) => {
+      metronomeHandler = handler;
+      handler({ active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1 });
+      return () => {};
+    });
+    ctx.mockExtractPracticeNotes.mockReturnValue({
+      notes,
+      totalAvailable: notes.length,
+      clef: 'Treble',
+    });
+
+    render(<PracticeViewPlugin context={ctx.context} />, { wrapper: TestWrapper });
+
+    // Simulate metronome becoming active
+    act(() => {
+      metronomeHandler?.({ active: true, beatIndex: 0, isDownbeat: true, bpm: 120, subdivision: 1 });
+    });
+    vi.mocked(ctx.context.metronome.toggle).mockClear();
+
+    // Start practice — metronome should be stopped + armed automatically
+    fireEvent.click(screen.getByRole('button', { name: /start practice/i }));
+
+    // Should have called toggle once to stop the running metronome
+    expect(ctx.context.metronome.toggle).toHaveBeenCalledTimes(1);
+
+    // Simulate the metronome service acknowledging it's now inactive (real app behaviour)
+    act(() => {
+      metronomeHandler?.({ active: false, beatIndex: -1, isDownbeat: false, bpm: 120, subdivision: 1 });
+    });
+
+    // Metronome button should be in armed state
+    expect(screen.getByRole('button', { name: /toggle metronome/i }).className)
+      .toContain('practice-plugin__metro-btn--armed');
+
+    // Simulate first MIDI note — metronome should now start
+    vi.mocked(ctx.context.metronome.toggle).mockClear();
+    act(() => {
+      ctx.simulateMidiEvent({ type: 'attack', midiNote: 60 });
+    });
+    expect(ctx.context.metronome.toggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
@@ -129,10 +129,16 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
 
   // ─── Metronome state ───────────────────────────────────────────────────────
   const [metronomeState, setMetronomeState] = useState<MetronomeState>(INITIAL_METRONOME_STATE);
+  const metronomeStateRef = useRef<MetronomeState>(INITIAL_METRONOME_STATE);
   const [metronomeSubdivision, setMetronomeSubdivision] = useState<MetronomeSubdivision>(1);
+  // Feature 083 (US3): armed = toggled while practice is in 'waiting' mode;
+  // the metronome will start on the first MIDI note attack instead of immediately.
+  const [metronomeArmed, setMetronomeArmed] = useState(false);
+  const metronomeArmedRef = useRef(false);
 
   useEffect(() => {
     return context.metronome.subscribe((state) => {
+      metronomeStateRef.current = state;
       setMetronomeState(state);
       if (state.subdivision !== undefined) setMetronomeSubdivision(state.subdivision);
     });
@@ -436,6 +442,19 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
     playerStateRef,
   });
 
+  // Feature 083 (US3): Callback passed to usePracticeMidi — fires once on the
+  // first MIDI note attack while the metronome is armed, starting the engine.
+  // Defined before usePracticeMidi to avoid temporal dead zone.
+  const onFirstNoteAttack = useCallback(() => {
+    if (!metronomeArmedRef.current) return;
+    metronomeArmedRef.current = false;
+    setMetronomeArmed(false);
+    context.metronome.toggle().catch((e) => {
+      console.error('[PracticeViewPlugin] metronome deferred start failed:', e);
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context.metronome]);
+
   // ─── MIDI logic (extracted hook) ───────────────────────────────────────────
   const {
     midiPressedNoteIds, midiEventTick, heldMidiKeysRef, chordDetectorRef: _chordDetectorRef,
@@ -452,6 +471,7 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
     loopStartTimesRef,
     practiceStartTimeRef,
     selectedStaffIndex,
+    onFirstNoteAttack,
   });
 
   // ─── Teardown (SC-006) ──────────────────────────────────────────────────────
@@ -554,9 +574,24 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   );
 
   const handleMetronomeToggle = useCallback(() => {
-    context.metronome.toggle().catch((e) => {
-      console.error('[PracticeViewPlugin] metronome.toggle failed:', e);
-    });
+    const ps = practiceStateRef.current;
+    const practiceRunning = ps.mode === 'waiting' || ps.mode === 'active' || ps.mode === 'holding';
+
+    if (practiceRunning && !metronomeStateRef.current.active && !metronomeArmedRef.current) {
+      // Practice is running but metronome is inactive — arm it (deferred start).
+      metronomeArmedRef.current = true;
+      setMetronomeArmed(true);
+    } else if (metronomeArmedRef.current) {
+      // Disarm without starting.
+      metronomeArmedRef.current = false;
+      setMetronomeArmed(false);
+    } else {
+      // Normal toggle: outside practice, or stopping an already-active metronome.
+      context.metronome.toggle().catch((e) => {
+        console.error('[PracticeViewPlugin] metronome.toggle failed:', e);
+      });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [context.metronome]);
 
   const handleMetronomeSubdivisionChange = useCallback(
@@ -594,6 +629,9 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
       setResultsOverlayVisible(true);
       // Stop practice — full reset so restarting begins from the beginning.
       dispatchPractice({ type: 'STOP' });
+      // Disarm metronome if it was armed (user stopped before first note).
+      metronomeArmedRef.current = false;
+      setMetronomeArmed(false);
       const lr = loopRegionRef.current;
       context.scorePlayer.seekToTick(lr ? lr.startTick : 0);
       return;
@@ -667,6 +705,17 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
       staffIndex,
       startIndex,
     });
+
+    // Feature 083 (US3): If the metronome is already active when practice starts,
+    // stop it and arm it — it will restart on the first MIDI note attack.
+    if (metronomeStateRef.current.active && !metronomeArmedRef.current) {
+      context.metronome.toggle().catch((e) => {
+        console.error('[PracticeViewPlugin] metronome stop-on-practice-start failed:', e);
+      });
+      metronomeArmedRef.current = true;
+      setMetronomeArmed(true);
+    }
+
     // practiceStartTimeRef is set later — when the first correct note is played
     // (deferred start: the clock doesn't start until the user hits the first note).
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1038,6 +1087,7 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
         onMetronomeToggle={handleMetronomeToggle}
         metronomeSubdivision={metronomeSubdivision}
         onMetronomeSubdivisionChange={handleMetronomeSubdivisionChange}
+        metronomeArmed={metronomeArmed}
         taskTag={taskTag}
         isReplaying={isReplaying}
         onTaskTagClick={() => context.openPlugin('sessions-plugin', {

--- a/frontend/plugins/practice-view-plugin/practiceToolbar.test.tsx
+++ b/frontend/plugins/practice-view-plugin/practiceToolbar.test.tsx
@@ -311,3 +311,137 @@ describe('PracticeToolbar — MIDI not supported', () => {
     expect(screen.queryByText(/MIDI is not supported/i)).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Feature 083 — Tempo slider precision: 1% steps, ±0.03 snap (T003)
+// ---------------------------------------------------------------------------
+
+describe('PracticeToolbar — tempo slider precision (Feature 083)', () => {
+  it('slider step is 0.01 (1% granularity)', () => {
+    render(<PracticeToolbar {...makeDefaultProps({ status: 'ready' })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo multiplier/i }) as HTMLInputElement;
+    expect(slider.step).toBe('0.01');
+  });
+
+  it('slider has a datalist providing the 100% snap tick mark', () => {
+    render(<PracticeToolbar {...makeDefaultProps({ status: 'ready' })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo multiplier/i }) as HTMLInputElement;
+    expect(slider.getAttribute('list')).toBeTruthy();
+    const datalist = document.getElementById(slider.getAttribute('list')!);
+    expect(datalist).not.toBeNull();
+    expect(datalist?.querySelector('option[value="1.0"]')).not.toBeNull();
+  });
+
+  it('snap zone is ±0.03: onChange at 0.96 does NOT snap to 1.0', () => {
+    const onTempoChange = vi.fn();
+    render(<PracticeToolbar {...makeDefaultProps({ status: 'ready', onTempoChange })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo multiplier/i });
+    fireEvent.change(slider, { target: { value: '0.96' } });
+    expect(onTempoChange).toHaveBeenCalledWith(0.96);
+  });
+
+  it('snap zone is ±0.03: onChange at 0.97 snaps to 1.0', () => {
+    const onTempoChange = vi.fn();
+    render(<PracticeToolbar {...makeDefaultProps({ status: 'ready', onTempoChange })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo multiplier/i });
+    fireEvent.change(slider, { target: { value: '0.97' } });
+    expect(onTempoChange).toHaveBeenCalledWith(1.0);
+  });
+
+  it('snap zone is ±0.03: onChange at 1.03 snaps to 1.0', () => {
+    const onTempoChange = vi.fn();
+    render(<PracticeToolbar {...makeDefaultProps({ status: 'ready', onTempoChange })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo multiplier/i });
+    fireEvent.change(slider, { target: { value: '1.03' } });
+    expect(onTempoChange).toHaveBeenCalledWith(1.0);
+  });
+
+  it('snap zone is ±0.03: onChange at 1.04 does NOT snap to 1.0', () => {
+    const onTempoChange = vi.fn();
+    render(<PracticeToolbar {...makeDefaultProps({ status: 'ready', onTempoChange })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo multiplier/i });
+    fireEvent.change(slider, { target: { value: '1.04' } });
+    expect(onTempoChange).toHaveBeenCalledWith(1.04);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feature 083 — Tempo slider dynamic minimum (FR-014) (T008)
+// ---------------------------------------------------------------------------
+
+describe('PracticeToolbar — tempo slider dynamic minimum (Feature 083 FR-014)', () => {
+  it('slider min is 0.1 when bpm=120 (BPM floor not triggered)', () => {
+    render(<PracticeToolbar {...makeDefaultProps({ status: 'ready', bpm: 120 })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo multiplier/i }) as HTMLInputElement;
+    expect(parseFloat(slider.min)).toBeCloseTo(0.1);
+  });
+
+  it('slider min is ~0.25 when bpm=40 (10 BPM floor: 10/40=0.25)', () => {
+    render(<PracticeToolbar {...makeDefaultProps({ status: 'ready', bpm: 40 })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo multiplier/i }) as HTMLInputElement;
+    expect(parseFloat(slider.min)).toBeCloseTo(0.25);
+  });
+
+  it('shows BPM-floor tooltip on slider when effective min > 0.1 (bpm=40)', () => {
+    render(<PracticeToolbar {...makeDefaultProps({ status: 'ready', bpm: 40 })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo multiplier/i }) as HTMLInputElement;
+    expect(slider.getAttribute('title')).toMatch(/10\s*BPM/i);
+  });
+
+  it('does NOT show BPM-floor tooltip when effective min equals 0.1 (bpm=120)', () => {
+    render(<PracticeToolbar {...makeDefaultProps({ status: 'ready', bpm: 120 })} />, { wrapper: TestWrapper });
+    const slider = screen.getByRole('slider', { name: /tempo multiplier/i }) as HTMLInputElement;
+    expect(slider.getAttribute('title') ?? '').not.toMatch(/BPM/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feature 083 — Metronome armed state: deferred start (T013)
+// ---------------------------------------------------------------------------
+
+describe('PracticeToolbar — metronome armed state (Feature 083 US3)', () => {
+  const metronomeProps = {
+    metronomeActive: false,
+    metronomeBeatIndex: -1,
+    metronomeIsDownbeat: false,
+    onMetronomeToggle: vi.fn(),
+    metronomeSubdivision: 1 as const,
+    onMetronomeSubdivisionChange: vi.fn(),
+  };
+
+  it('metronome button has --armed CSS class when metronomeArmed=true', () => {
+    render(
+      <PracticeToolbar {...makeDefaultProps({ ...metronomeProps, metronomeArmed: true })} />,
+      { wrapper: TestWrapper },
+    );
+    const btn = screen.getByRole('button', { name: /toggle metronome/i });
+    expect(btn.className).toContain('practice-plugin__metro-btn--armed');
+    expect(btn.className).not.toContain('practice-plugin__metro-btn--active');
+  });
+
+  it('metronome button does NOT have --armed class when metronomeArmed=false', () => {
+    render(
+      <PracticeToolbar {...makeDefaultProps({ ...metronomeProps, metronomeArmed: false })} />,
+      { wrapper: TestWrapper },
+    );
+    const btn = screen.getByRole('button', { name: /toggle metronome/i });
+    expect(btn.className).not.toContain('practice-plugin__metro-btn--armed');
+  });
+
+  it('armed class absent when metronomeActive=true (active wins over armed)', () => {
+    render(
+      <PracticeToolbar
+        {...makeDefaultProps({
+          ...metronomeProps,
+          metronomeActive: true,
+          metronomeArmed: true,
+          metronomeBeatIndex: 0,
+        })}
+      />,
+      { wrapper: TestWrapper },
+    );
+    const btn = screen.getByRole('button', { name: /toggle metronome/i });
+    expect(btn.className).not.toContain('practice-plugin__metro-btn--armed');
+    expect(btn.className).toContain('practice-plugin__metro-btn--active');
+  });
+});

--- a/frontend/plugins/practice-view-plugin/practiceToolbar.tsx
+++ b/frontend/plugins/practice-view-plugin/practiceToolbar.tsx
@@ -15,7 +15,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import type { PluginPlaybackStatus, MetronomeSubdivision } from '../../src/plugin-api/index';
-import { ProfileIcon } from '../../src/plugin-api/index';
+import { ProfileIcon, computeEffectiveMinMultiplier, MIN_TEMPO_MULTIPLIER, ABSOLUTE_BPM_FLOOR } from '../../src/plugin-api/index';
 import type { PracticeMode } from './practiceEngine.types';
 import { useTranslation } from '../../src/i18n';
 
@@ -83,6 +83,8 @@ export interface PracticeToolbarProps {
   onMetronomeToggle: () => void;
   metronomeSubdivision: MetronomeSubdivision;
   onMetronomeSubdivisionChange: (s: MetronomeSubdivision) => void;
+  /** When true, metronome is armed — will start on the first MIDI note attack. */
+  metronomeArmed?: boolean;
   /** When true, a replay is running — practice toggle should be disabled. */
   isReplaying?: boolean;
   /** Feature 061: Session task tag — when set, config is locked and tag is shown. */
@@ -123,6 +125,7 @@ export function PracticeToolbar({
   onMetronomeToggle,
   metronomeSubdivision,
   onMetronomeSubdivisionChange,
+  metronomeArmed = false,
   isReplaying,
   taskTag,
   onTaskTagClick,
@@ -141,6 +144,7 @@ export function PracticeToolbar({
     'practice-plugin__metro-btn',
     ...(metronomeActive ? ['practice-plugin__metro-btn--active'] : []),
     ...(metronomeActive && metronomeIsDownbeat ? ['practice-plugin__metro-btn--downbeat'] : []),
+    ...(metronomeArmed && !metronomeActive ? ['practice-plugin__metro-btn--armed'] : []),
   ].join(' ');
   const SUBDIV_ICONS: Record<MetronomeSubdivision, string> = { 1: '♩', 2: '♪', 4: '♬' };
   const SUBDIV_LABELS: Record<MetronomeSubdivision, string> = { 1: '♩ 1/4', 2: '♪ 1/8', 4: '♬ 1/16' };
@@ -385,22 +389,38 @@ export function PracticeToolbar({
       {/* Tempo */}
       <div className="practice-plugin__toolbar-tempo">
         <span className="practice-plugin__toolbar-tempo-label">{t('practice.toolbar.tempo')}</span>
-        <input
-          type="range"
-          min={0.5}
-          max={2.0}
-          step={0.05}
-          value={tempoMultiplier}
-          onChange={(e) => {
-            const raw = parseFloat(e.target.value);
-            onTempoChange(Math.abs(raw - 1.0) <= 0.05 ? 1.0 : raw);
-          }}
-          aria-label={t('practice.toolbar.tempo_aria')}
-          className="practice-plugin__toolbar-tempo-slider"
-          disabled={status === 'loading' || !!taskTag}
-        />
+        {(() => {
+          // bpm prop is the effective BPM (scoreTempo × multiplier); derive original for floor calc
+          const originalBpm = tempoMultiplier > 0 ? bpm / tempoMultiplier : bpm;
+          const effectiveMin = computeEffectiveMinMultiplier(originalBpm);
+          const showFloorTooltip = effectiveMin > MIN_TEMPO_MULTIPLIER;
+          const floorTooltip = showFloorTooltip ? `Min. speed limited to ${ABSOLUTE_BPM_FLOOR} BPM` : undefined;
+          return (
+            <>
+              <input
+                type="range"
+                min={effectiveMin}
+                max={2.0}
+                step={0.01}
+                value={tempoMultiplier}
+                onChange={(e) => {
+                  const raw = Math.round(parseFloat(e.target.value) * 100) / 100;
+                  onTempoChange(Math.round(Math.abs(raw - 1.0) * 100) <= 3 ? 1.0 : raw);
+                }}
+                aria-label={t('practice.toolbar.tempo_aria')}
+                className="practice-plugin__toolbar-tempo-slider"
+                disabled={status === 'loading' || !!taskTag}
+                list="practice-tempo-ticks"
+                title={floorTooltip}
+              />
+              <datalist id="practice-tempo-ticks">
+                <option value="1.0" />
+              </datalist>
+            </>
+          );
+        })()}
         {bpm > 0 && (
-          <span className="practice-plugin__toolbar-bpm">{Math.round(bpm * tempoMultiplier)}</span>
+          <span className="practice-plugin__toolbar-bpm">{bpm}</span>
         )}
       </div>
 

--- a/frontend/plugins/practice-view-plugin/usePracticeMidi.ts
+++ b/frontend/plugins/practice-view-plugin/usePracticeMidi.ts
@@ -24,6 +24,11 @@ export interface UsePracticeMidiParams {
   loopStartTimesRef: React.RefObject<number[]>;
   practiceStartTimeRef: React.RefObject<number>;
   selectedStaffIndex: number;
+  /**
+   * Feature 083 (US3): Called once on the first MIDI note attack while practice
+   * is in 'waiting' mode. Used to trigger deferred metronome start.
+   */
+  onFirstNoteAttack?: () => void;
 }
 
 export interface UsePracticeMidiReturn {
@@ -53,6 +58,7 @@ export function usePracticeMidi({
   loopStartTimesRef,
   practiceStartTimeRef,
   selectedStaffIndex: _selectedStaffIndex,
+  onFirstNoteAttack,
 }: UsePracticeMidiParams): UsePracticeMidiReturn {
   // ─── Chord detector ─────────────────────────────────────────────────────────
   const chordDetectorRef = useRef(new ChordDetector());
@@ -64,6 +70,20 @@ export function usePracticeMidi({
   // ─── MIDI-pressed note IDs ─────────────────────────────────────────────────
   const [midiPressedNoteIds, setMidiPressedNoteIds] = useState<ReadonlySet<string>>(new Set());
   const [midiEventTick, setMidiEventTick] = useState(0);
+
+  // ─── Feature 083: First-note attack callback (deferred metronome start) ────
+  // Keep a ref to the latest callback to avoid stale closures inside the MIDI
+  // subscription effect.
+  const onFirstNoteAttackRef = useRef(onFirstNoteAttack);
+  useEffect(() => { onFirstNoteAttackRef.current = onFirstNoteAttack; }, [onFirstNoteAttack]);
+
+  // Guard: fire exactly once per practice session. Reset when practice stops.
+  const hasCalledFirstNoteRef = useRef(false);
+  useEffect(() => {
+    if (practiceState.mode === 'inactive') {
+      hasCalledFirstNoteRef.current = false;
+    }
+  }, [practiceState.mode]);
 
   // ─── All-notes lookup for MIDI visual highlight ────────────────────────────
   const allNotesRef = useRef<PluginPracticeNoteEntry[]>([]);
@@ -187,6 +207,14 @@ export function usePracticeMidi({
 
       const ps = practiceStateRef.current;
       if (ps.mode !== 'active' && ps.mode !== 'waiting' && ps.mode !== 'holding') return;
+
+      // Feature 083 (US3): fire deferred-metronome callback on the first note
+      // attack of a practice session (mode === 'waiting'). The guard ref ensures
+      // simultaneous chord events only trigger the callback once.
+      if (ps.mode === 'waiting' && !hasCalledFirstNoteRef.current) {
+        hasCalledFirstNoteRef.current = true;
+        onFirstNoteAttackRef.current?.();
+      }
 
       const currentEntry = ps.notes[ps.currentIndex];
       if (!currentEntry) return;

--- a/frontend/src/plugin-api/index.ts
+++ b/frontend/src/plugin-api/index.ts
@@ -68,3 +68,6 @@ export { openDB } from '../services/storage/local-storage';
 // Feature 060: Shared practice score computation
 export { computePracticeScore } from './computePracticeScore';
 export type { PracticeScoreBreakdown, ScorableNoteResult } from './computePracticeScore';
+
+// Feature 083: Tempo calculation utilities (re-exported so plugins can import from plugin-api)
+export { computeEffectiveMinMultiplier, MIN_TEMPO_MULTIPLIER, MAX_TEMPO_MULTIPLIER, ABSOLUTE_BPM_FLOOR } from '../utils/tempoCalculations';

--- a/frontend/src/services/state/TempoStateContext.test.tsx
+++ b/frontend/src/services/state/TempoStateContext.test.tsx
@@ -49,14 +49,14 @@ describe('TempoStateContext', () => {
       expect(result.current.tempoState.tempoMultiplier).toBe(0.8);
     });
 
-    it('should clamp multiplier to minimum 0.5', () => {
+    it('should clamp multiplier to minimum 0.1 (Feature 083: extended range)', () => {
       const { result } = renderHook(() => useTempoState(), { wrapper });
       
       act(() => {
-        result.current.setTempoMultiplier(0.3);
+        result.current.setTempoMultiplier(0.05);
       });
       
-      expect(result.current.tempoState.tempoMultiplier).toBe(0.5);
+      expect(result.current.tempoState.tempoMultiplier).toBe(0.1);
     });
 
     it('should clamp multiplier to maximum 2.0', () => {
@@ -111,18 +111,18 @@ describe('TempoStateContext', () => {
       expect(result.current.tempoState.tempoMultiplier).toBe(0.90);
     });
 
-    it('should clamp to 0.5 when adjusting below minimum', () => {
+    it('should clamp to 0.1 when adjusting below minimum (Feature 083: extended range)', () => {
       const { result } = renderHook(() => useTempoState(), { wrapper });
       
       act(() => {
-        result.current.setTempoMultiplier(0.6);
+        result.current.setTempoMultiplier(0.15);
       });
       
       act(() => {
-        result.current.adjustTempo(-20); // Would go to 0.4
+        result.current.adjustTempo(-10); // Would go to 0.05, clamps to 0.1
       });
       
-      expect(result.current.tempoState.tempoMultiplier).toBe(0.5);
+      expect(result.current.tempoState.tempoMultiplier).toBe(0.1);
     });
 
     it('should clamp to 2.0 when adjusting above maximum', () => {

--- a/frontend/src/utils/tempoCalculations.test.ts
+++ b/frontend/src/utils/tempoCalculations.test.ts
@@ -1,0 +1,76 @@
+/**
+ * tempoCalculations unit tests — Feature 083
+ *
+ * Tests:
+ *   - MIN_TEMPO_MULTIPLIER is 0.1 (was 0.5)
+ *   - ABSOLUTE_BPM_FLOOR is 10 BPM (new constant)
+ *   - clampTempoMultiplier works with the new [0.1, 2.0] range
+ *   - computeEffectiveMinMultiplier returns correct floor per score BPM
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  MIN_TEMPO_MULTIPLIER,
+  MAX_TEMPO_MULTIPLIER,
+  ABSOLUTE_BPM_FLOOR,
+  clampTempoMultiplier,
+  computeEffectiveMinMultiplier,
+} from './tempoCalculations';
+
+describe('tempoCalculations — Feature 083 constants', () => {
+  it('MIN_TEMPO_MULTIPLIER is 0.1 (10%)', () => {
+    expect(MIN_TEMPO_MULTIPLIER).toBe(0.1);
+  });
+
+  it('MAX_TEMPO_MULTIPLIER is 2.0 (200%)', () => {
+    expect(MAX_TEMPO_MULTIPLIER).toBe(2.0);
+  });
+
+  it('ABSOLUTE_BPM_FLOOR is 10 BPM', () => {
+    expect(ABSOLUTE_BPM_FLOOR).toBe(10);
+  });
+});
+
+describe('clampTempoMultiplier — Feature 083 range', () => {
+  it('clamps values below the new minimum (0.1) to 0.1', () => {
+    expect(clampTempoMultiplier(0.05)).toBe(0.1);
+    expect(clampTempoMultiplier(0.0)).toBe(0.1);
+  });
+
+  it('passes through values within [0.1, 2.0]', () => {
+    expect(clampTempoMultiplier(0.1)).toBe(0.1);
+    expect(clampTempoMultiplier(0.3)).toBe(0.3);
+    expect(clampTempoMultiplier(1.0)).toBe(1.0);
+    expect(clampTempoMultiplier(2.0)).toBe(2.0);
+  });
+
+  it('clamps values above the maximum (2.0) to 2.0', () => {
+    expect(clampTempoMultiplier(3.0)).toBe(2.0);
+  });
+});
+
+describe('computeEffectiveMinMultiplier — Feature 083 BPM floor', () => {
+  it('returns 0.1 when score bpm is fast (bpm=120, 10% → 12 BPM > floor)', () => {
+    expect(computeEffectiveMinMultiplier(120)).toBeCloseTo(0.1);
+  });
+
+  it('returns 0.25 when bpm=40 (10 BPM floor: max(0.1, 10/40) = 0.25)', () => {
+    expect(computeEffectiveMinMultiplier(40)).toBeCloseTo(0.25);
+  });
+
+  it('returns 0.1 at bpm=100 (10/100 = 0.1 ties with floor)', () => {
+    expect(computeEffectiveMinMultiplier(100)).toBeCloseTo(0.1);
+  });
+
+  it('handles bpm=0 defensively — returns MIN_TEMPO_MULTIPLIER (0.1)', () => {
+    expect(computeEffectiveMinMultiplier(0)).toBe(0.1);
+  });
+
+  it('handles negative bpm defensively — returns MIN_TEMPO_MULTIPLIER (0.1)', () => {
+    expect(computeEffectiveMinMultiplier(-10)).toBe(0.1);
+  });
+
+  it('returns clamped value for very slow scores (bpm=20, 10/20=0.5)', () => {
+    expect(computeEffectiveMinMultiplier(20)).toBeCloseTo(0.5);
+  });
+});

--- a/frontend/src/utils/tempoCalculations.ts
+++ b/frontend/src/utils/tempoCalculations.ts
@@ -5,9 +5,16 @@
  */
 
 /**
- * Minimum tempo multiplier: 50% (half speed)
+ * Minimum tempo multiplier: 10% (slowest selectable speed)
  */
-export const MIN_TEMPO_MULTIPLIER = 0.5;
+export const MIN_TEMPO_MULTIPLIER = 0.1;
+
+/**
+ * Absolute BPM floor: the lowest effective playback BPM allowed.
+ * Used by computeEffectiveMinMultiplier to prevent inaudibly slow playback
+ * for scores that have a slow original BPM.
+ */
+export const ABSOLUTE_BPM_FLOOR = 10;
 
 /**
  * Maximum tempo multiplier: 200% (double speed)
@@ -20,18 +27,39 @@ export const MAX_TEMPO_MULTIPLIER = 2.0;
 export const DEFAULT_TEMPO_MULTIPLIER = 1.0;
 
 /**
- * Clamp tempo multiplier to valid range (0.5 to 2.0)
- * 
+ * Clamp tempo multiplier to valid range [MIN_TEMPO_MULTIPLIER, MAX_TEMPO_MULTIPLIER].
+ *
  * @param multiplier - Tempo multiplier to clamp
- * @returns Clamped value between 0.5 and 2.0
- * 
+ * @returns Clamped value within [0.1, 2.0]
+ *
  * @example
- * clampTempoMultiplier(0.3);  // Returns 0.5
+ * clampTempoMultiplier(0.05); // Returns 0.1
  * clampTempoMultiplier(1.5);  // Returns 1.5
  * clampTempoMultiplier(3.0);  // Returns 2.0
  */
 export function clampTempoMultiplier(multiplier: number): number {
   return Math.max(MIN_TEMPO_MULTIPLIER, Math.min(MAX_TEMPO_MULTIPLIER, multiplier));
+}
+
+/**
+ * Compute the effective minimum tempo multiplier for a given score BPM.
+ *
+ * Ensures that the absolute playback BPM never drops below ABSOLUTE_BPM_FLOOR
+ * (10 BPM), even when the user drags the slider to the global minimum (10%).
+ * For scores with an original BPM ≥ 100, this returns MIN_TEMPO_MULTIPLIER
+ * (0.1) unchanged. For slower scores the floor is raised proportionally.
+ *
+ * @param originalBpm - Score's original BPM from the player state
+ * @returns Effective minimum multiplier in [0.1, 2.0]
+ *
+ * @example
+ * computeEffectiveMinMultiplier(120); // 0.1  (12 BPM > floor)
+ * computeEffectiveMinMultiplier(40);  // 0.25 (10/40)
+ * computeEffectiveMinMultiplier(0);   // 0.1  (defensive)
+ */
+export function computeEffectiveMinMultiplier(originalBpm: number): number {
+  if (originalBpm <= 0) return MIN_TEMPO_MULTIPLIER;
+  return Math.max(MIN_TEMPO_MULTIPLIER, ABSOLUTE_BPM_FLOOR / originalBpm);
 }
 
 /**

--- a/frontend/tests/unit/TempoMultiplier.test.ts
+++ b/frontend/tests/unit/TempoMultiplier.test.ts
@@ -19,10 +19,10 @@ describe('Tempo Multiplier Calculations', () => {
       expect(clampTempoMultiplier(1.5)).toBe(1.5);
     });
 
-    it('should clamp values below minimum to 0.5', () => {
-      expect(clampTempoMultiplier(0.3)).toBe(0.5);
-      expect(clampTempoMultiplier(0.0)).toBe(0.5);
-      expect(clampTempoMultiplier(-0.5)).toBe(0.5);
+    it('should clamp values below minimum to 0.1 (Feature 083: extended range)', () => {
+      expect(clampTempoMultiplier(0.05)).toBe(0.1);
+      expect(clampTempoMultiplier(0.0)).toBe(0.1);
+      expect(clampTempoMultiplier(-0.5)).toBe(0.1);
     });
 
     it('should clamp values above maximum to 2.0', () => {

--- a/specs/083-tempo-metronome-practice/checklists/requirements.md
+++ b/specs/083-tempo-metronome-practice/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Tempo Slider Range Extension & Practice Metronome Deferred Start
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Clarification round completed 2026-04-25.
+- Q1: Beat 1 alignment (fresh measure start on first note).
+- Q2: Any note input triggers (wrong notes, chords all qualify).
+- Q3: Distinct armed/waiting visual state on metronome control (FR-012).
+- Q4: 10 BPM absolute floor with user-visible indicator (FR-014).
+- Q5: 1% integer steps with snap zone at 100% for easy return to original tempo (FR-010, FR-011).
+- Spec is ready for `/speckit.plan`.

--- a/specs/083-tempo-metronome-practice/contracts/PracticeToolbarProps.ts
+++ b/specs/083-tempo-metronome-practice/contracts/PracticeToolbarProps.ts
@@ -1,0 +1,70 @@
+/**
+ * Contract: Updated `PracticeToolbarProps` interface
+ * Feature 083 — Tempo Slider Range Extension & Practice Metronome Deferred Start
+ *
+ * Documents the changes to the PracticeToolbar component props.
+ * Source: frontend/plugins/practice-view-plugin/practiceToolbar.tsx
+ *
+ * Changes from baseline:
+ *   - Added: `metronomeArmed: boolean`   (FR-012)
+ *   - Unchanged: all other props
+ *
+ * Consumers:
+ *   - frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
+ *
+ * Tests:
+ *   - frontend/plugins/practice-view-plugin/practiceToolbar.test.tsx
+ */
+
+/**
+ * Props for PracticeToolbar component (post-feature-083 surface).
+ * Only the new/changed props are documented here; unchanged props are omitted.
+ */
+export interface PracticeToolbarPropsChanges {
+  // ─── New prop (FR-012) ──────────────────────────────────────────────────
+  /**
+   * True when the metronome is armed: toggled ON in practice mode but no
+   * note has been played yet. The metronome engine is NOT running while armed.
+   *
+   * When true:
+   *   - Renders `practice-plugin__metro-btn--armed` CSS class on the button
+   *   - The button pulses to signal it is waiting for the first note
+   *   - Mutually exclusive with `metronomeActive` (armed resets the moment
+   *     the engine starts on the first note)
+   *
+   * Invariants (enforced by PracticeViewPlugin, verifiable in tests):
+   *   - `metronomeArmed && metronomeActive` MUST NOT both be true simultaneously
+   *   - `metronomeArmed` MUST only be true when practice mode is running
+   *     (mode ∈ {waiting, active, holding})
+   */
+  metronomeArmed: boolean;
+
+  // ─── Changed slider behaviour (not a prop type change — implementation only) ──
+  /**
+   * Slider min is now dynamic: `computeEffectiveMinMultiplier(bpm)` → [0.1, 1.0]
+   * Slider step is now 0.01 (was 0.05)
+   * Snap zone is now ±0.03 (was ±0.05)
+   * Slider renders a datalist tick at 100% position
+   *
+   * These changes are implemented inside practiceToolbar.tsx and
+   * playbackToolbar.tsx; they do not add new props.
+   */
+  _sliderChangesNote: never; // documentation-only field; remove in implementation
+}
+
+/**
+ * CSS classes on the metronome button — possible combinations after feature-083.
+ *
+ * | Active | Armed | Downbeat | Class list                                                      |
+ * |--------|-------|----------|-----------------------------------------------------------------|
+ * | false  | false | —        | `practice-plugin__metro-btn`                                    |
+ * | false  | true  | —        | `practice-plugin__metro-btn practice-plugin__metro-btn--armed`  |
+ * | true   | false | false    | `practice-plugin__metro-btn practice-plugin__metro-btn--active` |
+ * | true   | false | true     | `practice-plugin__metro-btn practice-plugin__metro-btn--active practice-plugin__metro-btn--downbeat` |
+ * | true   | true  | —        | INVALID — must never occur                                      |
+ */
+export type MetronomeButtonClassState =
+  | 'off'
+  | 'armed'
+  | 'active'
+  | 'active-downbeat';

--- a/specs/083-tempo-metronome-practice/contracts/tempoCalculations-api.ts
+++ b/specs/083-tempo-metronome-practice/contracts/tempoCalculations-api.ts
@@ -1,0 +1,103 @@
+/**
+ * Contract: Updated `tempoCalculations` public API
+ * Feature 083 — Tempo Slider Range Extension & Practice Metronome Deferred Start
+ *
+ * This file documents the public surface of
+ * `frontend/src/utils/tempoCalculations.ts` after this feature.
+ *
+ * The contract is consumed by:
+ *  - frontend/plugins/play-score/playbackToolbar.tsx
+ *  - frontend/plugins/practice-view-plugin/practiceToolbar.tsx
+ *  - frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
+ *  - frontend/src/services/state/TempoStateContext.tsx  (unchanged usage)
+ *
+ * Tests: frontend/src/utils/tempoCalculations.test.ts
+ */
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** Minimum tempo multiplier: 10% (one-tenth speed). FR-001. */
+export declare const MIN_TEMPO_MULTIPLIER: 0.1;
+
+/** Maximum tempo multiplier: 200% (double speed). FR-001. */
+export declare const MAX_TEMPO_MULTIPLIER: 2.0;
+
+/** Default tempo multiplier: 100% (original score tempo). */
+export declare const DEFAULT_TEMPO_MULTIPLIER: 1.0;
+
+/**
+ * Absolute minimum playback BPM regardless of tempo multiplier. FR-014.
+ * When 10% of the score's original BPM falls below this floor, the slider
+ * minimum is clamped upward so the user cannot set playback below 10 BPM.
+ */
+export declare const ABSOLUTE_BPM_FLOOR: 10;
+
+// ─── Functions ───────────────────────────────────────────────────────────────
+
+/**
+ * Clamp a tempo multiplier to the valid range [MIN_TEMPO_MULTIPLIER, MAX_TEMPO_MULTIPLIER].
+ *
+ * Used on IndexedDB load (FR-009) and whenever an external value is ingested.
+ *
+ * @param multiplier — Raw tempo multiplier (any number)
+ * @returns Value clamped to [0.1, 2.0]
+ *
+ * @example
+ * clampTempoMultiplier(0.05) // → 0.1
+ * clampTempoMultiplier(0.8)  // → 0.8
+ * clampTempoMultiplier(3.0)  // → 2.0
+ */
+export declare function clampTempoMultiplier(multiplier: number): number;
+
+/**
+ * Compute the effective minimum tempo multiplier for a score, accounting for
+ * the ABSOLUTE_BPM_FLOOR. (FR-014)
+ *
+ * For most scores (original BPM ≥ 100), this returns MIN_TEMPO_MULTIPLIER (0.1).
+ * For unusually slow scores (e.g. 40 BPM Largo), the floor clamps the minimum
+ * upward so playback never drops below 10 BPM.
+ *
+ * @param originalBpm — Score's base BPM as reported by the WASM layout engine
+ *                       (NOT multiplied by tempoMultiplier)
+ * @returns Effective minimum multiplier in [MIN_TEMPO_MULTIPLIER, 1.0]
+ *
+ * @example
+ * computeEffectiveMinMultiplier(120) // → 0.1   (10 / 120 < 0.1 → use 0.1)
+ * computeEffectiveMinMultiplier(40)  // → 0.25  (10 / 40 = 0.25 > 0.1)
+ * computeEffectiveMinMultiplier(0)   // → 0.1   (defensive fallback)
+ */
+export declare function computeEffectiveMinMultiplier(originalBpm: number): number;
+
+/**
+ * Convert a tempo multiplier to an integer percentage.
+ *
+ * @param multiplier — Tempo multiplier (0.1 to 2.0)
+ * @returns Integer percentage (10 to 200)
+ *
+ * @example
+ * multiplierToPercentage(1.0)  // → 100
+ * multiplierToPercentage(0.1)  // → 10
+ * multiplierToPercentage(2.0)  // → 200
+ */
+export declare function multiplierToPercentage(multiplier: number): number;
+
+/**
+ * Convert a percentage to a tempo multiplier.
+ *
+ * @param percentage — Integer percentage (10 to 200)
+ * @returns Tempo multiplier (0.10 to 2.0)
+ *
+ * @example
+ * percentageToMultiplier(100) // → 1.0
+ * percentageToMultiplier(10)  // → 0.1
+ */
+export declare function percentageToMultiplier(percentage: number): number;
+
+/**
+ * Calculate the effective BPM given an original BPM and a tempo multiplier.
+ *
+ * @param originalBpm  — Base BPM from the score
+ * @param multiplier   — Tempo multiplier (0.1 to 2.0)
+ * @returns Effective BPM = round(originalBpm * multiplier)
+ */
+export declare function calculateEffectiveTempo(originalBpm: number, multiplier: number): number;

--- a/specs/083-tempo-metronome-practice/data-model.md
+++ b/specs/083-tempo-metronome-practice/data-model.md
@@ -1,0 +1,200 @@
+# Data Model: Tempo Slider Range Extension & Practice Metronome Deferred Start
+
+**Branch**: `083-tempo-metronome-practice` | **Date**: 2026-04-25
+
+---
+
+## 1. Updated Constants — `tempoCalculations.ts`
+
+### Before vs After
+
+| Constant | Before | After | Notes |
+|----------|--------|-------|-------|
+| `MIN_TEMPO_MULTIPLIER` | `0.5` (50%) | `0.1` (10%) | FR-001 |
+| `MAX_TEMPO_MULTIPLIER` | `2.0` (200%) | `2.0` (200%) | unchanged |
+| `DEFAULT_TEMPO_MULTIPLIER` | `1.0` (100%) | `1.0` (100%) | unchanged |
+| `ABSOLUTE_BPM_FLOOR` | *(absent)* | `10` (BPM) | FR-014 |
+
+### New Helper Function
+
+```ts
+/**
+ * Compute the effective minimum tempo multiplier for a score.
+ *
+ * When the score's original BPM is very slow, applying MIN_TEMPO_MULTIPLIER
+ * would yield a playback speed below ABSOLUTE_BPM_FLOOR. In that case, the
+ * minimum is clamped upward so playback never drops below 10 BPM (FR-014).
+ *
+ * Examples:
+ *   computeEffectiveMinMultiplier(120)  → 0.1   (10% — floor not reached)
+ *   computeEffectiveMinMultiplier(40)   → 0.25  (25% — floor clamps)
+ *   computeEffectiveMinMultiplier(0)    → 0.1   (defensive fallback)
+ */
+export function computeEffectiveMinMultiplier(originalBpm: number): number {
+  if (originalBpm <= 0) return MIN_TEMPO_MULTIPLIER;
+  return Math.max(MIN_TEMPO_MULTIPLIER, ABSOLUTE_BPM_FLOOR / originalBpm);
+}
+```
+
+### `clampTempoMultiplier` change
+
+The function body is unchanged; updating `MIN_TEMPO_MULTIPLIER` constant automatically changes the clamp boundary. **No code change** required inside the function.
+
+---
+
+## 2. Transient React State — `PracticeViewPlugin.tsx`
+
+### New state variable
+
+```ts
+/** True when the metronome is toggled on in practice mode but no note has been
+ *  played yet. The metronome engine is NOT running while armed. Resets when
+ *  practice stops, restarts, or the first note fires.
+ */
+const [metronomeArmed, setMetronomeArmed] = useState<boolean>(false);
+```
+
+### Reset ref (prevents multiple fires for chord events)
+
+```ts
+/** Guards onFirstNoteAttack from firing more than once per session. */
+const metronomeArmedRef = useRef<boolean>(false);
+```
+
+Synchronised with `metronomeArmed` state in a `useEffect` or via direct ref assignment before calling `setMetronomeArmed`. The ref is used inside the MIDI callback (stale closure), the state is used for rendering.
+
+### Modified `handleMetronomeToggle`
+
+| Practice mode | Current engine state | Armed? | Action |
+|---------------|---------------------|--------|--------|
+| Running (waiting/active/holding) | inactive | false | Set `metronomeArmed = true` |
+| Running (waiting/active/holding) | inactive | true | Set `metronomeArmed = false` (disarm) |
+| Running (waiting/active/holding) | active | any | `context.metronome.toggle()` (stop) |
+| Not running (inactive/complete) | any | any | `context.metronome.toggle()` (normal) |
+
+### Reset triggers for `metronomeArmed`
+
+| Event | Action |
+|-------|--------|
+| `handlePracticeToggle` — session STOP | `setMetronomeArmed(false); metronomeArmedRef.current = false` |
+| `handlePracticeToggle` — session START | `setMetronomeArmed(false); metronomeArmedRef.current = false` |
+| `onFirstNoteAttack` callback fires | `setMetronomeArmed(false); metronomeArmedRef.current = false` |
+| `practiceState.mode === 'complete'` (natural end) | `setMetronomeArmed(false)` in mode-watch `useEffect` |
+
+---
+
+## 3. Updated Hook Interface — `usePracticeMidi.ts`
+
+### New parameter
+
+```ts
+interface UsePracticeMidiParams {
+  // ... existing params unchanged ...
+
+  /**
+   * Called exactly once when the first MIDI attack event arrives during an
+   * active practice session (practice mode === 'waiting'). Used to fire the
+   * deferred metronome start (FR-005, FR-006).
+   *
+   * The hook guarantees the callback fires at most once per session.
+   * The caller is responsible for resetting the armed guard on session restart.
+   */
+  onFirstNoteAttack?: () => void;
+}
+```
+
+### Internal guard (inside `usePracticeMidi`)
+
+The hook uses `practiceStateRef.current.mode === 'waiting'` as the guard — it is `'waiting'` only for the first note of each session. Subsequent notes see `'active'` or `'holding'`, so the callback naturally fires exactly once without needing an internal ref.
+
+---
+
+## 4. Updated Props — `PracticeToolbar`
+
+### New prop
+
+```ts
+interface PracticeToolbarProps {
+  // ... existing props unchanged ...
+
+  /**
+   * True when the metronome is armed (enabled in practice mode,
+   * waiting for the first note). Renders the button with the
+   * `practice-plugin__metro-btn--armed` CSS class.
+   * Mutually exclusive with metronomeActive.
+   */
+  metronomeArmed: boolean;
+}
+```
+
+### Button class derivation (updated)
+
+```ts
+const metronomeBtnClass = [
+  'practice-plugin__metro-btn',
+  ...(metronomeActive ? ['practice-plugin__metro-btn--active'] : []),
+  ...(metronomeActive && metronomeIsDownbeat ? ['practice-plugin__metro-btn--downbeat'] : []),
+  ...(metronomeArmed ? ['practice-plugin__metro-btn--armed'] : []),
+].join(' ');
+```
+
+### Slider props (both toolbars — practice and play-score)
+
+| Attribute | Before | After |
+|-----------|--------|-------|
+| `min` | `{0.5}` | `{effectiveMin}` (dynamic, from `computeEffectiveMinMultiplier(bpm)`) |
+| `max` | `{2.0}` | `{2.0}` (unchanged) |
+| `step` | `{0.05}` | `{0.01}` |
+| snap condition | `<= 0.05` | `<= 0.03` |
+| `list` | *(absent)* | `"tempo-ticks"` |
+| datalist | *(absent)* | `<datalist id="tempo-ticks"><option value="1.0" /></datalist>` |
+| `title` (when floor active) | *(absent)* | `"Minimum tempo limited to 10 BPM for this score"` (conditional) |
+
+---
+
+## 5. CSS — New Modifier Class
+
+### `practice-plugin__metro-btn--armed`
+
+```css
+.practice-plugin__metro-btn--armed {
+  color: var(--color-metro-armed, #c8a000);
+  animation: metro-armed-pulse 0.5s ease-in-out infinite alternate;
+}
+
+@keyframes metro-armed-pulse {
+  from { opacity: 0.4; }
+  to   { opacity: 1.0; }
+}
+```
+
+Defined in the practice view plugin's CSS file (same location as the existing `--active` and `--downbeat` styles).
+
+---
+
+## 6. State Transitions — Metronome in Practice Mode
+
+```
+[practice OFF]
+    metronomeArmed = false
+    metronomeActive = false (or true — independent of practice)
+    ↓ user starts practice
+[practice WAITING — no note yet]
+    toggle metronome ON → metronomeArmed = true, metronomeActive = false
+    toggle metronome OFF → metronomeArmed = false, metronomeActive = false
+    ↓ first MIDI attack received
+    onFirstNoteAttack() → setMetronomeArmed(false) + context.metronome.toggle()
+[practice ACTIVE — note matched]
+    metronomeArmed = false
+    metronomeActive = true  ← engine running
+    ↓ session stops
+[practice STOPPED]
+    metronomeArmed = false (reset in handlePracticeToggle)
+    metronomeActive = true (metronome keeps running — user controls it separately)
+```
+
+---
+
+## 7. No Schema Changes
+
+`SavedPractice.tempoMultiplier` type is `number` — no change. The new `MIN_TEMPO_MULTIPLIER = 0.1` means any value ≥ 0.1 is valid; all previously saved values (0.5–2.0) remain valid (no migration). `clampTempoMultiplier` on load handles any out-of-range edge case defensively.

--- a/specs/083-tempo-metronome-practice/plan.md
+++ b/specs/083-tempo-metronome-practice/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Tempo Slider Range Extension & Practice Metronome Deferred Start
+
+**Branch**: `083-tempo-metronome-practice` | **Date**: 2026-04-25 | **Spec**: [spec.md](spec.md)  
+**Worktree**: `/Users/alvaro.delcastillo/devel/graditone/.worktrees/feature/083-tempo-metronome-practice`  
+**Input**: Feature specification from `/specs/083-tempo-metronome-practice/spec.md`
+
+## Summary
+
+Two independent improvements to the practice and playback experience. First, widen the tempo slider range from 50%–200% to **10%–200%** with 1% integer steps, a snap-to-100% zone of ±3 pp, a visual 100% tick mark, and an absolute BPM floor of 10 BPM for unusually slow scores. Second, add a **deferred metronome start** in practice mode: when the metronome is toggled on at session start it enters an "armed" visual state and remains silent until the first MIDI note attack, which fires the metronome at beat 1. Outside practice mode the metronome starts immediately as today.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict), Rust 1.x WASM (no backend changes required)  
+**Primary Dependencies**: React 19.2, Tone.js 14.9, Vite 6.x, Vitest 3.x, @testing-library/react, Playwright  
+**Storage**: React component state (transient); `SavedPractice.tempoMultiplier` in IndexedDB (persisted — clamped on load)  
+**Testing**: Vitest + @testing-library/react (unit/component), Playwright (E2E)  
+**Target Platform**: Tablet PWA — Chrome 57+, Safari 11+, Edge 16+ (iPad, Surface, Android tablets)  
+**Project Type**: Monorepo — frontend-only changes (`frontend/`); no Rust/WASM modifications  
+**Performance Goals**: 60 fps UI feedback; metronome timing accuracy ±10 ms; offline-capable  
+**Constraints**: Offline-first; no new network calls; WASM boundary respected; no TypeScript spatial calculations (Principle VI — not applicable); no new IndexedDB schemas  
+**Scale/Scope**: ~10 frontend files changed, ~5 new/updated test files; no backend changes
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Principle | Gate Question | Status | Notes |
+|---|-----------|---------------|--------|-------|
+| I | DDD | Are tempo multiplier bounds and the BPM floor modeled as domain rules? | ✅ PASS | New `ABSOLUTE_BPM_FLOOR = 10` constant lives in `tempoCalculations.ts` alongside other domain constants |
+| II | Hexagonal | Does deferred metronome start bypass the plugin-API boundary? | ✅ PASS | `MetronomeEngine` in `src/services/metronome/` untouched; armed state and first-note trigger live in the plugin layer |
+| III | PWA | Are all changes client-side and offline-capable? | ✅ PASS | No network calls; Tone.js Web Audio is offline |
+| IV | Precision | Does 1% step avoid float accumulation in the display? | ✅ PASS | `Math.round(raw * 100) / 100` normalises slider output; `multiplierToPercentage` already uses `Math.round` |
+| V | Test-First | Are tests written before implementation? | ⚠️ REQUIRED | All tasks follow red-green-refactor; failing tests committed first |
+| VI | Layout Authority | Any new spatial calculations in renderer? | ✅ N/A | No geometry involved |
+| VII | Regression | Do existing metronome E2E tests T021–T023 and toolbar unit tests stay green? | ✅ PASS | Additive changes; snap zone tolerance update requires corresponding test adjustment |
+| VIII | Profile Awareness | Are new user-state values profile-scoped? | ✅ PASS | `tempoMultiplier` in `SavedPractice` is already scoped by practice ID; armed state is transient React state (not persisted) |
+
+**Gate result**: No violations. Proceed to Phase 0.
+
+**Post-design re-check**: Confirmed after Phase 1 — no new violations introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/083-tempo-metronome-practice/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   ├── PracticeToolbarProps.ts
+│   └── tempoCalculations-api.ts
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+├── src/
+│   ├── utils/
+│   │   ├── tempoCalculations.ts          # MIN 0.5→0.1, ABSOLUTE_BPM_FLOOR=10, computeEffectiveMinMultiplier()
+│   │   └── tempoCalculations.test.ts     # updated + new BPM-floor tests
+│   └── services/
+│       └── metronome/
+│           └── MetronomeEngine.ts        # No changes — API already supports deferred start
+│
+└── plugins/
+    ├── play-score/
+    │   ├── playbackToolbar.tsx           # min 0.5→0.1, step 0.05→0.01, snap ±0.03, 100% tick mark
+    │   └── playbackToolbar.test.tsx      # update snap zone test
+    └── practice-view-plugin/
+        ├── PracticeViewPlugin.tsx        # metronomeArmed state, modified toggle, first-note callback
+        ├── practiceToolbar.tsx           # metronomeArmed prop → armed CSS class; slider min/step/snap; 100% tick
+        ├── practiceToolbar.test.tsx      # armed state rendering test
+        └── usePracticeMidi.ts           # onFirstNoteAttack?: () => void parameter
+
+frontend/e2e/
+└── metronome.spec.ts                    # add T024 (deferred start), T025 (armed visual state)
+```
+
+**Structure Decision**: Frontend-only monorepo change. All new state is transient React state — no new IndexedDB schemas. No Rust/WASM modifications required.

--- a/specs/083-tempo-metronome-practice/quickstart.md
+++ b/specs/083-tempo-metronome-practice/quickstart.md
@@ -1,0 +1,148 @@
+# Quickstart: Developing & Testing Feature 083
+
+**Branch**: `083-tempo-metronome-practice`  
+**Worktree**: `/Users/alvaro.delcastillo/devel/graditone/.worktrees/feature/083-tempo-metronome-practice`
+
+---
+
+## Prerequisites
+
+```bash
+cd /Users/alvaro.delcastillo/devel/graditone/.worktrees/feature/083-tempo-metronome-practice/frontend
+npm install
+```
+
+---
+
+## Running Unit Tests
+
+```bash
+# All unit tests
+cd frontend && npm run test
+
+# Watch mode (during development)
+npm run test -- --watch
+
+# Specific test files relevant to this feature
+npm run test -- src/utils/tempoCalculations.test.ts
+npm run test -- src/services/metronome/MetronomeEngine.test.ts
+npm run test -- plugins/practice-view-plugin/practiceToolbar.test.tsx
+npm run test -- plugins/practice-view-plugin/practiceEngine.test.ts
+npm run test -- plugins/play-score/playbackToolbar.test.tsx
+```
+
+---
+
+## Running E2E Tests
+
+```bash
+# Start dev server (required for E2E)
+npm run dev &
+
+# Run full E2E suite
+npm run test:e2e
+
+# Run only metronome E2E tests (includes new T024, T025)
+npm run test:e2e -- --grep "metronome"
+
+# Run with UI for debugging
+npm run test:e2e -- --ui
+```
+
+---
+
+## Development Workflow (TDD)
+
+Follow the red-green-refactor cycle for each task (Principle V):
+
+### Step 1 — Tempo Calculations (tempoCalculations.ts)
+
+1. Update `tempoCalculations.test.ts`: add tests for `MIN_TEMPO_MULTIPLIER = 0.1`, `ABSOLUTE_BPM_FLOOR = 10`, `computeEffectiveMinMultiplier()`
+2. Run tests → they fail (red)
+3. Update `tempoCalculations.ts`: change `MIN_TEMPO_MULTIPLIER`, add `ABSOLUTE_BPM_FLOOR` and `computeEffectiveMinMultiplier()`
+4. Run tests → they pass (green)
+5. Run `clampTempoMultiplier` tests — they pass unchanged (regression check)
+
+### Step 2 — Slider UI (practiceToolbar.tsx + playbackToolbar.tsx)
+
+1. Update `practiceToolbar.test.tsx`: test that slider renders `min={effectiveMin}`, `step=0.01`, datalist tick at 100%
+2. Update `playbackToolbar.test.tsx`: same slider tests
+3. Run → fail (red)
+4. Update both toolbar files: change slider attributes, add datalist, update snap condition
+5. Run → pass (green)
+
+### Step 3 — Metronome Armed State (PracticeViewPlugin.tsx + practiceToolbar.tsx)
+
+1. Update `practiceToolbar.test.tsx`: add test for `metronomeArmed=true` → button has `--armed` class
+2. Run → fail (red)
+3. Add `metronomeArmed` prop to `PracticeToolbarProps`; add CSS class logic
+4. Run → pass (green)
+5. Update `PracticeViewPlugin.tsx`: add `metronomeArmed` state + modified `handleMetronomeToggle`
+6. Pass `metronomeArmed` prop to `<PracticeToolbar />`
+
+### Step 4 — Deferred Start (usePracticeMidi.ts)
+
+1. Update `PracticeViewPlugin.test.tsx` (or write an integration test): when metronome is armed and first attack fires, `context.metronome.toggle` is called and `metronomeArmed` becomes false
+2. Run → fail (red)
+3. Add `onFirstNoteAttack` param to `usePracticeMidi`; wire it in `PracticeViewPlugin`
+4. Run → pass (green)
+
+### Step 5 — E2E Tests
+
+1. Write T024, T025 test cases in `e2e/metronome.spec.ts` → fail (red)
+2. No further code changes needed if steps 1–4 are complete
+3. Run E2E → pass (green)
+
+---
+
+## Manual Verification Checklist
+
+### Tempo Slider
+
+- [ ] Open any score in the play-score view → drag slider to leftmost position → display reads **10%**
+- [ ] Drag slider to rightmost position → display reads **200%**
+- [ ] Drag near 97%–103% → slider snaps to exactly **100%**
+- [ ] A tick mark is visible at the 100% position on the slider track
+- [ ] Open a slow score (e.g., a piece with Largo ≈40 BPM) → slider minimum is higher than 10% → tooltip visible explaining the BPM floor
+
+### Metronome Deferred Start
+
+- [ ] Enter practice view, load a score
+- [ ] Enable the metronome → button shows **pulsing amber** (armed state) — NO audio clicks
+- [ ] Wait 5+ seconds → still no clicks (metronome silent while armed)
+- [ ] Play any note on MIDI keyboard → metronome **starts immediately** on that beat
+- [ ] Stop practice → reload → enable metronome again → armed state resets correctly
+- [ ] **Outside practice mode** (play-score view): enable metronome → clicks start **immediately** (no deferred start)
+- [ ] In practice mode, arm metronome, then toggle it off → metronome remains silent (disarmed)
+
+### Regression
+
+- [ ] Existing metronome E2E tests T021–T023 pass
+- [ ] Playback toolbar tempo slider still snaps to 100% correctly
+- [ ] Previously saved practice sessions load without errors (tempo clamped if needed)
+
+---
+
+## Key Files Reference
+
+| File | Change |
+|------|--------|
+| `frontend/src/utils/tempoCalculations.ts` | `MIN_TEMPO_MULTIPLIER` 0.5→0.1, add `ABSOLUTE_BPM_FLOOR`, `computeEffectiveMinMultiplier()` |
+| `frontend/src/utils/tempoCalculations.test.ts` | New/updated tests for above |
+| `frontend/plugins/play-score/playbackToolbar.tsx` | Slider: min dynamic, step 0.01, snap ±0.03, datalist |
+| `frontend/plugins/play-score/playbackToolbar.test.tsx` | Snap zone test update |
+| `frontend/plugins/practice-view-plugin/practiceToolbar.tsx` | Slider: same as play-score + `metronomeArmed` prop → `--armed` class |
+| `frontend/plugins/practice-view-plugin/practiceToolbar.test.tsx` | Armed state rendering test |
+| `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx` | `metronomeArmed` state, modified toggle, `onFirstNoteAttack` wiring |
+| `frontend/plugins/practice-view-plugin/usePracticeMidi.ts` | `onFirstNoteAttack?: () => void` parameter |
+| `frontend/e2e/metronome.spec.ts` | T024 deferred start, T025 armed visual |
+
+---
+
+## CSS Location
+
+Armed-state styles go in the same CSS file as the existing `practice-plugin__metro-btn--active` rule. Search for `metro-btn` in the frontend `src/` or `plugins/practice-view-plugin/` directories to find the file.
+
+```bash
+grep -r "metro-btn--active" frontend/src frontend/plugins --include="*.css" -l
+```

--- a/specs/083-tempo-metronome-practice/research.md
+++ b/specs/083-tempo-metronome-practice/research.md
@@ -1,0 +1,190 @@
+# Research: Tempo Slider Range Extension & Practice Metronome Deferred Start
+
+**Branch**: `083-tempo-metronome-practice` | **Date**: 2026-04-25  
+**Phase**: 0 — Resolves all NEEDS CLARIFICATION items from plan.md Technical Context
+
+---
+
+## R-001: Deferred Metronome Start — Integration Point
+
+**Question**: Where does the armed-fire callback live and how does the first note attack trigger it?
+
+**Decision**: Inject an `onFirstNoteAttack?: () => void` callback parameter into `usePracticeMidi`. Fire it exactly once when the first `attack` event arrives while `practiceStateRef.current.mode === 'waiting'` (the practice engine's initial state before the first note). Use a `hasArmedFiredRef = useRef(false)` inside `PracticeViewPlugin.tsx`, reset it whenever practice stops or restarts.
+
+**Why this point?** The `'waiting'` mode in the practice state machine already encodes "practice started, no note yet". Using this condition avoids duplicate-trigger races for chord simultaneous events (the first `attack` event that changes mode from `waiting` to `active` fires the callback; subsequent events within the same chord are already in `'active'` mode so the guard `mode === 'waiting'` prevents re-entry).
+
+**Rationale**: Keeping the callback at the `usePracticeMidi` boundary respects the existing pattern: note-attack processing lives in that hook. Adding a parameter keeps the engine stateless; the orchestration lives in `PracticeViewPlugin.tsx` (the feature plugin component, not the service layer), consistent with Principle II (Hexagonal).
+
+**Alternatives considered**:
+- Subscribing directly to `context.midi` in a second `useEffect` in `PracticeViewPlugin.tsx` — rejected because it duplicates the MIDI subscription and risks processing events out of order with the existing hook.
+- Adding state to `MetronomeEngine` for an "armed" mode — rejected because it couples domain service to UI concept (practice mode), violating Principle II.
+
+---
+
+## R-002: Armed State Representation
+
+**Question**: Should `metronomeArmed` be React state or a ref, and how does the toggle handler interact with it?
+
+**Decision**: Use `useState<boolean>(false)` for `metronomeArmed` in `PracticeViewPlugin.tsx`. The armed state is a rendered prop (it flows to `PracticeToolbar` to show the armed CSS class), so it must be React state (not just a ref) to trigger re-renders.
+
+**Toggle logic** (modified `handleMetronomeToggle`):
+
+```
+if practice is running (mode ∈ {waiting, active, holding}) AND metronome NOT active AND NOT armed:
+  → set metronomeArmed = true         (enter armed state; do NOT call context.metronome.toggle)
+else if armed:
+  → set metronomeArmed = false        (disarm; metronome stays silent)
+else:
+  → context.metronome.toggle()        (normal behaviour: outside practice, or already active)
+```
+
+**Reset conditions for `metronomeArmed`**:
+- Practice session STOP: reset to `false` in `handlePracticeToggle`
+- Practice session START (fresh): reset to `false` in `handlePracticeToggle`
+- Metronome disarmed by second toggle press: reset to `false`
+- `onFirstNoteAttack` fires: reset to `false` (metronome is now `active`; armed no longer relevant)
+- Practice session completes naturally: `mode === 'complete'` — reset in the `useEffect` that watches `practiceState.mode`
+
+**Rationale**: Treating armed as state (not ref) ensures the toolbar button's CSS class updates immediately on the next render frame, satisfying FR-012 and SC-007.
+
+---
+
+## R-003: Metronome Start Call on First Note
+
+**Question**: What exact call starts the metronome when the first note fires?
+
+**Decision**: Call `context.metronome.toggle()` (the same method the toggle button calls) rather than a lower-level `start()`. The metronome context already handles BPM synchronisation, Transport state, and phase-locking via `scheduleOffsetSeconds`. Calling `toggle()` when the engine is currently inactive will start it — the same path as the normal button press.
+
+**Timing**: The callback fires inside the MIDI attack event handler, which runs synchronously in a React effect. `toggle()` returns a Promise; errors are caught with `console.error` matching the existing pattern.
+
+**Rationale**: Re-using `toggle()` avoids duplicating BPM/Transport logic. The `MetronomeEngine.start()` signature (`bpm, numerator, denominator, startBeatIndex, scheduleOffsetSeconds, subdivision`) is already abstracted behind `PluginMetronomeContext` — plugins never call `start()` directly (Principle II).
+
+**Alternatives considered**:
+- Calling a new `context.metronome.startDeferred()` method — rejected as unnecessary complexity; `toggle()` already does the right thing.
+- Scheduling the click at the exact MIDI event timestamp — rejected; Tone.js Web Audio timing is handled by `MetronomeEngine` internally via `scheduleRepeat`; the first click fires ≤1 beat-interval after the call, which satisfies SC-004 ("within one beat's duration").
+
+---
+
+## R-004: Step Precision and Float Drift on `<input type="range" step="0.01">`
+
+**Question**: Does changing `step` from `0.05` to `0.01` introduce float drift in the displayed percentage?
+
+**Decision**: Yes — browsers produce values like `0.10000000000000001` at `step=0.01`. Normalise with `Math.round(raw * 100) / 100` before passing to `onTempoChange`. Display uses `multiplierToPercentage()` which already calls `Math.round`, so the displayed integer is always exact.
+
+**Implementation**: Both `playbackToolbar.tsx` and `practiceToolbar.tsx` wrap the raw slider value:
+
+```ts
+const raw = parseFloat(e.target.value);
+const snapped = Math.abs(raw - 1.0) <= 0.03 ? 1.0 : Math.round(raw * 100) / 100;
+onTempoChange(snapped);
+```
+
+**Rationale**: Integer percentage display (FR-010) requires exact integers. The `Math.round` normalisation is the minimal fix with zero performance cost.
+
+**Alternatives considered**:
+- Using `step=1` on a `min=10 max=200` integer slider — simpler, but requires converting the stored `tempoMultiplier` (0.0–2.0 float) to/from integers at every boundary. Adds conversion surface area; the current float representation is the canonical form used everywhere (IndexedDB, Tone.js BPM, player).
+
+---
+
+## R-005: Snap Zone with New Step Size
+
+**Question**: What is the correct snap zone for 1% integer steps?
+
+**Decision**: Keep the snap as `±3` percentage points: `Math.abs(raw - 1.0) <= 0.03`. This gives a 7-step snap window (97%, 98%, 99%, **100%**, 101%, 102%, 103%), matching FR-011's "approximately ±3 percentage points" requirement.
+
+**Old snap zone**: `Math.abs(raw - 1.0) <= 0.05` — was ±5pp with 5pp steps (±1 step). New zone is ±3 steps of 1pp — comparable gestural affordance.
+
+**Rationale**: SC-006 requires that a user can land at 100% from a nearby position in a single gesture without pixel-perfect accuracy. A 7pp window (3 steps on each side) is the narrowest window that remains comfortable on a touch slider.
+
+**Visual indicator**: A `<datalist>` with a single `<option value="1.0">` — this renders a native browser tick mark at 100% on the slider track in Chrome and Firefox. For Safari (no `datalist` tick support), a thin CSS `::after` pseudo-element on the slider wrapper provides a visual marker.
+
+---
+
+## R-006: Absolute BPM Floor — Effective Min Multiplier Calculation
+
+**Question**: How is the dynamic minimum enforced when `originalBpm * 0.1 < 10 BPM`?
+
+**Decision**: Add `computeEffectiveMinMultiplier(originalBpm: number): number` to `tempoCalculations.ts`:
+
+```ts
+export const ABSOLUTE_BPM_FLOOR = 10; // BPM — never go below this
+
+export function computeEffectiveMinMultiplier(originalBpm: number): number {
+  if (originalBpm <= 0) return MIN_TEMPO_MULTIPLIER;
+  return Math.max(MIN_TEMPO_MULTIPLIER, ABSOLUTE_BPM_FLOOR / originalBpm);
+}
+```
+
+The slider's `min` attribute receives the result. Example: `originalBpm = 40` → `max(0.1, 10/40) = 0.25` (25%).
+
+**UI communication**: When `computeEffectiveMinMultiplier(bpm) > MIN_TEMPO_MULTIPLIER`, the slider's minimum is higher than 10%. A `title` attribute on the slider element explains this: `"Minimum tempo limited to 10 BPM for this score"`. The `%` display always reflects the actual clamped position.
+
+**`playerState.bpm`**: Confirmed to be the score's **original** BPM from the WASM layout engine (not multiplied by `tempoMultiplier`). The playback engine applies the multiplier separately. This is the value to pass to `computeEffectiveMinMultiplier`.
+
+**Rationale**: FR-014 and SC-008 require visual communication of the BPM floor constraint. A `title` attribute is the minimal, accessible solution; no modal or toast required.
+
+**Alternatives considered**:
+- Hardcoding `min=0.1` always and clamping only on save — rejected because it would show a position (10%) the user cannot actually hear correctly (sub-10 BPM playback would stutter or be unsupported by Tone.js Transport).
+- Adding a separate "min BPM" slider label — rejected as over-engineering; a tooltip suffices for this edge case (≥100 BPM scores are unaffected).
+
+---
+
+## R-007: Saved Tempo Clamping on Load
+
+**Question**: Do saved `tempoMultiplier` values below 0.1 need migration logic?
+
+**Decision**: No migration needed. `clampTempoMultiplier()` already uses `MIN_TEMPO_MULTIPLIER` and `MAX_TEMPO_MULTIPLIER`. After changing `MIN_TEMPO_MULTIPLIER` from `0.5` to `0.1`, any previously saved value in the range 0.1–0.5 will load correctly without clamping (they are now valid). Values below 0.1 do not exist in the wild (old minimum was 0.5). The upper bound (2.0) is unchanged.
+
+**In practice**: All existing saved practices have `tempoMultiplier ∈ [0.5, 2.0]` — the new range is a strict superset, so no previously saved value falls outside the new valid range on the lower end. Silent clamping via `clampTempoMultiplier()` on load (FR-009) remains correct as a defensive measure.
+
+**Rationale**: FR-009 is satisfied without additional migration code. The widening of the range is backward-compatible.
+
+---
+
+## R-008: Armed Visual State — CSS Approach
+
+**Question**: How should the "armed/waiting" metronome state look and be implemented?
+
+**Decision**: Add CSS modifier class `practice-plugin__metro-btn--armed` to the metronome button when `metronomeArmed === true`. The CSS rule applies a pulsing opacity animation (0.5s ease-in-out infinite alternate, opacity 0.4–1.0) to signal "waiting for input". Icon remains the same metronome symbol; colour shifts to a muted/amber tone via `color: var(--color-metro-armed, #c8a000)`.
+
+**Implementation**:
+
+```ts
+// In practiceToolbar.tsx
+const metronomeBtnClass = [
+  'practice-plugin__metro-btn',
+  ...(metronomeActive ? ['practice-plugin__metro-btn--active'] : []),
+  ...(metronomeActive && metronomeIsDownbeat ? ['practice-plugin__metro-btn--downbeat'] : []),
+  ...(metronomeArmed ? ['practice-plugin__metro-btn--armed'] : []),
+].join(' ');
+```
+
+**Rationale**: CSS class approach matches the existing pattern (`--active`, `--downbeat`). No new icon assets needed. The pulsing animation is distinct from both the off state (static) and the active ticking state (beat-sync animation key change). Satisfies FR-012 and SC-007.
+
+**Note**: `metronomeArmed` and `metronomeActive` are mutually exclusive (`armed` resets to `false` the moment the engine starts). Guard in tests: never render both classes simultaneously.
+
+---
+
+## R-009: No Changes to `MetronomeEngine.ts`
+
+**Question**: Does `MetronomeEngine` need modification for deferred start?
+
+**Decision**: No. The engine's `start()` method already accepts `scheduleOffsetSeconds` for phase-locking. When called from the first-note callback with `scheduleOffsetSeconds = 0` (default), it fires the first click within one `tickIntervalSeconds`. The 10 BPM minimum in the engine's internal BPM clamp (`[20, 300]`) is unrelated to the tempo slider multiplier — it applies only to the audio scheduling frequency, not the playback speed. No conflicts.
+
+**Rationale**: Keeping the service layer unchanged confirms Principle II is respected. The feature is implemented entirely in the plugin and shared utility layers.
+
+---
+
+## Summary Table
+
+| ID | Question | Decision |
+|----|----------|----------|
+| R-001 | Integration point for deferred trigger | `onFirstNoteAttack` param in `usePracticeMidi`; fires when `mode === 'waiting'` |
+| R-002 | Armed state representation | `useState<boolean>` in `PracticeViewPlugin`; resets on session start/stop |
+| R-003 | Call to start metronome on first note | `context.metronome.toggle()` — same as button press |
+| R-004 | Float drift at step=0.01 | `Math.round(raw * 100) / 100` normalisation in onChange handlers |
+| R-005 | Snap zone size | `Math.abs(raw - 1.0) <= 0.03` (±3 pp); `<datalist>` tick mark at 100% |
+| R-006 | Absolute BPM floor | `computeEffectiveMinMultiplier(bpm)` = `max(0.1, 10/bpm)`; `title` tooltip |
+| R-007 | Saved tempo clamping | No migration needed; existing saved values all ≥ 0.5 (new min is 0.1) |
+| R-008 | Armed visual state | `practice-plugin__metro-btn--armed` CSS class + pulsing opacity animation |
+| R-009 | MetronomeEngine changes | None required |

--- a/specs/083-tempo-metronome-practice/spec.md
+++ b/specs/083-tempo-metronome-practice/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Tempo Slider Range Extension & Practice Metronome Deferred Start
+
+**Feature Branch**: `083-tempo-metronome-practice`  
+**Created**: 2026-04-25  
+**Status**: Draft  
+**Input**: User description: "Modify the tempo slider to cover 10% - 200%. And in practise mode, if the metronome is active, start it when the first note is played in the practice."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Ultra-Slow Tempo for Difficult Passages (Priority: P1)
+
+A student encounters a technically demanding passage they cannot play at normal speed. They drag the tempo slider all the way down to 10% to hear and practice the passage at an extremely slow pace, allowing them to absorb each individual note before gradually increasing speed.
+
+**Why this priority**: Extending the slow end of the tempo range (down to 10%) directly addresses the core use case of deliberate slow practice, which is the most common reason musicians adjust tempo during learning.
+
+**Independent Test**: Can be fully tested by opening any score, dragging the tempo slider to its minimum position, and verifying playback at approximately 10% of the original tempo — independently valuable without the metronome feature.
+
+**Acceptance Scenarios**:
+
+1. **Given** a score is loaded and the tempo slider is visible, **When** the user drags the slider to the leftmost position, **Then** the displayed tempo reads 10% and playback speed reflects that value.
+2. **Given** playback is active at 10% tempo, **When** the user observes notes being played, **Then** all notes play at the correct duration proportional to 10% speed with no audio artifacts.
+3. **Given** the slider is at any position between 10% and 100%, **When** the user moves it, **Then** the tempo adjusts smoothly with no gaps or jumps in the available range.
+
+---
+
+### User Story 2 - High-Speed Challenge Practice (Priority: P2)
+
+An advanced student wants to push themselves by practicing a piece faster than the original score tempo. They drag the slider up to 200% to challenge their sight-reading speed or test muscle memory under pressure.
+
+**Why this priority**: Extending the upper limit to 200% broadens the tool's utility for advanced users. Lower priority than the slow end because extreme fast playback is less universally needed.
+
+**Independent Test**: Can be fully tested by dragging the tempo slider to its maximum position and verifying playback at 200% tempo — independently valuable and demonstrable.
+
+**Acceptance Scenarios**:
+
+1. **Given** a score is loaded, **When** the user drags the slider to the rightmost position, **Then** the displayed tempo reads 200% and playback speed doubles relative to the original.
+2. **Given** the slider is at 200%, **When** playback runs, **Then** all notes play correctly at double speed without skipping, clipping, or corrupting the audio.
+3. **Given** the user is at any position between 100% and 200%, **When** they adjust the slider, **Then** the tempo changes proportionally and the display updates immediately.
+
+---
+
+### User Story 3 - Metronome Starts on First Note in Practice Mode (Priority: P1)
+
+A student enters practice mode with the metronome enabled. Instead of the metronome clicking from the moment they enter practice mode, it remains silent until they play their first note. Once they play, the metronome kicks in from that beat, helping them stay in time from the point of actual playing rather than from a premature countdown.
+
+**Why this priority**: This is a fundamental UX improvement for practice mode — a ticking metronome before the student is ready is disorienting. Synchronising the start to the first played note mirrors how human teachers count musicians in, making the tool more natural and effective.
+
+**Independent Test**: Can be fully tested by entering practice mode, enabling the metronome, waiting several seconds, then playing a note — verifying the metronome only starts upon note detection and not before.
+
+**Acceptance Scenarios**:
+
+1. **Given** practice mode is active and the metronome is enabled, **When** the session starts, **Then** the metronome does NOT produce any sound or visual beat until the first note is played.
+2. **Given** practice mode is active and the metronome is enabled, **When** the user plays the first note, **Then** the metronome begins ticking immediately treating that moment as beat 1 (starting a fresh measure cycle from the first note).
+3. **Given** practice mode is active and the metronome is enabled, **When** the user plays a wrong note or an accidental key press as their first input, **Then** the metronome still starts — any note event qualifies as the trigger.
+4. **Given** practice mode is active and the metronome is enabled, **When** the user plays a chord as their first input, **Then** the metronome starts on the first note event of that chord (whichever arrives first); subsequent simultaneous events are ignored as additional triggers.
+5. **Given** practice mode is active and the metronome is disabled, **When** the user plays the first note, **Then** the metronome remains silent (no change from current behaviour).
+6. **Given** practice mode is active and the metronome is enabled, **When** the session starts and no note has been played yet, **Then** the metronome button/control shows a distinct visual "armed" state (different from both the off state and the active ticking state) to signal it is waiting for input.
+7. **Given** practice mode is active and the metronome is enabled, **When** the user plays a note after a long pause at the start, **Then** the metronome starts cleanly on that note's beat without any retroactive clicks.
+8. **Given** practice mode is NOT active (e.g., normal playback mode), **When** the metronome is enabled, **Then** the metronome starts immediately as it does today (no change to non-practice behaviour).
+
+---
+
+### Edge Cases
+
+- What happens when the user sets the slider to exactly 10% and then tries to drag it lower? The slider must clamp at 10% with no ability to go below.
+- What happens when the user sets the slider to exactly 200% and tries to drag it higher? The slider must clamp at 200% with no ability to exceed.
+- What happens if the user exits practice mode before playing any note while the metronome is enabled? The metronome must not start when re-entering a non-practice context — the deferred start resets.
+- What happens if the user replays (restarts) a practice session? The metronome deferred-start resets: it should again wait for the first note.
+- What happens if tempo is restored from a saved session where the value was outside the new 10–200% range? The value must be clamped to the nearest boundary (10% or 200%) and the user must be shown the clamped value.
+- What happens when the score's original tempo is very slow (e.g., Largo at 40 BPM) and 10% would yield 4 BPM? The slider minimum is clamped to the absolute BPM floor (10 BPM) and the UI must communicate this limit clearly — the displayed percentage reflects the clamped value, not 10%.
+- What happens when the user drags the slider near 100%? The slider must snap to exactly 100% within a comfortable tolerance zone (e.g., ±3 percentage points) to make returning to the original tempo easy.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The tempo slider MUST have a minimum value of 10% and a maximum value of 200% of the original score tempo.
+- **FR-002**: The tempo display label MUST always show the currently selected integer percentage value, updating in real-time as the slider moves.
+- **FR-003**: The slider MUST prevent values below 10% and above 200% (hard clamp at both ends).
+- **FR-004**: Playback speed MUST accurately reflect the selected tempo percentage across the full 10%–200% range with no audible distortion or timing errors.
+- **FR-005**: In practice mode, when the metronome is enabled, the metronome MUST remain silent from the start of the practice session until the first note input event is detected.
+- **FR-006**: In practice mode, when the first note input event is detected and the metronome is enabled, the metronome MUST start immediately treating that moment as beat 1 (a fresh measure cycle), maintaining steady beat at the configured tempo thereafter.
+- **FR-007**: The deferred metronome start behaviour MUST be exclusive to practice mode. Outside practice mode the metronome MUST continue to start immediately when enabled, as today.
+- **FR-008**: When a practice session is restarted or reset, the deferred metronome start MUST reset so the metronome again waits for the next first note.
+- **FR-009**: Previously saved tempo values that fall outside the new 10%–200% range MUST be silently clamped to the nearest boundary on load.
+- **FR-010**: The tempo slider MUST use 1% integer steps — values snap to whole-number percentages; the display always shows an exact integer (e.g., "73%", never "73.6%").
+- **FR-011**: The slider MUST include a snap zone at 100% — when the user drags within approximately ±3 percentage points of 100%, the slider MUST snap to exactly 100%, allowing easy return to the original score tempo. A visual indicator (e.g., tick mark or label) MUST mark the 100% position on the slider track.
+- **FR-012**: While the metronome is in the "armed/waiting" state (enabled in practice mode, before the first note), the metronome button or control MUST show a distinct visual state that is clearly different from both the off state and the active ticking state (e.g., a different icon, a pulsing effect, or a muted/desaturated colour).
+- **FR-013**: Any note input event qualifies as the first-note trigger for the metronome deferred start — wrong notes, correct notes, and any note in a chord all qualify. No note-matching or correctness check is required.
+- **FR-014**: If 10% of the score's original tempo would result in a speed below 10 BPM, the slider's effective minimum MUST be clamped to 10 BPM. The UI MUST communicate this limit visually (e.g., a tooltip or label) so the user understands why the slider cannot go lower than a displayed percentage higher than 10%.
+
+### Assumptions
+
+- The term "first note played" means the first note input event captured by the practice session (MIDI input, keyboard, or on-screen tap) — any input qualifies regardless of correctness. It is not the first note in the score.
+- When the metronome starts on the first note, that note's arrival is treated as beat 1 of a fresh measure cycle. The metronome does not attempt to align to the score position of the note.
+- A chord (multiple simultaneous note events) still counts as a single trigger — whichever note event arrives first fires the metronome; subsequent simultaneous events within the same chord attack are ignored as duplicate triggers.
+- The metronome visual control defers together with the audio. It displays a distinct armed/waiting state before the first note is played.
+- The existing tempo slider persists its value across sessions. This feature does not change persistence behaviour — only the allowable range and step size.
+- The absolute BPM floor is 10 BPM. For scores whose original tempo is 100 BPM or higher, 10% always exceeds this floor and no clamping occurs. The floor only applies to unusually slow scores.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can set any integer tempo between 10% and 200% inclusive using the slider, with the displayed value always matching the selected speed.
+- **SC-002**: Playback at 10% and 200% is perceptually correct — notes are heard at the proportional duration with no skipping or audio glitches.
+- **SC-003**: In practice mode with metronome enabled, zero metronome beats are produced before the first note is played across 100% of test runs.
+- **SC-004**: The metronome starts within one beat's duration of the first note being played (i.e., no perceptible lag between first note and metronome onset).
+- **SC-005**: Outside practice mode, metronome behaviour is unchanged — it starts immediately when enabled, verified by regression tests covering existing behaviour.
+- **SC-006**: A user can land on exactly 100% from a nearby position in a single drag gesture without requiring pixel-perfect accuracy — verified by usability test or automated drag test within ±3% of 100%.
+- **SC-007**: When the metronome is armed in practice mode, the metronome control is visually distinguishable from both its off state and its active state, confirmed by visual inspection or snapshot test.
+- **SC-008**: For scores where 10% of original tempo falls below 10 BPM, the slider's lower limit is clamped to 10 BPM and a user-visible indicator communicates the constraint.
+

--- a/specs/083-tempo-metronome-practice/tasks.md
+++ b/specs/083-tempo-metronome-practice/tasks.md
@@ -1,0 +1,276 @@
+# Tasks: Tempo Slider Range Extension & Practice Metronome Deferred Start
+
+**Branch**: `083-tempo-metronome-practice` | **Date**: 2026-04-25  
+**Input**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/](contracts/), [quickstart.md](quickstart.md)
+
+## Format: `[ID] [P?] [Story?] Description — file path`
+
+- **[P]**: Parallelizable with other [P]-marked tasks in the same phase
+- **[US1/US2/US3]**: Which user story this task delivers
+- All paths relative to worktree root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the development baseline is green before any changes.
+
+- [ ] T001 Run existing unit and E2E test suites to confirm green baseline — `cd frontend && npm run test && npm run test:e2e`
+
+**Checkpoint**: All pre-existing tests pass. Safe to begin implementation.
+
+---
+
+## Phase 2: Foundational — Shared Slider Precision Improvements
+
+**Purpose**: The step size (0.05→0.01), snap zone (±0.05→±0.03), float normalisation, and 100% datalist tick mark are **shared prerequisites** for both User Story 1 (10% min) and User Story 2 (200% max validation). These changes MUST be complete before story-specific slider work begins.
+
+**⚠️ CRITICAL**: T002–T005 must be complete before Phase 3 or Phase 5 slider tasks.
+
+- [ ] T002 [P] Write failing tests for step=0.01, snap zone ±0.03, float normalisation, and datalist in `frontend/plugins/play-score/playbackToolbar.test.tsx` — confirm RED before proceeding to T004
+- [ ] T003 [P] Write failing tests for step=0.01, snap zone ±0.03, float normalisation, and datalist in `frontend/plugins/practice-view-plugin/practiceToolbar.test.tsx` — confirm RED before proceeding to T005
+- [ ] T004 Update `frontend/plugins/play-score/playbackToolbar.tsx`: change `step` from `0.05` to `0.01`; update snap condition from `<= 0.05` to `<= 0.03`; wrap `parseFloat(e.target.value)` with `Math.round(raw * 100) / 100` normalisation; add `<datalist id="play-score-tempo-ticks"><option value="1.0" /></datalist>` and `list="play-score-tempo-ticks"` on the range input — verify T002 tests pass GREEN
+- [ ] T005 [P] Update `frontend/plugins/practice-view-plugin/practiceToolbar.tsx`: same changes as T004 (step, snap, normalisation, datalist with id `"practice-tempo-ticks"`) — verify T003 tests pass GREEN
+
+**Checkpoint**: Both toolbars use 1% steps and ±3 pp snap zone. Existing snap tests updated and passing.
+
+---
+
+## Phase 3: User Story 1 — Ultra-Slow Tempo for Difficult Passages (Priority: P1) 🎯 MVP
+
+**Goal**: Students can drag the tempo slider all the way down to 10% (or to the BPM-floor-enforced minimum for very slow scores), giving them the extreme slow-practice range they need.
+
+**Independent Test**: Open any score in play-score view → drag the tempo slider to its leftmost stop → verify the display reads "10%" and playback is audibly slow. Fully testable without the metronome feature.
+
+### Tests for User Story 1
+
+> **Write these tests FIRST and confirm they FAIL before writing any implementation.**
+
+- [ ] T006 [P] [US1] Write failing unit tests in `frontend/src/utils/tempoCalculations.test.ts`:
+  - `MIN_TEMPO_MULTIPLIER` equals `0.1`
+  - `ABSOLUTE_BPM_FLOOR` equals `10`
+  - `computeEffectiveMinMultiplier(120)` returns `0.1` (floor not triggered)
+  - `computeEffectiveMinMultiplier(40)` returns `0.25` (10/40, floor triggered)
+  - `computeEffectiveMinMultiplier(0)` returns `0.1` (defensive fallback)
+  - `clampTempoMultiplier(0.05)` returns `0.1` (clamped to new min)
+  - `clampTempoMultiplier(0.3)` returns `0.3` (within new range)
+  Confirm RED before proceeding to T007
+- [ ] T007 [P] [US1] Write failing component tests in `frontend/plugins/play-score/playbackToolbar.test.tsx`:
+  - Slider `min` attribute equals `computeEffectiveMinMultiplier(bpm)` when `bpm >= 100`
+  - Slider `min` attribute is clamped above `0.1` when `bpm` yields floor (e.g., bpm=40 → min=0.25)
+  - `title` tooltip is present on slider when effective min > `MIN_TEMPO_MULTIPLIER`
+  Confirm RED
+- [ ] T008 [P] [US1] Write failing component tests in `frontend/plugins/practice-view-plugin/practiceToolbar.test.tsx` — same min/tooltip assertions as T007. Confirm RED
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Update `frontend/src/utils/tempoCalculations.ts`:
+  - Change `MIN_TEMPO_MULTIPLIER` from `0.5` to `0.1`
+  - Add `export const ABSOLUTE_BPM_FLOOR = 10`
+  - Add `export function computeEffectiveMinMultiplier(originalBpm: number): number` per data-model.md spec — verify T006 tests pass GREEN
+- [ ] T010 [US1] Update `frontend/plugins/play-score/playbackToolbar.tsx`:
+  - Import `computeEffectiveMinMultiplier` from `../../src/utils/tempoCalculations`
+  - Compute `const effectiveMin = computeEffectiveMinMultiplier(bpm)` using the `bpm` prop
+  - Set slider `min={effectiveMin}` (was hardcoded `0.5`)
+  - Add `title` attribute on the slider or its wrapper: `"Minimum tempo limited to 10 BPM for this score"` — shown only when `effectiveMin > MIN_TEMPO_MULTIPLIER`
+  Verify T007 tests pass GREEN
+- [ ] T011 [P] [US1] Update `frontend/plugins/practice-view-plugin/practiceToolbar.tsx`:
+  - Same changes as T010: import `computeEffectiveMinMultiplier`, compute `effectiveMin` from the `bpm` prop, set dynamic `min`, conditional `title` tooltip
+  Verify T008 tests pass GREEN
+- [ ] T012 [US1] Create `frontend/e2e/tempo.spec.ts` with E2E test T001: load a score in play-score view → drag tempo slider to minimum → assert displayed percentage is `"10%"` (or BPM-floor label when applicable); assert playback starts without errors — confirm GREEN
+
+**Checkpoint**: Slider minimum is 10% in both toolbars. BPM floor applies for slow scores. All US1 tests pass. US2 can be validated independently.
+
+---
+
+## Phase 4: User Story 3 — Metronome Starts on First Note in Practice Mode (Priority: P1)
+
+**Goal**: When a student enters practice mode with the metronome enabled, it stays silent (but shows an "armed" pulsing state) until they play their first note, at which point it fires as beat 1. Behaviour outside practice mode is unchanged.
+
+**Independent Test**: Enter practice view → load any score → enable the metronome → wait 5 seconds without playing → verify no audio clicks and the metronome button is pulsing amber → play any MIDI note → verify the metronome starts immediately. Fully testable without any tempo slider changes.
+
+### Tests for User Story 3
+
+> **Write these tests FIRST and confirm they FAIL before writing any implementation.**
+
+- [ ] T013 [P] [US3] Write failing component tests in `frontend/plugins/practice-view-plugin/practiceToolbar.test.tsx`:
+  - When `metronomeArmed=true` and `metronomeActive=false`: button has class `practice-plugin__metro-btn--armed` and does NOT have `practice-plugin__metro-btn--active`
+  - When `metronomeArmed=false` and `metronomeActive=false`: button has neither `--armed` nor `--active`
+  - When `metronomeArmed=false` and `metronomeActive=true`: button has `--active` and NOT `--armed`
+  - Invariant: `metronomeArmed=true` and `metronomeActive=true` simultaneously → armed class absent (active wins; the armed state resets the instant the engine starts)
+  Confirm RED
+- [ ] T014 [P] [US3] Write failing integration test in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx` (create file if absent):
+  - Toggle metronome while practice is in `'waiting'` mode → `context.metronome.toggle` is NOT called; `metronomeArmed` becomes true
+  - Simulate first MIDI attack (call `onFirstNoteAttack`) → `context.metronome.toggle` IS called once; `metronomeArmed` becomes false
+  - Toggle metronome again while armed → `metronomeArmed` becomes false (disarm without calling toggle)
+  - Toggle metronome outside practice mode → `context.metronome.toggle` IS called immediately (normal behaviour)
+  Confirm RED
+
+### Implementation for User Story 3
+
+- [ ] T015 [US3] Update `frontend/plugins/practice-view-plugin/practiceToolbar.tsx`:
+  - Add `metronomeArmed: boolean` to `PracticeToolbarProps`
+  - Extend `metronomeBtnClass` derivation: append `'practice-plugin__metro-btn--armed'` when `metronomeArmed === true`
+  Verify T013 tests pass GREEN
+- [ ] T016 [US3] Add CSS for armed state in the practice plugin stylesheet (locate with `grep -r "metro-btn--active" frontend/ --include="*.css" -l`):
+  ```css
+  .practice-plugin__metro-btn--armed {
+    color: var(--color-metro-armed, #c8a000);
+    animation: metro-armed-pulse 0.5s ease-in-out infinite alternate;
+  }
+  @keyframes metro-armed-pulse {
+    from { opacity: 0.4; }
+    to   { opacity: 1.0; }
+  }
+  ```
+- [ ] T017 [US3] Update `frontend/plugins/practice-view-plugin/usePracticeMidi.ts`:
+  - Add `onFirstNoteAttack?: () => void` to the params interface
+  - Inside the MIDI attack handler: when `practiceStateRef.current.mode === 'waiting'`, call `onFirstNoteAttack?.()` exactly once (the `'waiting'` → `'active'` transition naturally prevents re-entry; no additional guard ref needed since `mode` changes immediately)
+- [ ] T018 [US3] Update `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx`:
+  - Add `const [metronomeArmed, setMetronomeArmed] = useState<boolean>(false)` alongside existing `metronomeState`
+  - Add `const metronomeArmedRef = useRef<boolean>(false)` for stale-closure safety in callbacks
+  - Modify `handleMetronomeToggle`: implement the armed/disarm/normal logic per data-model.md §2 (toggle table)
+  - Define `onFirstNoteAttack` callback: `setMetronomeArmed(false); metronomeArmedRef.current = false; context.metronome.toggle().catch(...)` 
+  - Pass `onFirstNoteAttack` to `usePracticeMidi`
+  - Reset `metronomeArmed` and `metronomeArmedRef` in `handlePracticeToggle` (session START and STOP)
+  - Add `useEffect` watching `practiceState.mode`: reset armed when `mode === 'complete'`
+  - Pass `metronomeArmed={metronomeArmed}` to `<PracticeToolbar />`
+  Verify T014 integration tests pass GREEN
+- [ ] T019 [US3] Add E2E test T024 in `frontend/e2e/metronome.spec.ts`:
+  - Enter practice view with a loaded score
+  - Enable metronome → assert NO audio (mock or observe no beat events) and button has `--armed` class
+  - Simulate first MIDI note → assert metronome starts (engine `active`, clicks heard or beat state changes)
+  - Stop practice → start again → assert metronome re-arms (deferred start resets)
+- [ ] T020 [P] [US3] Add E2E test T025 in `frontend/e2e/metronome.spec.ts`:
+  - Enable metronome in practice mode (armed) → take screenshot / check CSS → assert button is visually different from both the OFF state (no practice) and the ACTIVE state (mid-session)
+
+**Checkpoint**: Metronome deferred start is complete. Armed visual state renders. Deferred start fires exactly once on first note. Outside practice mode, metronome still starts immediately (regression safe).
+
+---
+
+## Phase 5: User Story 2 — High-Speed Challenge Practice (Priority: P2)
+
+**Goal**: Students can drag the slider all the way to 200% for a double-speed challenge. With the new 1% steps (from Phase 2), the upper range is smoother and the display always shows an exact integer.
+
+**Independent Test**: Open any score → drag tempo slider to its rightmost stop → verify display reads "200%". Independently testable from US1 and US3 — the upper bound (2.0) was already present; this phase validates the full range with the new step size and confirms no regressions.
+
+### Tests for User Story 2
+
+- [ ] T021 [P] [US2] Add/update tests in `frontend/plugins/play-score/playbackToolbar.test.tsx`:
+  - Slider `max` attribute is `2.0`
+  - When `tempoMultiplier=2.0`, displayed label shows `"200%"`
+  - Drag from 1.95 → snap does NOT snap (snap zone only near 1.0); display shows "195%"
+  Confirm GREEN (these validate existing code + Phase 2 changes; they should pass after T004)
+- [ ] T022 [P] [US2] Add/update tests in `frontend/plugins/practice-view-plugin/practiceToolbar.test.tsx`:
+  - Same max=2.0 and 200% display assertions
+  Confirm GREEN (validates T005 changes)
+
+### Implementation for User Story 2
+
+- [ ] T023 [US2] Add E2E test T003 in `frontend/e2e/tempo.spec.ts`:
+  - Load a score → drag slider to rightmost position → assert displayed percentage is `"200%"`
+  - Assert playback runs without JavaScript errors at 200%
+  - Assert slider does NOT snap at 197%–200% (only snaps near 100%)
+
+**Checkpoint**: All three user stories are independently functional and tested. US1 (10% min), US2 (200% max precision), and US3 (deferred metronome) are all green.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T024 Update `FEATURES.md` — add entry for tempo range extension (10%–200%, 1% steps, 100% snap) and metronome deferred start in practice mode
+- [ ] T025 Run the full test suite to confirm all tests pass: `cd frontend && npm run test && npm run test:e2e` — fix any regressions before marking the feature complete
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 ✓ — BLOCKS Phase 3 and Phase 5 slider work
+- **Phase 3 (US1)**: Depends on Phase 2 — can run in parallel with Phase 4
+- **Phase 4 (US3)**: Depends on Phase 2 — can run in parallel with Phase 3 (touches different files)
+- **Phase 5 (US2)**: Depends on Phase 2 — can start after Phase 2; does not depend on Phase 3 or 4
+- **Phase 6 (Polish)**: Depends on Phases 3, 4, and 5 all complete
+
+### User Story Dependencies
+
+- **US1 (Phase 3)**: Independent — only shares Phase 2 foundation. No dependency on US3.
+- **US3 (Phase 4)**: Independent — zero overlap with US1 code. `practiceToolbar.tsx` is shared but US1 changes the slider and US3 changes the metro button — tasks are parallelizable at the file level.
+- **US2 (Phase 5)**: Depends on Phase 2 (step/snap changes). All implementation tasks are GREEN-only (verifying existing behaviour + Phase 2 changes) — no new code in toolbars.
+
+### Within Each Phase
+
+- `[P]`-marked test tasks can run in parallel before their paired implementation tasks
+- Test tasks MUST be RED before the corresponding implementation task starts
+- Implementation tasks must be run in order within a phase when dependencies are noted
+
+### Files Touched (change surface map)
+
+| File | Phases |
+|------|--------|
+| `frontend/src/utils/tempoCalculations.ts` | Phase 3 (T009) |
+| `frontend/src/utils/tempoCalculations.test.ts` | Phase 3 (T006) |
+| `frontend/plugins/play-score/playbackToolbar.tsx` | Phase 2 (T004), Phase 3 (T010) |
+| `frontend/plugins/play-score/playbackToolbar.test.tsx` | Phase 2 (T002), Phase 3 (T007), Phase 5 (T021) |
+| `frontend/plugins/practice-view-plugin/practiceToolbar.tsx` | Phase 2 (T005), Phase 3 (T011), Phase 4 (T015) |
+| `frontend/plugins/practice-view-plugin/practiceToolbar.test.tsx` | Phase 2 (T003), Phase 3 (T008), Phase 4 (T013) |
+| `frontend/plugins/practice-view-plugin/usePracticeMidi.ts` | Phase 4 (T017) |
+| `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx` | Phase 4 (T018) |
+| `frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx` | Phase 4 (T014) |
+| `frontend/plugins/practice-view-plugin/*.css` (metro-btn styles) | Phase 4 (T016) |
+| `frontend/e2e/tempo.spec.ts` (new file) | Phase 3 (T012), Phase 5 (T023) |
+| `frontend/e2e/metronome.spec.ts` | Phase 4 (T019, T020) |
+| `FEATURES.md` | Phase 6 (T024) |
+
+---
+
+## Parallel Execution Examples
+
+### Parallel Example: Phase 2 (Foundational)
+
+```bash
+# Both can run simultaneously (different test files):
+# Agent A: T002 — write failing tests in playbackToolbar.test.tsx
+# Agent B: T003 — write failing tests in practiceToolbar.test.tsx
+
+# Then (both need T002/T003 to be RED first):
+# Agent A: T004 — fix playbackToolbar.tsx
+# Agent B: T005 — fix practiceToolbar.tsx
+```
+
+### Parallel Example: Phase 3 + Phase 4 (Both P1 Stories)
+
+```bash
+# After Phase 2 is complete, both stories can be worked simultaneously:
+# Stream A — US1 (Tempo min 10%):
+#   T006 (tempoCalculations tests RED) → T009 (tempoCalculations impl) →
+#   T007+T008 (toolbar tests RED) → T010+T011 (toolbar impl) → T012 (E2E)
+
+# Stream B — US3 (Metronome deferred start):
+#   T013+T014 (toolbar+integration tests RED) → T015+T016 (CSS+props) →
+#   T017 (usePracticeMidi) → T018 (PracticeViewPlugin) → T019+T020 (E2E)
+```
+
+### Parallel Example: Phase 4 test tasks
+
+```bash
+# T013 and T014 can be written simultaneously (different files):
+# T013 → practiceToolbar.test.tsx
+# T014 → PracticeViewPlugin.test.tsx
+```
+
+---
+
+## Implementation Strategy
+
+**MVP scope**: Phase 1 + Phase 2 + Phase 3 (US1 — 10% tempo min) = independently shippable.
+
+- Phase 3 (US1) delivers the most-requested practice improvement (slow-practice range) with no risk to metronome behaviour
+- Phase 4 (US3) is independently executable in parallel with US1; both are P1 priority
+- Phase 5 (US2) requires only validation tasks (200% max already existed) — lowest risk
+- Phase 6 (Polish) is additive only; no production risk
+
+**TDD reminder** (Principle V — NON-NEGOTIABLE):  
+For every numbered test task, the tests MUST be committed while still RED. Only then should the corresponding implementation task begin.


### PR DESCRIPTION
## Feature 083

Extends tempo control precision for both Play Score and Practice View, and adds a smart metronome "armed" mode for practice sessions.

### Changes

**Tempo slider**
- Range: 10%–200% (was 50%–200%), step 1% (was 5%)
- BPM floor: minimum raises proportionally so playback never drops below 10 BPM
- Snap zone: recalibrated to ±3% at 100% (was ±5%), using integer arithmetic to avoid float edge cases
- Tick mark datalist at 100% in both toolbars
- Tooltip when floor raises the minimum above 10%

**Bug fixes**
- Practice toolbar BPM display was double-multiplying (scoreTempo × multiplier × multiplier → shows 528 BPM); fixed to show effective BPM directly
- `computeEffectiveMinMultiplier` was receiving effective BPM instead of original; fixed by deriving `originalBpm = effectiveBpm / multiplier`
- Stale closure in metronome toggle handlers; fixed via `metronomeStateRef` updated in subscription

**Metronome armed state (Practice View)**
- Toggling metronome while practice is in `waiting` mode arms it instead of starting immediately
- Starting practice while metronome is already active: stops it and arms it automatically
- First MIDI note attack while armed starts the metronome in sync
- Stopping practice disarms the metronome
- Armed button shows pulsing amber glow (CSS `--armed` modifier)

**Architecture**
- Tempo utils re-exported through `plugin-api/index` (fixes `no-restricted-imports` lint rule for plugins)
- `onFirstNoteAttack` callback added to `usePracticeMidi` hook

### Tests
1987 passing (+39 new unit tests)