### PR TITLE
fix(085): Metronome alignment, pickup support, and double-click artefact

### DIFF
--- a/frontend/plugins/play-score/PlayScorePlugin.test.tsx
+++ b/frontend/plugins/play-score/PlayScorePlugin.test.tsx
@@ -138,7 +138,7 @@ function createMockContext(stateOverride: Partial<ScorePlayerState> = {}, ScoreR
       toggle: vi.fn().mockResolvedValue(undefined),
       subscribe: vi.fn((handler) => {
         // Immediate call with inactive metronome state
-        handler({ active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1 });
+        handler({ active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1, subBeatIndex: 0 });
         return () => {};
       }),
     },

--- a/frontend/plugins/play-score/PlayScorePlugin.tsx
+++ b/frontend/plugins/play-score/PlayScorePlugin.tsx
@@ -39,6 +39,8 @@ const INITIAL_PLAYER_STATE: ScorePlayerState = {
   totalDurationTicks: 0,
   highlightedNoteIds: new Set<string>(),
   bpm: 120,
+  exactBpm: 120,
+  pickupTicks: 0,
   title: null,
   error: null,
   staffCount: 0,
@@ -51,6 +53,7 @@ const INITIAL_METRONOME_STATE: MetronomeState = {
   isDownbeat: false,
   bpm: 0,
   subdivision: 1,
+  subBeatIndex: 0,
 };
 
 // ---------------------------------------------------------------------------
@@ -303,6 +306,7 @@ export function PlayScorePlugin({ context }: PlayScorePluginProps) {
         onMetronomeToggle={handleMetronomeToggle}
         metronomeSubdivision={metronomeSubdivision}
         onMetronomeSubdivisionChange={handleMetronomeSubdivisionChange}
+        metronomeSubBeatIndex={metronomeState.subBeatIndex}
       />
 
       {/* Loading indicator */}

--- a/frontend/plugins/play-score/playbackToolbar.test.tsx
+++ b/frontend/plugins/play-score/playbackToolbar.test.tsx
@@ -45,6 +45,7 @@ function makeDefaultProps(
     onMetronomeToggle: vi.fn(),
     metronomeSubdivision: 1 as const,
     onMetronomeSubdivisionChange: vi.fn(),
+    metronomeSubBeatIndex: 0,
     ...overrides,
   };
 }

--- a/frontend/plugins/play-score/playbackToolbar.tsx
+++ b/frontend/plugins/play-score/playbackToolbar.tsx
@@ -63,6 +63,8 @@ export interface PlaybackToolbarProps {
   metronomeSubdivision: MetronomeSubdivision;
   /** Called when the user picks a new subdivision */
   onMetronomeSubdivisionChange: (s: MetronomeSubdivision) => void;
+  /** Position within the current beat subdivision cycle (0 = on-beat) */
+  metronomeSubBeatIndex: number;
 }
 
 export function PlaybackToolbar({
@@ -84,6 +86,7 @@ export function PlaybackToolbar({
   onMetronomeToggle,
   metronomeSubdivision,
   onMetronomeSubdivisionChange,
+  metronomeSubBeatIndex,
 }: PlaybackToolbarProps) {
   const { t } = useTranslation();
   const isPlaying = status === 'playing';
@@ -105,7 +108,7 @@ export function PlaybackToolbar({
 
   // Using beatIndex as `key` forces React to remount the button on each beat,
   // which resets the CSS animation so it replays from 0% every beat.
-  const metronomeAnimKey = metronomeActive ? `metro-${metronomeBeatIndex}` : 'metro-off';
+  const metronomeAnimKey = metronomeActive ? `metro-${metronomeBeatIndex}-${metronomeSubBeatIndex}` : 'metro-off';
 
   // Subdivision dropdown state
   const [menuOpen, setMenuOpen] = useState(false);

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx
@@ -164,6 +164,7 @@ function createMockContext(
           isDownbeat: false,
           bpm: 0,
           subdivision: 1,
+          subBeatIndex: 0,
         });
         return () => {};
       }),
@@ -1807,7 +1808,7 @@ describe('PracticeViewPlugin — metronome deferred start (Feature 083 US3)', ()
     const ctx = createMockContext({ status: 'ready', staffCount: 1 });
     (ctx.context.metronome.subscribe as ReturnType<typeof vi.fn>).mockImplementation((handler) => {
       metronomeHandler = handler;
-      handler({ active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1 });
+      handler({ active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1, subBeatIndex: 0 });
       return () => {};
     });
     ctx.mockExtractPracticeNotes.mockReturnValue({
@@ -1820,7 +1821,7 @@ describe('PracticeViewPlugin — metronome deferred start (Feature 083 US3)', ()
 
     // Simulate metronome becoming active
     act(() => {
-      metronomeHandler?.({ active: true, beatIndex: 0, isDownbeat: true, bpm: 120, subdivision: 1 });
+      metronomeHandler?.({ active: true, beatIndex: 0, isDownbeat: true, bpm: 120, subdivision: 1, subBeatIndex: 0 });
     });
     vi.mocked(ctx.context.metronome.toggle).mockClear();
 
@@ -1832,7 +1833,7 @@ describe('PracticeViewPlugin — metronome deferred start (Feature 083 US3)', ()
 
     // Simulate the metronome service acknowledging it's now inactive (real app behaviour)
     act(() => {
-      metronomeHandler?.({ active: false, beatIndex: -1, isDownbeat: false, bpm: 120, subdivision: 1 });
+      metronomeHandler?.({ active: false, beatIndex: -1, isDownbeat: false, bpm: 120, subdivision: 1, subBeatIndex: 0 });
     });
 
     // Metronome button should be in armed state

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
@@ -79,6 +79,7 @@ const INITIAL_METRONOME_STATE: MetronomeState = {
   isDownbeat: false,
   subdivision: 1,
   bpm: 0,
+  subBeatIndex: 0,
 };
 
 const INITIAL_PLAYER_STATE: ScorePlayerState = {

--- a/frontend/plugins/train-view/TrainPlugin.test.tsx
+++ b/frontend/plugins/train-view/TrainPlugin.test.tsx
@@ -160,7 +160,7 @@ function makeMockContext(overrides?: { scorePlayer?: PluginScorePlayerContext & 
     metronome: {
       toggle: vi.fn().mockResolvedValue(undefined),
       subscribe: vi.fn((handler: (s: { active: boolean; beatIndex: number; isDownbeat: boolean; bpm: number }) => void) => {
-        handler({ active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1 });
+        handler({ active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1, subBeatIndex: 0 });
         return () => {};
       }),
     },

--- a/frontend/plugins/train-view/TrainPlugin.tsx
+++ b/frontend/plugins/train-view/TrainPlugin.tsx
@@ -122,7 +122,8 @@ export function TrainPlugin({ context }: TrainPluginProps) {
   const [showScoreSelector, setShowScoreSelector] = useState(false);
   const [scorePlayerState, setScorePlayerState] = useState<ScorePlayerState>({
     status: 'idle', currentTick: 0, totalDurationTicks: 0,
-    highlightedNoteIds: new Set<string>(), bpm: 0, title: null, error: null,
+    highlightedNoteIds: new Set<string>(), bpm: 0, exactBpm: 0, pickupTicks: 0,
+    title: null, error: null,
     timeSignature: { numerator: 4, denominator: 4 }, staffCount: 0,
   });
   const scorePitchesRef = useRef<PluginScorePitches | null>(null);
@@ -130,7 +131,7 @@ export function TrainPlugin({ context }: TrainPluginProps) {
 
   // Feature 035: Metronome state
   const [metronomeState, setMetronomeState] = useState<MetronomeState>({
-    active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1,
+    active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1, subBeatIndex: 0,
   });
 
   // ── UI state ─────────────────────────────────────────────────────────────────

--- a/frontend/plugins/train-view/TrainVirtualKeyboard.test.tsx
+++ b/frontend/plugins/train-view/TrainVirtualKeyboard.test.tsx
@@ -116,7 +116,7 @@ function makeMockContext(): PluginContext & {
     metronome: {
       toggle: vi.fn().mockResolvedValue(undefined),
       subscribe: vi.fn((handler: (s: { active: boolean; beatIndex: number; isDownbeat: boolean; bpm: number }) => void) => {
-        handler({ active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1 });
+        handler({ active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1, subBeatIndex: 0 });
         return () => {};
       }),
     },

--- a/frontend/src/plugin-api/metronomeContext.test.ts
+++ b/frontend/src/plugin-api/metronomeContext.test.ts
@@ -18,8 +18,25 @@ import type { PluginMetronomeContext, MetronomeState, ScorePlayerState } from '.
 
 type StateHandler = (s: MetronomeState) => void;
 
-const INACTIVE: MetronomeState = { active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1 };
-const ACTIVE: MetronomeState = { active: true, beatIndex: 0, isDownbeat: true, bpm: 120, subdivision: 1 };
+const INACTIVE: MetronomeState = { active: false, beatIndex: -1, isDownbeat: false, bpm: 0, subdivision: 1, subBeatIndex: 0 };
+const ACTIVE: MetronomeState = { active: true, beatIndex: 0, isDownbeat: true, bpm: 120, subdivision: 1, subBeatIndex: 0 };
+
+// ─── Mock ToneAdapter ────────────────────────────────────────────────────────
+// Captures the onTransportRestart listener so loop-restart tests can fire it.
+
+const adapterMock = vi.hoisted(() => {
+  let _restartListener: (() => void) | null = null;
+  const onTransportRestart = vi.fn((listener: () => void) => {
+    _restartListener = listener;
+    return () => { _restartListener = null; };
+  });
+  return {
+    onTransportRestart,
+    getTransportSeconds: vi.fn(() => 0),
+    getRestartListener: () => _restartListener,
+    resetRestartListener: () => { _restartListener = null; },
+  };
+});
 
 let mockEngineStateHandlers: Set<StateHandler>;
 let mockEngine: {
@@ -43,6 +60,15 @@ vi.mock('../services/metronome/useMetronome', () => ({
   }),
 }));
 
+vi.mock('../services/playback/ToneAdapter', () => ({
+  ToneAdapter: {
+    getInstance: vi.fn(() => ({
+      onTransportRestart: adapterMock.onTransportRestart,
+      getTransportSeconds: adapterMock.getTransportSeconds,
+    })),
+  },
+}));
+
 import {
   createNoOpMetronome,
   createMetronomeProxy,
@@ -61,10 +87,12 @@ function makeMockScorePlayer(initialBpm = 120) {
     totalDurationTicks: 0,
     highlightedNoteIds: new Set(),
     bpm: initialBpm,
+    exactBpm: initialBpm,
     title: null,
     error: null,
     staffCount: 0,
     timeSignature: { numerator: 4, denominator: 4 },
+    pickupTicks: 0,
   };
 
   return {
@@ -94,6 +122,8 @@ function makeMockScorePlayer(initialBpm = 120) {
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
+  adapterMock.onTransportRestart.mockClear();
+  adapterMock.resetRestartListener();
   currentHookState = INACTIVE;
   mockEngineStateHandlers = new Set();
   mockEngine = {
@@ -285,9 +315,263 @@ describe('useMetronomeBridge (T008)', () => {
     // Engine fire should NOT call removed handler
     act(() => {
       mockEngineStateHandlers.forEach(h =>
-        h({ active: true, beatIndex: 0, isDownbeat: true, bpm: 120, subdivision: 1 })
+        h({ active: true, beatIndex: 0, isDownbeat: true, bpm: 120, subdivision: 1, subBeatIndex: 0 })
       );
     });
     expect(received.length).toBe(countAfter);
+  });
+});
+
+// ─── useMetronomeBridge — loop restart (US2) ──────────────────────────────────
+
+describe('useMetronomeBridge — loop restart via onTransportRestart (US2)', () => {
+  it('registers onTransportRestart listener on mount', () => {
+    const scorePlayer = makeMockScorePlayer(120);
+    renderHook(() => useMetronomeBridge(scorePlayer));
+    expect(adapterMock.onTransportRestart).toHaveBeenCalledOnce();
+  });
+
+  it('calls engine.start() when onTransportRestart fires while engine is active AND status is playing (loop wrap)', async () => {
+    currentHookState = ACTIVE;
+    const scorePlayer = makeMockScorePlayer(120);
+    renderHook(() => useMetronomeBridge(scorePlayer));
+
+    // Simulate loop wrap: status must be 'playing' so the listener knows it's a loop,
+    // not an initial-play Transport restart (which the subscriber handles instead).
+    await act(async () => {
+      scorePlayer._notify({ status: 'playing', bpm: 120 });
+    });
+
+    mockEngine.start.mockClear();
+
+    const listener = adapterMock.getRestartListener();
+    expect(listener).not.toBeNull();
+
+    await act(async () => {
+      listener!();
+      // flush the Promise.resolve() microtask inside the listener
+      await Promise.resolve();
+    });
+
+    expect(mockEngine.start).toHaveBeenCalled();
+  });
+
+  it('does NOT call engine.start() when onTransportRestart fires while status is NOT playing (initial play)', async () => {
+    // The subscriber's 'playing' transition handler takes care of initial play.
+    // The onTransportRestart microtask must skip to avoid firing beat-0 at the
+    // wrong phase (e.g. at tick 0 of a pickup score) before the subscriber corrects it.
+    currentHookState = ACTIVE;
+    const scorePlayer = makeMockScorePlayer(120);
+    renderHook(() => useMetronomeBridge(scorePlayer));
+    // status stays 'idle' (default)
+
+    const listener = adapterMock.getRestartListener();
+    expect(listener).not.toBeNull();
+
+    await act(async () => {
+      listener!();
+      await Promise.resolve();
+    });
+
+    expect(mockEngine.start).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call engine.start() when onTransportRestart fires while engine is inactive', async () => {
+    currentHookState = INACTIVE;
+    const scorePlayer = makeMockScorePlayer(120);
+    renderHook(() => useMetronomeBridge(scorePlayer));
+
+    const listener = adapterMock.getRestartListener();
+    expect(listener).not.toBeNull();
+
+    await act(async () => {
+      listener!();
+      await Promise.resolve();
+    });
+
+    expect(mockEngine.start).not.toHaveBeenCalled();
+  });
+
+  it('uses the current scorePlayer BPM when restarting after loop wrap', async () => {
+    currentHookState = ACTIVE;
+    const scorePlayer = makeMockScorePlayer(72);
+    renderHook(() => useMetronomeBridge(scorePlayer));
+
+    // Put into 'playing' state so the listener treats this as a loop wrap
+    await act(async () => {
+      scorePlayer._notify({ status: 'playing', bpm: 72 });
+    });
+    mockEngine.start.mockClear();
+
+    const listener = adapterMock.getRestartListener();
+    await act(async () => {
+      listener!();
+      await Promise.resolve();
+    });
+
+    const [bpmArg] = mockEngine.start.mock.calls[0];
+    expect(bpmArg).toBe(72);
+  });
+});
+
+// ─── useMetronomeBridge — fresh-start phase lock (US1 timing fix) ────────────
+
+describe('useMetronomeBridge — fresh-start fires beat-0 click (US1)', () => {
+  it('schedules first click at transportSeconds+0.001 when transport just started (tick=0)', async () => {
+    // Simulate: metronome is active, playback transitions to 'playing' from tick 0
+    // with transportSeconds=0 (Transport just started with +0.05 lookahead, not yet
+    // past the lookahead window).  The fix should fire on beat 0 immediately rather
+    // than skipping to beat 1 (one full beat interval later).
+    currentHookState = ACTIVE;
+    adapterMock.getTransportSeconds.mockReturnValue(0);
+    const scorePlayer = makeMockScorePlayer(13);
+    scorePlayer.getCurrentTickLive.mockReturnValue(0);
+
+    const { result } = renderHook(() => useMetronomeBridge(scorePlayer));
+
+    await act(async () => {
+      scorePlayer._notify({ status: 'playing', bpm: 13 });
+    });
+
+    // engine.stop() then engine.start() should have been called
+    expect(mockEngine.stop).toHaveBeenCalled();
+    expect(mockEngine.start).toHaveBeenCalled();
+
+    // The 5th argument is scheduleOffsetSeconds — should be 0+0.001 = 0.001
+    // (not a full beat interval ≈ 4.615 s which would miss beat 0)
+    const [, , , startBeatIndex, scheduleOffsetSeconds] = mockEngine.start.mock.calls[mockEngine.start.mock.calls.length - 1];
+    expect(startBeatIndex).toBe(0); // downbeat
+    expect(scheduleOffsetSeconds).toBeCloseTo(0.001, 3);
+  });
+
+  it('still fires beat-0 click when subscriber fires late (transportSeconds 0.15s, still in first beat)', async () => {
+    // Simulate: React subscriber fires ~150 ms after startTransport() (slow render).
+    // transportSeconds=0.15 (Transport already past 50 ms lookahead), but currentTick
+    // is still near 0 because we're at 13 BPM and a beat is ~4.6 s long.
+    // Expected: fresh-start guard still applies because we're in the first beat,
+    // so the click fires immediately (transportSeconds+0.001) rather than ~4.5 s later.
+    // Without this guard, the metronome would lag the music by ~50 ms on every beat.
+    currentHookState = ACTIVE;
+    adapterMock.getTransportSeconds.mockReturnValue(0.15);
+    const scorePlayer = makeMockScorePlayer(13);
+    // 150 ms at 13 BPM = 150/1000 * 13/60 * 960 ≈ 31 ticks (well within first beat)
+    scorePlayer.getCurrentTickLive.mockReturnValue(31);
+
+    const { result } = renderHook(() => useMetronomeBridge(scorePlayer));
+
+    await act(async () => {
+      scorePlayer._notify({ status: 'playing', bpm: 13 });
+    });
+
+    expect(mockEngine.start).toHaveBeenCalled();
+    const [, , , startBeatIndex, scheduleOffsetSeconds] = mockEngine.start.mock.calls[mockEngine.start.mock.calls.length - 1];
+    expect(startBeatIndex).toBe(0);
+    // Should be transportSeconds + 0.001 ≈ 0.151, NOT ~4.45 s (next-beat path)
+    expect(scheduleOffsetSeconds).toBeCloseTo(0.151, 2);
+    expect(scheduleOffsetSeconds).toBeLessThan(0.5);
+  });
+
+  it('falls back to next-beat logic when transport has been running >50 ms (mid-song toggle)', async () => {
+    // Simulate enabling metronome mid-song at tick=480 (half-beat), Transport at 2.307 s
+    currentHookState = INACTIVE;
+    adapterMock.getTransportSeconds.mockReturnValue(2.307);
+    const scorePlayer = makeMockScorePlayer(13);
+    scorePlayer.getCurrentTickLive.mockReturnValue(480); // half-beat into measure
+
+    const { result } = renderHook(() => useMetronomeBridge(scorePlayer));
+
+    await act(async () => {
+      // Manually notify 'playing' so toggle() uses phase-lock path
+      scorePlayer._notify({ status: 'playing', bpm: 13 });
+      // Now toggle while playing
+      await result.current.toggle();
+    });
+
+    const lastCall = mockEngine.start.mock.calls[mockEngine.start.mock.calls.length - 1];
+    const [, , , , scheduleOffsetSeconds] = lastCall;
+    // scheduleOffsetSeconds should be transportSeconds + timeUntilNextBeat
+    // transportSeconds=2.307, fractionalBeat=0.5 → timeUntilNextBeat≈2.307 s
+    // → scheduleOffsetSeconds ≈ 4.614 (> 0.05, not the fresh-start path)
+    expect(scheduleOffsetSeconds).toBeGreaterThan(0.05);
+  });
+});
+
+// ─── useMetronomeBridge — pickup measure phase correction ────────────────────
+
+describe('useMetronomeBridge — pickup measure beat alignment', () => {
+  it('Für Elise (3/8, 2-beat pickup): beat-0 fires at tick=960 (first full-measure downbeat)', async () => {
+    // Für Elise is 3/8 time with a 2-eighth-note pickup.
+    // ticksPerBeat = 960 * (4/8) = 480.  Pickup = 2 × 480 = 960 ticks.
+    // At tick=0 (score start), we are on beat 1 of a 3-beat measure (0-indexed),
+    // NOT beat 0. Without the pickup correction, beatOrdinal=0 → startBeatIndex=0
+    // (falsely fires as downbeat).  With correction, adjustedTick=-960 → ordinal=-2
+    // → ((−2 % 3) + 3) % 3 = 1 → startBeatIndex=1 (correct: pickup beat).
+    currentHookState = ACTIVE;
+    adapterMock.getTransportSeconds.mockReturnValue(0);
+    const scorePlayer = makeMockScorePlayer(120);
+    scorePlayer.getCurrentTickLive.mockReturnValue(0);
+
+    const { result } = renderHook(() => useMetronomeBridge(scorePlayer));
+
+    await act(async () => {
+      scorePlayer._notify({
+        status: 'playing',
+        bpm: 120,
+        timeSignature: { numerator: 3, denominator: 8 },
+        pickupTicks: 960, // 2 eighth-note beats
+      });
+    });
+
+    expect(mockEngine.start).toHaveBeenCalled();
+    const [, , , startBeatIndex] = mockEngine.start.mock.calls[mockEngine.start.mock.calls.length - 1];
+    // tick=0 is beat 1 in a 3-beat cycle (pickup takes beats 1 and 2, downbeat was at -480)
+    expect(startBeatIndex).toBe(1);
+  });
+
+  it('no pickup (4/4): beat-0 fires at tick=0 as before', async () => {
+    currentHookState = ACTIVE;
+    adapterMock.getTransportSeconds.mockReturnValue(0);
+    const scorePlayer = makeMockScorePlayer(120);
+    scorePlayer.getCurrentTickLive.mockReturnValue(0);
+
+    const { result } = renderHook(() => useMetronomeBridge(scorePlayer));
+
+    await act(async () => {
+      scorePlayer._notify({
+        status: 'playing',
+        bpm: 120,
+        timeSignature: { numerator: 4, denominator: 4 },
+        pickupTicks: 0,
+      });
+    });
+
+    expect(mockEngine.start).toHaveBeenCalled();
+    const [, , , startBeatIndex] = mockEngine.start.mock.calls[mockEngine.start.mock.calls.length - 1];
+    expect(startBeatIndex).toBe(0); // downbeat as expected
+  });
+
+  it('1-beat 3/4 pickup: beat-0 fires at tick=1920 (first real downbeat)', async () => {
+    // 3/4 time, 1-beat pickup. ticksPerBeat=960. pickupTicks=960.
+    // adjustedTick = 0 - 960 = -960 → ordinal = -1 → ((-1%3)+3)%3 = 2.
+    currentHookState = ACTIVE;
+    adapterMock.getTransportSeconds.mockReturnValue(0);
+    const scorePlayer = makeMockScorePlayer(120);
+    scorePlayer.getCurrentTickLive.mockReturnValue(0);
+
+    const { result } = renderHook(() => useMetronomeBridge(scorePlayer));
+
+    await act(async () => {
+      scorePlayer._notify({
+        status: 'playing',
+        bpm: 120,
+        timeSignature: { numerator: 3, denominator: 4 },
+        pickupTicks: 960, // 1 quarter-note beat
+      });
+    });
+
+    expect(mockEngine.start).toHaveBeenCalled();
+    const [, , , startBeatIndex] = mockEngine.start.mock.calls[mockEngine.start.mock.calls.length - 1];
+    // tick=0 is beat 2 (0-indexed) of a 3-beat measure (the last beat before the real downbeat)
+    expect(startBeatIndex).toBe(2);
   });
 });

--- a/frontend/src/plugin-api/metronomeContext.ts
+++ b/frontend/src/plugin-api/metronomeContext.ts
@@ -40,6 +40,7 @@ const INACTIVE_STATE: MetronomeState = {
   isDownbeat: false,
   bpm: 0,
   subdivision: 1,
+  subBeatIndex: 0,
 };
 
 // ─── Beat-phase helper ────────────────────────────────────────────────────────
@@ -61,6 +62,10 @@ const INACTIVE_STATE: MetronomeState = {
  * @param bpm            - Effective BPM.
  * @param numerator      - Time-signature numerator.
  * @param denominator    - Time-signature denominator.
+ * @param pickupTicks    - Duration of the pickup/anacrusis measure in ticks (0 = no pickup).
+ *                         When non-zero, tick 0 is beat `numerator - pickupTicks/ticksPerBeat`
+ *                         within the first virtual measure, so the first real downbeat is at
+ *                         tick `pickupTicks`.
  * @returns startBeatIndex and scheduleOffsetSeconds to pass to engine.start()
  */
 function computeBeatPhase(
@@ -69,28 +74,44 @@ function computeBeatPhase(
   bpm: number,
   numerator: number,
   denominator: number,
+  pickupTicks = 0,
 ): { startBeatIndex: number; scheduleOffsetSeconds: number } {
   const ticksPerBeat = PPQ * (4 / denominator);
   const beatInterval = (60 / bpm) * (4 / denominator);
 
-  const ticksIntoCurrentBeat = currentTick % ticksPerBeat;
+  // Adjust currentTick relative to the first real downbeat.
+  // For pickup scores tick 0 is mid-measure; shifting by -pickupTicks makes
+  // tick `pickupTicks` (the true downbeat) align with offset 0, so that
+  // `beatOrdinal % numerator` correctly yields 0 there.
+  const adjustedTick = currentTick - pickupTicks;
+
+  const ticksIntoCurrentBeat = ((adjustedTick % ticksPerBeat) + ticksPerBeat) % ticksPerBeat;
   const fractionalBeat = ticksIntoCurrentBeat / ticksPerBeat;
 
-  // Always schedule the NEXT beat boundary so that:
-  //   1. scheduleOffsetSeconds is always strictly ahead of transportSeconds
-  //      → Tone.js never has to decide whether to fire "now" or "one cycle later"
-  //   2. startBeatIndex always matches the beat that actually fires first.
+  // ── Fresh-start optimisation ───────────────────────────────────────────────
+  // If we are still within the first beat (transportSeconds < beatInterval) AND
+  // the tick is at/near a beat boundary (fractionalBeat < 5%), schedule the
+  // first click at transportSeconds + 1 ms rather than skipping a full beat.
+  // Without this the downbeat is silently skipped — especially noticeable at
+  // slow tempos (13 BPM → 4.6 s/beat) where the user hears the first note with
+  // no click, then waits almost 5 s for the metronome to join in.
   //
-  // The old "snap to current boundary if fractionalBeat < 2%" case was the source
-  // of the strong-beat displacement: it set startBeatIndex=0 (downbeat) but
-  // passed scheduleOffsetSeconds ≈ transportSeconds.  Tone.js, seeing that
-  // startTime is at or behind the current Transport position, skipped one full
-  // interval — so the first click landed one beat later while still announcing
-  // "downbeat", shifting every subsequent strong-beat marker by one beat.
-  const nextBeatOrdinal = Math.floor(currentTick / ticksPerBeat) + 1;
-  const startBeatIndex = nextBeatOrdinal % numerator;
-  // Guard against exactly-zero fractional part (currentTick on a boundary):
-  // use a full interval rather than 0 to avoid a startTime == transportSeconds race.
+  // Using transportSeconds < beatInterval (not a fixed 50 ms threshold) handles
+  // React subscriber delays of 150–200 ms after startTransport().
+  // `fractionalBeat < 0.05` prevents this from firing when toggled on mid-song.
+  if (transportSeconds < beatInterval && fractionalBeat < 0.05) {
+    const beatOrdinal = Math.floor(adjustedTick / ticksPerBeat);
+    return {
+      startBeatIndex: ((beatOrdinal % numerator) + numerator) % numerator,
+      scheduleOffsetSeconds: transportSeconds + 0.001,
+    };
+  }
+
+  // Always schedule the NEXT beat boundary so that scheduleOffsetSeconds is
+  // strictly ahead of transportSeconds.  This avoids a Tone.js race where it
+  // would otherwise have to decide whether to fire "now" or "one cycle later".
+  const nextBeatOrdinal = Math.floor(adjustedTick / ticksPerBeat) + 1;
+  const startBeatIndex = ((nextBeatOrdinal % numerator) + numerator) % numerator;
   const timeUntilNextBeat = fractionalBeat < 1e-9
     ? beatInterval
     : beatInterval * (1 - fractionalBeat);
@@ -130,6 +151,7 @@ export function useMetronomeBridge(
     timeSignature: DEFAULT_TIME_SIGNATURE,
     status: 'idle' as string,
     currentTick: 0,
+    pickupTicks: 0,
   });
 
   // Current engine active state — stable ref so toggle() closure always reads latest.
@@ -141,10 +163,61 @@ export function useMetronomeBridge(
 
   // T020: Subscribe to scorePlayer for BPM + timeSignature.
   // On BPM change while engine is active, call engine.updateBpm() (FR-007a).
+  //
+  // FR-003 / FR-004 (Issue #2 — loop restart fix): Also subscribe to
+  // ToneAdapter.onTransportRestart so the engine re-registers its
+  // scheduleRepeat after every loop-boundary Transport restart.
+  // The listener fires synchronously BEFORE Transport.stop()/start(), so
+  // engine.start() is deferred via a microtask to ensure the Transport is
+  // already running at position 0 when scheduleRepeat is registered.
   useEffect(() => {
+    const adapter = ToneAdapter.getInstance();
+    const unsubTransportRestart = adapter.onTransportRestart(() => {
+      if (!engineStateRef.current.active) return;
+      // Capture state synchronously (before Transport restarts).
+      const { bpm, timeSignature, pickupTicks } = scoreStateRef.current;
+      const capturedStatus = scoreStateRef.current.status;
+      Promise.resolve().then(() => {
+        // ── Initial play (Transport restart triggered by user pressing Play) ──
+        // When status is NOT yet 'playing' (e.g. 'ready'), the subscriber's
+        // 'prevStatus !== playing → status === playing' branch will fire and
+        // call engine.start() with the correct beat phase via computeBeatPhase.
+        // Let it handle that — starting here would fire a wrong-phase click
+        // (beat 0 at tick 0 ignores pickup) that the subscriber cannot undo
+        // fast enough to prevent the user from hearing it.
+        if (capturedStatus !== 'playing') return;
+
+        // ── Loop-wrap restart (Transport resets to 0 mid-playback) ──
+        // Status stays 'playing' throughout a loop wrap.  Re-register the
+        // scheduleRepeat with the correct beat phase for the loop-start tick.
+        if (!engineStateRef.current.active) return;
+        const liveTick = scorePlayer.getCurrentTickLive();
+        const transportSeconds = adapter.getTransportSeconds();
+        const { startBeatIndex, scheduleOffsetSeconds } = computeBeatPhase(
+          liveTick,
+          transportSeconds,
+          bpm,
+          timeSignature.numerator,
+          timeSignature.denominator,
+          pickupTicks,
+        );
+        engine
+          .start(bpm, timeSignature.numerator, timeSignature.denominator, startBeatIndex, scheduleOffsetSeconds, subdivisionRef.current, /* skipTransportStart */ true)
+          .catch((err) => {
+            console.error('[useMetronomeBridge] failed to restart after loop wrap:', err);
+          });
+      });
+    });
+
     const unsubscribe = scorePlayer.subscribe((s) => {
-      const newBpm = s.bpm > 0 ? s.bpm : DEFAULT_BPM;
+      // Use exactBpm (unrounded) for all audio-timing calculations so the
+      // metronome beat interval matches the note schedule exactly.  The rounded
+      // s.bpm is only for display — at slow practice speeds (e.g. 120 BPM × 11 %
+      // = 13.2 BPM, rounds to 13) the rounding error is 1.5 % which causes ~70 ms
+      // of drift per beat.
+      const newBpm = (s.exactBpm ?? s.bpm) > 0 ? (s.exactBpm ?? s.bpm) : DEFAULT_BPM;
       const newTs = s.timeSignature ?? DEFAULT_TIME_SIGNATURE;
+      const newPickupTicks = s.pickupTicks ?? 0;
 
       const prevBpm = scoreStateRef.current.bpm;
       const prevStatus = scoreStateRef.current.status;
@@ -153,6 +226,7 @@ export function useMetronomeBridge(
         timeSignature: newTs,
         status: s.status,
         currentTick: s.currentTick,
+        pickupTicks: newPickupTicks,
       };
 
       // Update running engine if BPM changed while active
@@ -171,7 +245,7 @@ export function useMetronomeBridge(
         prevStatus !== 'playing' &&
         s.status === 'playing'
       ) {
-        const { bpm, timeSignature } = scoreStateRef.current;
+        const { bpm, timeSignature, pickupTicks } = scoreStateRef.current;
         // Synchronous: immediately kill old scheduleRepeat so no stale clicks fire
         // before we re-register at the correct beat phase.
         engine.stop();
@@ -189,9 +263,10 @@ export function useMetronomeBridge(
           bpm,
           timeSignature.numerator,
           timeSignature.denominator,
+          pickupTicks,
         );
         engine
-          .start(bpm, timeSignature.numerator, timeSignature.denominator, startBeatIndex, scheduleOffsetSeconds, subdivisionRef.current)
+          .start(bpm, timeSignature.numerator, timeSignature.denominator, startBeatIndex, scheduleOffsetSeconds, subdivisionRef.current, /* skipTransportStart */ true)
           .catch((err) => {
             console.error('[useMetronomeBridge] failed to sync on playback start:', err);
           });
@@ -199,21 +274,22 @@ export function useMetronomeBridge(
       }
 
       // ── Playback stops / pauses while metronome is active ────────────────
-      // Transport is halted; restart the engine in standalone mode from beat 1.
-      if (
-        engineStateRef.current.active &&
-        prevStatus === 'playing' &&
-        (s.status === 'ready' || s.status === 'idle' || s.status === 'paused')
-      ) {
-        const { bpm, timeSignature } = scoreStateRef.current;
-        // Synchronous stop first to avoid stale clicks
-        engine.stop();
-        engine.start(bpm, timeSignature.numerator, timeSignature.denominator, 0, 0, subdivisionRef.current).catch((err) => {
-          console.error('[useMetronomeBridge] failed to resume after playback stop:', err);
-        });
-      }
+      // When playback transitions playing → ready/paused (e.g. natural end of
+      // score, user stop/pause, or transient state during a loop wrap), we do
+      // NOT restart the engine here.  Doing so caused two bugs:
+      //   1. A phantom DOWNBEAT click at the moment of the transition (since
+      //      restart used startBeat=0, offset=0).
+      //   2. The metronome "beat 1" was misaligned for the rest of playback
+      //      because the standalone restart re-anchored the beat counter.
+      // The engine's scheduleRepeat naturally goes silent when the Transport
+      // stops, which is the correct behaviour: the metronome follows the score.
+      // If the user wants the metronome to keep ticking after a stop, they can
+      // toggle it off and on again.
     });
-    return unsubscribe;
+    return () => {
+      unsubTransportRestart();
+      unsubscribe();
+    };
     // scorePlayer is stable (proxy ref) — no dep array churn
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [engine, scorePlayer]);
@@ -224,9 +300,11 @@ export function useMetronomeBridge(
     subdivisionRef.current = subdivision;
     // If engine is running, restart immediately at the new subdivision from beat 1
     if (engineStateRef.current.active) {
-      const { bpm, timeSignature } = scoreStateRef.current;
+      const { bpm, timeSignature, status } = scoreStateRef.current;
       const effectiveBpm = bpm > 0 ? bpm : DEFAULT_BPM;
-      await engine.start(effectiveBpm, timeSignature.numerator, timeSignature.denominator, 0, 0, subdivision);
+      // Skip Transport.start() if playback is running (it already owns the Transport)
+      const skipTransportStart = status === 'playing';
+      await engine.start(effectiveBpm, timeSignature.numerator, timeSignature.denominator, 0, 0, subdivision, skipTransportStart);
     }
   }, [engine]);
 
@@ -238,7 +316,7 @@ export function useMetronomeBridge(
     if (currentState.active) {
       engine.stop();
     } else {
-      const { bpm, timeSignature, status } = scoreStateRef.current;
+      const { bpm, timeSignature, status, pickupTicks } = scoreStateRef.current;
       const effectiveBpm = bpm > 0 ? bpm : DEFAULT_BPM;
 
       if (status === 'playing') {
@@ -252,7 +330,9 @@ export function useMetronomeBridge(
           effectiveBpm,
           timeSignature.numerator,
           timeSignature.denominator,
+          pickupTicks,
         );
+        // skipTransportStart=true: playback already owns the Transport
         await engine.start(
           effectiveBpm,
           timeSignature.numerator,
@@ -260,9 +340,11 @@ export function useMetronomeBridge(
           startBeatIndex,
           scheduleOffsetSeconds,
           subdivisionRef.current,
+          /* skipTransportStart */ true,
         );
       } else {
         // Standalone mode (no playback) — start from the downbeat.
+        // skipTransportStart=false (default): engine.start() will start Transport.
         await engine.start(effectiveBpm, timeSignature.numerator, timeSignature.denominator, 0, 0, subdivisionRef.current);
       }
     }

--- a/frontend/src/plugin-api/scorePlayerContext.ts
+++ b/frontend/src/plugin-api/scorePlayerContext.ts
@@ -181,6 +181,7 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
   const [expandedNotesByStaff, setExpandedNotesByStaff] = useState<Note[][]>([]);
   const [scoreTempo, setScoreTempo] = useState<number>(120);
   const [scoreTimeSignature, setScoreTimeSignature] = useState<{ numerator: number; denominator: number }>({ numerator: 4, denominator: 4 });
+  const [scorePickupTicks, setScorePickupTicks] = useState<number>(0);
   const [title, setTitle] = useState<string | null>(null);
 
   /**
@@ -260,9 +261,13 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
 
   // ─── Effective BPM ───────────────────────────────────────────────────────
 
-  const effectiveBpm = useMemo(
-    () => Math.round(scoreTempo * tempoState.tempoMultiplier),
+  const exactBpm = useMemo(
+    () => scoreTempo * tempoState.tempoMultiplier,
     [scoreTempo, tempoState.tempoMultiplier]
+  );
+  const effectiveBpm = useMemo(
+    () => Math.round(exactBpm),
+    [exactBpm]
   );
 
   // ─── Subscribe system ─────────────────────────────────────────────────────
@@ -274,10 +279,12 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
     totalDurationTicks: 0,
     highlightedNoteIds: new Set<string>(),
     bpm: 0,
+    exactBpm: 0,
     title: null,
     error: null,
     staffCount: 0,
     timeSignature: { numerator: 4, denominator: 4 },
+    pickupTicks: 0,
   });
 
   // Notify all subscribers when state changes
@@ -289,10 +296,12 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
       totalDurationTicks: playbackState.totalDurationTicks,
       highlightedNoteIds,
       bpm: effectiveBpm,
+      exactBpm,
       title,
       error: errorMessage,
       staffCount,
       timeSignature: scoreTimeSignature,
+      pickupTicks: scorePickupTicks,
     };
     currentStateRef.current = newState;
     subscribersRef.current.forEach(h => h(newState));
@@ -302,10 +311,12 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
     playbackState.totalDurationTicks,
     highlightedNoteIds,
     effectiveBpm,
+    exactBpm,
     title,
     errorMessage,
     score,
     scoreTimeSignature,
+    scorePickupTicks,
   ]);
 
   // ─── getCatalogue ─────────────────────────────────────────────────────────
@@ -416,6 +427,7 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
       setScoreTempo(parsedTempo);
       setOriginalTempo(parsedTempo);
       setScoreTimeSignature(parsedTimeSignature);
+      setScorePickupTicks(scoreObject.pickup_ticks ?? 0);
       setTitle(parsedTitle);
       setOverlayStatus(null); // reverts to playback-engine status ('stopped' → 'ready')
     } catch (err) {
@@ -778,10 +790,12 @@ export function createNoOpScorePlayer(): PluginScorePlayerContext {
     totalDurationTicks: 0,
     highlightedNoteIds: new Set<string>(),
     bpm: 0,
+    exactBpm: 0,
     title: null,
     error: null,
     staffCount: 0,
     timeSignature: { numerator: 4, denominator: 4 },
+    pickupTicks: 0,
   };
 
   return {

--- a/frontend/src/plugin-api/types.ts
+++ b/frontend/src/plugin-api/types.ts
@@ -482,10 +482,19 @@ export interface ScorePlayerState {
    */
   readonly highlightedNoteIds: ReadonlySet<string>;
   /**
-   * Effective playback tempo in BPM (originalBpm × tempoMultiplier).
+   * Effective playback tempo in BPM (originalBpm × tempoMultiplier), rounded to
+   * the nearest integer.  Use this for display purposes.
    * 0 when no score is loaded.
    */
   readonly bpm: number;
+  /**
+   * Exact (unrounded) effective tempo in BPM (originalBpm × tempoMultiplier).
+   * Use this for audio-timing calculations (e.g. metronome beat interval) to
+   * avoid rounding errors that would cause progressive drift at slow tempos.
+   * Equals `bpm` when the product is already an integer.
+   * 0 when no score is loaded.
+   */
+  readonly exactBpm: number;
   /** Display title from score metadata; null until a score is loaded. */
   readonly title: string | null;
   /** Error message; non-null when status === 'error'. */
@@ -506,6 +515,14 @@ export interface ScorePlayerState {
     readonly numerator: number;
     readonly denominator: number;
   };
+  /**
+   * Duration of the pickup/anacrusis measure in ticks (0 = no pickup).
+   * When non-zero, tick 0 is NOT a measure downbeat — the first real downbeat
+   * falls at tick `pickupTicks`.  The metronome uses this to phase-lock beat
+   * counting so that beat 0 (downbeat) fires on the correct measure boundary
+   * in pieces like Für Elise (3/8 with a 2-beat pickup).
+   */
+  readonly pickupTicks: number;
 }
 
 /**
@@ -752,6 +769,14 @@ export interface MetronomeState {
    * Current beat subdivision (1 = quarter, 2 = eighth, 4 = sixteenth).
    */
   readonly subdivision: MetronomeSubdivision;
+  /**
+   * Position within the current beat subdivision cycle.
+   * 0 = on-beat (full beat boundary); 1..(subdivision-1) = intermediate
+   * subdivision tick within the current beat.
+   * Used by visual indicators to blink on every subdivision tick, not only
+   * on full beat boundaries (FR-006, FR-007, SC-003).
+   */
+  readonly subBeatIndex: number;
 }
 
 /**

--- a/frontend/src/services/metronome/MetronomeEngine.test.ts
+++ b/frontend/src/services/metronome/MetronomeEngine.test.ts
@@ -19,10 +19,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // initialised before the factory functions run.
 
 const toneState = vi.hoisted(() => {
-  let _beatCallback: (() => void) | null = null;
+  let _beatCallback: ((time?: number) => void) | null = null;
   let _eventIdCounter = 0;
 
-  const scheduleRepeat = vi.fn((cb: () => void) => {
+  const scheduleRepeat = vi.fn((cb: (time?: number) => void) => {
     _beatCallback = cb;
     return ++_eventIdCounter;
   });
@@ -69,11 +69,11 @@ const toneState = vi.hoisted(() => {
 });
 
 const adapterState = vi.hoisted(() => {
-  let _beatCallback: (() => void) | null = null;
+  let _beatCallback: ((time?: number) => void) | null = null;
   let _eventIdCounter = 0;
 
   const init = vi.fn().mockResolvedValue(undefined);
-  const scheduleRepeat = vi.fn((cb: () => void) => {
+  const scheduleRepeat = vi.fn((cb: (time?: number) => void) => {
     _beatCallback = cb;
     return ++_eventIdCounter;
   });
@@ -149,10 +149,18 @@ function fireBeat(times = 1): void {
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('MetronomeEngine — BPM clamping (T002)', () => {
-  it('clamps BPM below 20 to 20', async () => {
+  // FR-009, SC-001: supported range is 10–300 BPM
+  it('clamps BPM below 10 to 10 (new minimum — regression for 10 BPM desync)', async () => {
     const engine = new MetronomeEngine();
     await engine.start(5, 4, 4);
-    expect(engine.getState().bpm).toBe(20);
+    expect(engine.getState().bpm).toBe(10);
+    engine.dispose();
+  });
+
+  it('accepts 10 BPM without clamping (minimum supported tempo)', async () => {
+    const engine = new MetronomeEngine();
+    await engine.start(10, 4, 4);
+    expect(engine.getState().bpm).toBe(10);
     engine.dispose();
   });
 
@@ -170,10 +178,10 @@ describe('MetronomeEngine — BPM clamping (T002)', () => {
     engine.dispose();
   });
 
-  it('passes through valid boundary BPM values (20 and 300)', async () => {
+  it('passes through valid boundary BPM values (10 and 300)', async () => {
     const engine = new MetronomeEngine();
-    await engine.start(20, 4, 4);
-    expect(engine.getState().bpm).toBe(20);
+    await engine.start(10, 4, 4);
+    expect(engine.getState().bpm).toBe(10);
     engine.dispose();
 
     const engine2 = new MetronomeEngine();
@@ -408,12 +416,12 @@ describe('MetronomeEngine — updateBpm (T018)', () => {
     expect(engine.getState().bpm).toBe(140);
   });
 
-  it('clamps the new BPM to [20, 300]', async () => {
+  it('clamps the new BPM to [10, 300]', async () => {
     await engine.start(120, 4, 4);
     engine.updateBpm(999);
     expect(engine.getState().bpm).toBe(300);
     engine.updateBpm(1);
-    expect(engine.getState().bpm).toBe(20);
+    expect(engine.getState().bpm).toBe(10);
   });
 
   it('clears the existing event and reschedules at new interval', async () => {
@@ -496,5 +504,91 @@ describe('MetronomeEngine — beat interval computation (T002)', () => {
     const [, interval] = adapterState.scheduleRepeat.mock.calls[0];
     // beatIntervalSeconds = (60 / 60) * (4 / 8) = 1 * 0.5 = 0.5
     expect(interval).toBeCloseTo(0.5, 5);
+  });
+});
+
+// ─── Subdivision visual blink (US3 — FR-006, FR-007, SC-003) ─────────────────
+
+describe('MetronomeEngine — subdivision subscriber notifications (US3)', () => {
+  let engine: MetronomeEngine;
+
+  beforeEach(() => {
+    engine = new MetronomeEngine();
+    adapterState.resetBeatCallback();
+    adapterState.resetEventId();
+  });
+
+  afterEach(() => {
+    engine.dispose();
+  });
+
+  it('with subdivision 1, each tick emits one subscriber notification (on-beat only)', async () => {
+    const states: MetronomeState[] = [];
+    engine.subscribe(s => states.push(s));
+    await engine.start(120, 4, 4, 0, 0, 1);
+    const startCount = states.length;
+    fireBeat(1);
+    expect(states.length - startCount).toBe(1);
+    expect(states.at(-1)!.subBeatIndex).toBe(0);
+  });
+
+  it('with subdivision 2, each Transport tick emits a subscriber notification (not only on-beat)', async () => {
+    // Regression test for Issue #3: without the fix, only tick 1 of 2 fires subscriber.
+    const states: MetronomeState[] = [];
+    engine.subscribe(s => states.push(s));
+    await engine.start(120, 4, 4, 0, 0, 2);
+    const startCount = states.length;
+    // Two Transport ticks = one beat boundary (tick 1) + one subdivision tick (tick 2)
+    fireBeat(2);
+    expect(states.length - startCount).toBe(2);
+  });
+
+  it('first tick of subdivision 2 emits subBeatIndex: 0 (on-beat)', async () => {
+    const states: MetronomeState[] = [];
+    engine.subscribe(s => states.push(s));
+    await engine.start(120, 4, 4, 0, 0, 2);
+    const startCount = states.length;
+    fireBeat(1);
+    const tick1 = states[startCount];
+    expect(tick1.subBeatIndex).toBe(0);
+  });
+
+  it('second tick of subdivision 2 emits subBeatIndex: 1 (eighth-note subdivision)', async () => {
+    const states: MetronomeState[] = [];
+    engine.subscribe(s => states.push(s));
+    await engine.start(120, 4, 4, 0, 0, 2);
+    const startCount = states.length;
+    fireBeat(2);
+    const tick2 = states[startCount + 1];
+    expect(tick2.subBeatIndex).toBe(1);
+  });
+
+  it('after a full subdivision cycle (2 ticks), subBeatIndex resets to 0 and beatIndex advances', async () => {
+    const states: MetronomeState[] = [];
+    engine.subscribe(s => states.push(s));
+    await engine.start(120, 4, 4, 0, 0, 2);
+    const startCount = states.length;
+    fireBeat(3); // 3rd tick = start of next beat
+    const tick3 = states[startCount + 2];
+    expect(tick3.subBeatIndex).toBe(0);
+    expect(tick3.beatIndex).toBe(1); // advanced from beat 0 to beat 1
+  });
+
+  it('with subdivision 4, fires 4 notifications per beat', async () => {
+    const states: MetronomeState[] = [];
+    engine.subscribe(s => states.push(s));
+    await engine.start(120, 4, 4, 0, 0, 4);
+    const startCount = states.length;
+    fireBeat(4);
+    expect(states.length - startCount).toBe(4);
+    const subBeatIndexes = states.slice(startCount).map(s => s.subBeatIndex);
+    expect(subBeatIndexes).toEqual([0, 1, 2, 3]);
+  });
+
+  it('_getState() includes subBeatIndex', async () => {
+    await engine.start(120, 4, 4, 0, 0, 2);
+    const state = engine.getState();
+    expect(typeof state.subBeatIndex).toBe('number');
+    expect(state.subBeatIndex).toBe(0);
   });
 });

--- a/frontend/src/services/metronome/MetronomeEngine.ts
+++ b/frontend/src/services/metronome/MetronomeEngine.ts
@@ -61,10 +61,10 @@ export class MetronomeEngine {
    * Emits a console.warn when clamping occurs (FR-008a).
    */
   public clampBpm(bpm: number): number {
-    const clamped = Math.min(300, Math.max(20, bpm));
+    const clamped = Math.min(300, Math.max(10, bpm));
     if (clamped !== bpm) {
       console.warn(
-        `[MetronomeEngine] BPM ${bpm} out of range [20, 300], clamped to ${clamped}.`
+        `[MetronomeEngine] BPM ${bpm} out of range [10, 300], clamped to ${clamped}.`
       );
     }
     return clamped;
@@ -84,6 +84,11 @@ export class MetronomeEngine {
    *   default 0 (fires at Transport position 0 / immediately after standalone Transport.start).
    *   Pass `Tone.Transport.seconds + timeUntilNextBeatBoundary` when the Transport is
    *   already running so the metronome phase-locks to the current measure position.
+   * @param subdivision          - Subdivision (1 = quarter/eighth, 2 = eighth/sixteenth...)
+   * @param skipTransportStart   - When true, skip the standalone `Transport.start()` at the
+   *   end of this method.  Pass true whenever the Transport is already running (or is about
+   *   to be started) by the playback engine so that engine.start() does NOT issue a second
+   *   Transport.start() call that would reset timing and cause a double-click artefact.
    */
   public async start(
     bpm: number,
@@ -92,6 +97,7 @@ export class MetronomeEngine {
     startBeatIndex = 0,
     scheduleOffsetSeconds = 0,
     subdivision: MetronomeSubdivision = 1,
+    skipTransportStart = false,
   ): Promise<void> {
     const adapter = ToneAdapter.getInstance();
 
@@ -143,10 +149,13 @@ export class MetronomeEngine {
     // Schedule repeat beat on Transport.
     // scheduleOffsetSeconds > 0 phase-locks the first click to a beat boundary
     // when the Transport is already running (playback mid-measure).
+    // The Transport callback forwards the scheduled audio-context time so that
+    // triggerAttackRelease() fires at the exact sample-accurate beat position
+    // rather than at Tone.now() (which is ~lookahead seconds early).
     const beatIntervalSeconds = this._computeBeatInterval(this._bpm, this._denominator);
     const tickIntervalSeconds = beatIntervalSeconds / this._subdivision;
     this._eventId = adapter.scheduleRepeat(
-      () => this._fireBeat(),
+      (time) => this._fireBeat(time),
       tickIntervalSeconds,
       scheduleOffsetSeconds > 0 ? scheduleOffsetSeconds : undefined,
     );
@@ -160,8 +169,11 @@ export class MetronomeEngine {
       this._clearEvent();
     });
 
-    // Start Transport in standalone mode — no-op if already running by playback.
-    if ((Tone.Transport as unknown as { state: string }).state !== 'started') {
+    // Start Transport in standalone mode — skipped when playback engine owns the Transport.
+    // When skipTransportStart=true the caller guarantees Transport is already running (or
+    // is about to be started by startTransport()).  A second Transport.start() here would
+    // reset Transport timing and produce a spurious double-click at the beat boundary.
+    if (!skipTransportStart && (Tone.Transport as unknown as { state: string }).state !== 'started') {
       Tone.Transport.start('+0.01');
     }
 
@@ -203,7 +215,7 @@ export class MetronomeEngine {
     const beatIntervalSeconds = this._computeBeatInterval(this._bpm, this._denominator);
     const tickIntervalSeconds = beatIntervalSeconds / this._subdivision;
     this._eventId = ToneAdapter.getInstance().scheduleRepeat(
-      () => this._fireBeat(),
+      (time) => this._fireBeat(time),
       tickIntervalSeconds,
     );
 
@@ -261,20 +273,20 @@ export class MetronomeEngine {
    * Called by the Transport-scheduled repeat callback on every beat.
    * Triggers the appropriate click sound and notifies subscribers.
    */
-  private _fireBeat(): void {
+  private _fireBeat(time?: number): void {
     const isOnBeat = this._subBeatIndex === 0;
     const isDownbeat = isOnBeat && this._beatIndex === 0;
 
     try {
       if (isDownbeat) {
-        // Measure downbeat: low percussive “tock”
-        this._downbeatSynth?.triggerAttackRelease('C2', '16n');
-      } else if (isOnBeat) {
-        // Regular beat within the measure
-        this._upbeatSynth?.triggerAttackRelease('G4', '32n');
+        // Measure downbeat: low percussive "tock".
+        // Pass the Tone.js-scheduled audio-context time for sample-accurate
+        // playback — without it triggerAttackRelease defaults to Tone.now()
+        // which fires ~lookahead ms early relative to music notes.
+        this._downbeatSynth?.triggerAttackRelease('C2', '16n', time);
       } else {
-        // Subdivision tick (8th or 16th): same pitch as regular beat
-        this._upbeatSynth?.triggerAttackRelease('G4', '32n');
+        // Regular beat or subdivision tick — same upbeat click sound.
+        this._upbeatSynth?.triggerAttackRelease('G4', '32n', time);
       }
     } catch {
       // Swallow audio errors — beat should still count even if synth fails
@@ -282,6 +294,7 @@ export class MetronomeEngine {
 
     // Capture indices before advancing for the subscriber snapshot
     const currentBeatIndex = this._beatIndex;
+    const currentSubBeatIndex = this._subBeatIndex;
 
     // Advance sub-beat; roll over to next beat when subdivision is complete
     this._subBeatIndex += 1;
@@ -290,18 +303,17 @@ export class MetronomeEngine {
       this._beatIndex = (this._beatIndex + 1) % this._numerator;
     }
 
-    // Notify subscribers only on real beat boundaries (not sub-ticks) to
-    // keep the visual pulse in sync with the score beat grid.
-    if (isOnBeat) {
-      const state: MetronomeState = {
-        active: this._active,
-        beatIndex: currentBeatIndex,
-        isDownbeat,
-        bpm: this._bpm,
-        subdivision: this._subdivision,
-      };
-      this._subscribers.forEach(h => h(state));
-    }
+    // Notify subscribers on every tick (beat AND subdivision) so that visual
+    // indicators blink on all subdivision ticks, not only beat boundaries.
+    const state: MetronomeState = {
+      active: this._active,
+      beatIndex: currentBeatIndex,
+      isDownbeat,
+      bpm: this._bpm,
+      subdivision: this._subdivision,
+      subBeatIndex: currentSubBeatIndex,
+    };
+    this._subscribers.forEach(h => h(state));
   }
 
   private _getState(): MetronomeState {
@@ -312,6 +324,7 @@ export class MetronomeEngine {
         isDownbeat: false,
         bpm: 0,
         subdivision: this._subdivision,
+        subBeatIndex: 0,
       };
     }
     return {
@@ -320,6 +333,7 @@ export class MetronomeEngine {
       isDownbeat: this._beatIndex === 0,
       bpm: this._bpm,
       subdivision: this._subdivision,
+      subBeatIndex: this._subBeatIndex,
     };
   }
 

--- a/frontend/src/services/metronome/useMetronome.ts
+++ b/frontend/src/services/metronome/useMetronome.ts
@@ -30,6 +30,7 @@ const INACTIVE_STATE: MetronomeState = {
   isDownbeat: false,
   bpm: 0,
   subdivision: 1,
+  subBeatIndex: 0,
 };
 
 export interface UseMetronomeReturn {

--- a/frontend/src/services/playback/ToneAdapter.ts
+++ b/frontend/src/services/playback/ToneAdapter.ts
@@ -402,12 +402,12 @@ export class ToneAdapter {
    * @returns Event ID that can be used with clearTransportEvent()
    */
   public scheduleRepeat(
-    callback: () => void,
+    callback: (time?: number) => void,
     intervalSeconds: number,
     startOffsetSeconds?: number,
   ): number {
     return Tone.Transport.scheduleRepeat(
-      () => callback(),
+      (time) => callback(time),
       intervalSeconds,
       startOffsetSeconds,
     );

--- a/frontend/src/services/state/TempoStateContext.test.tsx
+++ b/frontend/src/services/state/TempoStateContext.test.tsx
@@ -78,7 +78,8 @@ describe('TempoStateContext', () => {
         result.current.adjustTempo(1);
       });
       
-      expect(result.current.tempoState.tempoMultiplier).toBe(1.01);
+      // Snapping rounds to nearest integer BPM: 120 * 1.01 = 121.2 → 121 BPM
+      expect(result.current.getEffectiveTempo()).toBe(121);
     });
 
     it('should decrease tempo by 1% (-1)', () => {
@@ -88,7 +89,8 @@ describe('TempoStateContext', () => {
         result.current.adjustTempo(-1);
       });
       
-      expect(result.current.tempoState.tempoMultiplier).toBe(0.99);
+      // Snapping rounds to nearest integer BPM: 120 * 0.99 = 118.8 → 119 BPM
+      expect(result.current.getEffectiveTempo()).toBe(119);
     });
 
     it('should increase tempo by 10% (+10)', () => {

--- a/frontend/src/services/state/TempoStateContext.tsx
+++ b/frontend/src/services/state/TempoStateContext.tsx
@@ -54,23 +54,31 @@ export function TempoStateProvider({ children }: TempoStateProviderProps) {
   });
 
   /**
-   * Set tempo multiplier directly (with clamping)
-   * 
+   * Set tempo multiplier directly (with clamping and integer-BPM snapping).
+   *
+   * Snaps the multiplier so that originalTempo × multiplier is always a whole
+   * number BPM.  This guarantees the note schedule and the metronome use the
+   * exact same interval, eliminating progressive drift at fractional tempos
+   * (e.g. 120 BPM × 11% = 13.2 BPM would otherwise drift ~70 ms per beat).
+   *
    * @param multiplier - New tempo multiplier (0.5 to 2.0)
    */
   const setTempoMultiplier = useCallback((multiplier: number): void => {
-    const clampedMultiplier = clampTempoMultiplier(multiplier);
-    setTempoState((prev) => ({
-      ...prev,
-      tempoMultiplier: clampedMultiplier,
-    }));
+    setTempoState((prev) => {
+      const clamped = clampTempoMultiplier(multiplier);
+      // Snap: round(originalTempo × m) / originalTempo → integer BPM
+      const snapped = prev.originalTempo > 0
+        ? clampTempoMultiplier(Math.round(prev.originalTempo * clamped) / prev.originalTempo)
+        : clamped;
+      return { ...prev, tempoMultiplier: snapped };
+    });
   }, []);
 
   /**
-   * Adjust tempo by percentage change
-   * 
+   * Adjust tempo by percentage change (with integer-BPM snapping).
+   *
    * @param percentageChange - Change in percentage points (e.g., +1 for +1%, -10 for -10%)
-   * 
+   *
    * @example
    * adjustTempo(1);   // Increase by 1% (1.0 → 1.01)
    * adjustTempo(-1);  // Decrease by 1% (1.0 → 0.99)
@@ -79,12 +87,12 @@ export function TempoStateProvider({ children }: TempoStateProviderProps) {
    */
   const adjustTempo = useCallback((percentageChange: number): void => {
     setTempoState((prev) => {
-      const newMultiplier = prev.tempoMultiplier + percentageChange / 100;
-      const clampedMultiplier = clampTempoMultiplier(newMultiplier);
-      return {
-        ...prev,
-        tempoMultiplier: clampedMultiplier,
-      };
+      const raw = prev.tempoMultiplier + percentageChange / 100;
+      const clamped = clampTempoMultiplier(raw);
+      const snapped = prev.originalTempo > 0
+        ? clampTempoMultiplier(Math.round(prev.originalTempo * clamped) / prev.originalTempo)
+        : clamped;
+      return { ...prev, tempoMultiplier: snapped };
     });
   }, []);
 

--- a/specs/085-fix-metronome-issues/checklists/requirements.md
+++ b/specs/085-fix-metronome-issues/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Fix Metronome Issues
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.
+- FR-002 references "wall-clock interval timers" as a constraint — this describes *what not to do* at a conceptual level, not an implementation prescription, and was retained to accurately bound the timing accuracy requirement.
+- Root causes and regression test references in the Known Issues section are intentionally marked "To be determined / To be created" — this is by design since they will be filled in during implementation.

--- a/specs/085-fix-metronome-issues/spec.md
+++ b/specs/085-fix-metronome-issues/spec.md
@@ -1,0 +1,146 @@
+# Feature Specification: Fix Metronome Issues
+
+**Feature Branch**: `085-fix-metronome-issues`  
+**Created**: 2026-04-26  
+**Status**: Draft  
+**Input**: User description: "Fix metronome issues: ultraslow tempo sync, loop playback stops metronome, visual blink ignores subdivision setting"
+
+## Clarifications
+
+### Session 2026-04-26
+
+- Q: What is the scope of changes allowed for the metronome fix? → A: Scheduling logic is in scope; only the sound synthesis (oscillator/audio output) is off-limits.
+- Q: Does the ≤50ms deviation threshold apply at all tempos? → A: Universal: ≤50ms at ALL supported tempos (10–300 BPM), one universal bar.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Metronome Stays In Sync at Ultraslow Tempos (Priority: P1)
+
+A musician practicing a difficult passage sets the tempo to an extremely slow value (e.g., 10 BPM) to drill note accuracy. The metronome should tick precisely on every beat, perfectly aligned with playback, so the musician can reliably use it as a timing reference even at very low tempos.
+
+**Why this priority**: Tempo accuracy is the fundamental contract of a metronome. A desync at any tempo renders the feature unusable for its core purpose and directly undermines practice quality.
+
+**Independent Test**: Set tempo to 10 BPM, start playback with metronome enabled, and verify that metronome ticks land exactly on each beat of the score for at least 8 measures.
+
+**Acceptance Scenarios**:
+
+1. **Given** playback is stopped, **When** the user sets tempo to 10 BPM and starts playback with the metronome enabled, **Then** each metronome tick coincides with the corresponding beat in the score without drifting or leading.
+2. **Given** playback is running at 10 BPM with metronome active, **When** 4 or more measures have elapsed, **Then** no accumulated drift is observable between metronome ticks and score beat positions.
+3. **Given** a metronome is running at 10 BPM, **When** compared to one running at 120 BPM, **Then** both maintain the same tick-to-beat accuracy relative to playback position.
+
+---
+
+### User Story 2 - Metronome Continues Running Through All Loop Repetitions (Priority: P2)
+
+A musician enables loop playback to repeat a section for practice. The metronome should tick continuously throughout every loop iteration without interruption — it must not stop, freeze, or restart between loops. Only an explicit user action (Stop, Pause, or disabling the metronome) should interrupt it.
+
+**Why this priority**: Loop practice is a core use-case for music learning. A metronome that silently stops after the second loop forces the musician to divert attention from the instrument to restart it, breaking the practice flow.
+
+**Independent Test**: Enable loop mode on a section of 2+ measures, start playback, and verify metronome ticks continue uninterrupted through at least 5 consecutive loop repetitions.
+
+**Acceptance Scenarios**:
+
+1. **Given** loop mode is active and playback is running, **When** the playback position wraps from the loop end back to the loop start, **Then** the metronome tick stream continues without any gap or silence.
+2. **Given** the metronome is ticking through repeated loops, **When** 3 or more loops have completed, **Then** ticks remain in sync with the playback position at the beginning of each new loop iteration.
+3. **Given** loop playback is running with metronome active, **When** the user presses Stop, **Then** the metronome stops cleanly and does not restart on its own.
+4. **Given** loop playback has been stopped (metronome also stopped), **When** the user presses Play again (without loop), **Then** the metronome starts fresh and behaves normally.
+
+---
+
+### User Story 3 - Visual Blink Respects the Configured Subdivision (Priority: P3)
+
+A musician configures the metronome to blink at eighth-note (1/8) subdivisions to develop finer rhythmic awareness. The visual indicator must blink on every eighth note, not just on quarter-note beats. The blink frequency must match the selected subdivision setting.
+
+**Why this priority**: Subdivisions are the second most visible feature of the metronome UI. If the blink ignores the setting, users cannot trust any metronome configuration and may incorrectly believe the feature is broken.
+
+**Independent Test**: Set metronome subdivision to 1/8, start playback at a moderate tempo (e.g., 60 BPM), and count that 2 blinks occur per beat (one on each eighth note).
+
+**Acceptance Scenarios**:
+
+1. **Given** the metronome subdivision is set to 1/4, **When** playback is running, **Then** the visual indicator blinks once per quarter-note beat.
+2. **Given** the metronome subdivision is set to 1/8, **When** playback is running, **Then** the visual indicator blinks twice per quarter-note beat (i.e., on each eighth note).
+3. **Given** the metronome subdivision is changed from 1/4 to 1/8 while playback is running, **When** the change is applied, **Then** the blink rate immediately doubles to match the new subdivision without requiring a restart.
+4. **Given** the metronome subdivision is set to 1/8, **When** playback is at a very slow tempo (e.g., 20 BPM), **Then** the blink still fires on each eighth-note interval, not only on quarter-note beats.
+
+---
+
+### Edge Cases
+
+- What happens when tempo is set below the minimum supported value (e.g., < 1 BPM)? The metronome should not crash or produce erratic ticks; it should clamp to a minimum or disable gracefully.
+- What happens when the loop region is shorter than one beat at ultraslow tempos? The metronome should still emit ticks correctly based on absolute playback time, not loop cycle count.
+- What happens when the user changes the subdivision while the metronome is already mid-tick cycle? The change should take effect at the next tick boundary without skipping or doubling a tick.
+- What happens when loop mode is toggled on/off while playback is running with the metronome active? The metronome should not restart or lose its phase.
+- What happens when playback is paused and resumed mid-loop? The metronome should resume in sync from the paused position, not restart the loop's tick counter.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The metronome tick scheduler MUST use playback-position-based timing so that tick intervals remain accurate at any tempo in the supported range (10–300 BPM).
+- **FR-002**: The metronome MUST NOT use wall-clock interval timers as the sole source of tick timing, as these drift from playback position at extreme tempos.
+- **FR-003**: When loop playback is active, the metronome tick stream MUST continue uninterrupted across every loop boundary for the entire duration of playback.
+- **FR-004**: The metronome MUST NOT stop or reset its internal state when the playback position wraps from loop end to loop start.
+- **FR-005**: When playback is stopped by the user, the metronome MUST stop and MUST NOT auto-restart without a new explicit playback start action.
+- **FR-006**: The visual blink indicator MUST fire on every note event determined by the configured subdivision value (1/4, 1/8, etc.).
+- **FR-007**: The blink interval MUST be derived from the active subdivision setting, not hardcoded to quarter-note intervals.
+- **FR-008**: Changing the subdivision setting MUST immediately update the blink interval for subsequent ticks without requiring a playback restart.
+- **FR-009**: The metronome MUST remain in sync with the score playback position across all supported tempos (10–300 BPM), with tick deviation ≤ 50 ms at any tempo in that range.
+
+### Assumptions
+
+- The metronome already has subdivision settings exposed in the UI (at minimum 1/4 and 1/8 options).
+- "In sync" means each metronome tick lands within ≤ 50 ms of the corresponding beat/subdivision position in the score at any tempo in the supported range (10–300 BPM).
+- Loop mode is an existing feature; this fix targets only metronome behavior within the existing loop framework.
+- No changes to the metronome's sound synthesis layer (oscillator/audio output generation) are required. The tick scheduling logic — timing calculations, tick intervals, and when ticks fire — IS in scope for changes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: At all supported tempos (10–300 BPM), the metronome tick deviation from the score's beat position is ≤ 50 ms for at least 8 consecutive beats; this universal threshold must hold at the extreme low end (10 BPM) as well as at representative typical values (e.g., 120 BPM), eliminating the perceived desync.
+- **SC-002**: During loop playback, the metronome tick stream is uninterrupted across at least 10 consecutive loop iterations with no gaps, stops, or spurious restarts.
+- **SC-003**: When the subdivision is set to 1/8, exactly 2 blink events occur per quarter-note beat period, matching the expected eighth-note subdivision rate.
+- **SC-004**: All three metronome behaviors (tempo sync, loop continuity, subdivision blink) pass their acceptance scenarios without any manual workaround required by the user.
+
+## Known Issues & Regression Tests *(if applicable)*
+
+### Issue #1: Metronome Runs Faster Than Playback at 10 BPM
+
+**Discovered**: 2026-04-26 during user testing
+
+**Symptom**: When tempo is set to 10 BPM (ultraslow), the metronome ticks at a rate noticeably faster than the actual playback position advances through the score.
+
+**Root Cause**: To be determined during implementation — likely a timer-based scheduling approach that does not compensate for tempo scaling, causing tick intervals computed from a default tempo to be too short at very low BPM values.
+
+**Affected Components**: Metronome scheduler / tick engine (frontend).
+
+**Regression Test**: To be created during implementation — unit test that asserts tick timestamps align with beat positions at 10 BPM over an 8-beat window.
+
+---
+
+### Issue #2: Metronome Stops After Second Loop Iteration
+
+**Discovered**: 2026-04-26 during user testing
+
+**Symptom**: When loop playback is active, the metronome ticks correctly during the first loop and into the second, but ceases ticking after the second loop completes. Manually stopping loop playback causes the metronome to restart unexpectedly.
+
+**Root Cause**: To be determined — likely the metronome's internal state (tick counter or scheduler reference) is not reset properly when the playback position wraps, causing the scheduler to halt.
+
+**Affected Components**: Loop playback coordinator and metronome lifecycle management (frontend).
+
+**Regression Test**: To be created — integration test that simulates 5 loop iterations and asserts continuous tick events throughout.
+
+---
+
+### Issue #3: Visual Blink Ignores Subdivision Setting
+
+**Discovered**: 2026-04-26 during user testing
+
+**Symptom**: Regardless of the configured subdivision (e.g., 1/8), the visual blink indicator only fires on quarter-note (1/4) beats.
+
+**Root Cause**: To be determined — likely the blink interval is computed from a hardcoded quarter-note reference rather than reading the active subdivision setting.
+
+**Affected Components**: Metronome visual indicator / blink renderer (frontend).
+
+**Regression Test**: To be created — unit test that verifies blink event count matches the expected subdivision multiplier (e.g., ×2 events per beat for 1/8 vs 1/4).
+


### PR DESCRIPTION
## Summary

Fixes multiple metronome bugs discovered during practice-mode testing.

## Changes

### T022 — Integer-BPM snapping
- `TempoStateContext`: snap tempo multiplier so `originalTempo × multiplier` is always a whole-number BPM, eliminating progressive drift at slow practice speeds (e.g. 120 BPM × 11% = 13.2 BPM → snapped to 13 BPM, 0 drift vs ~70 ms/beat)
- Expose `exactBpm` (unrounded) on `ScorePlayerState` and use it in the metronome bridge so the beat interval matches the note schedule exactly

### T023 — Pickup / anacrusis phase correction
- Expose `pickupTicks` on `ScorePlayerState` (sourced from `score.pickup_ticks`)
- `computeBeatPhase`: shift `currentTick` by `-pickupTicks` before computing beat ordinals so that beat 0 (downbeat) falls at tick `pickupTicks`, not tick 0 — fixes Für Elise (3/8 time, 2-beat pickup) where the downbeat is the 3rd eighth of measure 1

### Loop-restart fix
- Subscribe to `ToneAdapter.onTransportRestart`; on loop-boundary Transport restart, re-register `scheduleRepeat` via a microtask so the first click of the new loop fires at the correct beat phase

### Phantom-downbeat fix
- Remove the `playing → ready/paused` subscriber branch that restarted the engine with `startBeat=0, offset=0` on every stop/pause — this was the cause of a spurious DOWNBEAT click at the end of each loop iteration

### Double-click fix
- Add `skipTransportStart` parameter to `MetronomeEngine.start()`; pass `true` from all bridge call sites where the playback engine already owns the Transport, preventing a second `Transport.start('+0.01')` that would reset timing and produce an extra click at playback start

### Audio timing fix
- Pass Tone.js scheduled audio-context time through `scheduleRepeat → _fireBeat() → triggerAttackRelease()` for sample-accurate click placement

### Cleanup
- Merge identical `else-if`/`else` branches in `_fireBeat()`
- BPM clamp minimum: 20 → 10 (aligns with 10% of 100 BPM default)
- Trim verbose intermediate-state comments; keep explanations for non-obvious decisions

## Testing
- 98 unit/integration tests passing (`MetronomeEngine`, `useMetronomeBridge`, `TempoStateContext`)
- Manual: verified no double-click on play start, correct downbeat phase for Für Elise pickup, metronome stays aligned through loop restarts