### PR TITLE
fix(086): Note detection at ultra-low tempos + metronome deferred start

### DIFF
--- a/frontend/plugins/practice-view-plugin/practiceEngine.test.ts
+++ b/frontend/plugins/practice-view-plugin/practiceEngine.test.ts
@@ -1041,4 +1041,28 @@ describe('[US5] Feature 053: semi-strict extra-notes policy (engine level)', () 
     expect(s.noteResults[0].outcome).toBe('correct');
     expect(s.noteResults[0].wrongAttempts).toBe(3);
   });
+
+  // ─── T019: integration smoke — CORRECT_MIDI → holding → HOLD_COMPLETE → correct ──
+  it('T019: CORRECT_MIDI with requiredHoldMs = 24 000 → holding mode → HOLD_COMPLETE → outcome correct', () => {
+    const holdNote = makeHoldNote([60]);
+    let s = activeState([holdNote]);
+
+    // Press the note with a long hold requirement (whole note at 10 BPM)
+    s = reduce(s, {
+      type: 'CORRECT_MIDI',
+      midiNote: 60,
+      responseTimeMs: 0,
+      expectedTimeMs: 0,
+      pressTimeMs: 1000,
+      requiredHoldMs: 24_000,
+    });
+    expect(s.mode).toBe('holding');
+
+    // Hold completes (called after ≥ 23 500 ms in practice, any value here exercises state machine)
+    s = reduce(s, { type: 'HOLD_COMPLETE', holdDurationMs: 23_600 });
+    expect(s.mode).not.toBe('holding');
+    const result = s.noteResults[0];
+    expect(result).toBeDefined();
+    expect(result.outcome).toBe('correct');
+  });
 });

--- a/frontend/plugins/practice-view-plugin/useHoldProgress.test.ts
+++ b/frontend/plugins/practice-view-plugin/useHoldProgress.test.ts
@@ -38,8 +38,98 @@ describe('useHoldProgress', () => {
       expect.objectContaining({ type: 'HOLD_COMPLETE' }),
     );
 
-    // Advance a further 1 900 ms (total 23 500 ms) — must fire by this point
-    await act(() => vi.advanceTimersByTimeAsync(1_900));
+    // Advance a further 2 000 ms (total 23 600 ms, past the 23 500 ms threshold)
+    // We overshoot by ~100 ms to ensure at least one RAF frame fires after the
+    // acceptance boundary (RAF fires every ~16 ms in fake-timer mode).
+    await act(() => vi.advanceTimersByTimeAsync(2_000));
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'HOLD_COMPLETE' }),
+    );
+
+    vi.useRealTimers();
+  });
+
+  // ─── T006: US1 — no early fire at 21 600 ms, fires by 23 600 ms ─────────────
+  it('T006: for requiredHoldMs = 24 000, HOLD_COMPLETE has NOT fired at 21 600 ms but HAS fired by 23 600 ms', async () => {
+    vi.useFakeTimers();
+    const dispatch = vi.fn();
+    const startMs = Date.now();
+
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'holding' as const,
+      holdStartTimeMs: startMs,
+      requiredHoldMs: 24_000,
+    };
+
+    renderHook(() => useHoldProgress({ practiceState, dispatchPractice: dispatch }));
+
+    await act(() => vi.advanceTimersByTimeAsync(21_600));
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'HOLD_COMPLETE' }),
+    );
+
+    await act(() => vi.advanceTimersByTimeAsync(2_000)); // total 23 600 ms
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'HOLD_COMPLETE' }),
+    );
+
+    vi.useRealTimers();
+  });
+
+  // ─── T014: regression — 90% rule still binds for short notes at 120 BPM ───
+  it('T014: for requiredHoldMs = 2 000 (120 BPM whole note), HOLD_COMPLETE fires between 1 800 ms and 1 850 ms', async () => {
+    vi.useFakeTimers();
+    const dispatch = vi.fn();
+    const startMs = Date.now();
+
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'holding' as const,
+      holdStartTimeMs: startMs,
+      requiredHoldMs: 2_000,
+    };
+
+    renderHook(() => useHoldProgress({ practiceState, dispatchPractice: dispatch }));
+
+    // Must NOT fire before 1 800 ms (90% of 2 000 = 1 800; acceptanceMs = 2000 - min(200,500) = 1800)
+    await act(() => vi.advanceTimersByTimeAsync(1_790));
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'HOLD_COMPLETE' }),
+    );
+
+    // Must fire by 1 850 ms (one RAF frame past the 1 800 ms threshold)
+    await act(() => vi.advanceTimersByTimeAsync(60));
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'HOLD_COMPLETE' }),
+    );
+
+    vi.useRealTimers();
+  });
+
+  // ─── T015: regression — 90% rule for 1 000 ms half note ────────────────────
+  it('T015: for requiredHoldMs = 1 000 (120 BPM half note), HOLD_COMPLETE fires between 900 ms and 950 ms', async () => {
+    vi.useFakeTimers();
+    const dispatch = vi.fn();
+    const startMs = Date.now();
+
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'holding' as const,
+      holdStartTimeMs: startMs,
+      requiredHoldMs: 1_000,
+    };
+
+    renderHook(() => useHoldProgress({ practiceState, dispatchPractice: dispatch }));
+
+    // acceptanceMs = 1000 - min(100, 500) = 900 ms; must NOT fire before 900 ms
+    await act(() => vi.advanceTimersByTimeAsync(890));
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'HOLD_COMPLETE' }),
+    );
+
+    // Must fire by 950 ms
+    await act(() => vi.advanceTimersByTimeAsync(60));
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'HOLD_COMPLETE' }),
     );

--- a/frontend/plugins/practice-view-plugin/useHoldProgress.test.ts
+++ b/frontend/plugins/practice-view-plugin/useHoldProgress.test.ts
@@ -1,5 +1,5 @@
-import { renderHook } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import { useHoldProgress } from './useHoldProgress';
 import { INITIAL_PRACTICE_STATE } from './practiceEngine.types';
 
@@ -15,5 +15,35 @@ describe('useHoldProgress', () => {
     const { result } = renderHook(() => useHoldProgress(makeMockParams()));
     expect(result.current).toHaveProperty('holdProgress');
     expect(typeof result.current.holdProgress).toBe('number');
+  });
+
+  // ─── T002: RED gate — 90% rule fires 2 400 ms early for a 24 000 ms note ───
+  it('T002: HOLD_COMPLETE dispatches only after ≥ 23 500 ms for requiredHoldMs = 24 000 (whole note at 10 BPM)', async () => {
+    vi.useFakeTimers();
+    const dispatch = vi.fn();
+    const startMs = Date.now();
+
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'holding' as const,
+      holdStartTimeMs: startMs,
+      requiredHoldMs: 24_000,
+    };
+
+    renderHook(() => useHoldProgress({ practiceState, dispatchPractice: dispatch }));
+
+    // Advance to 21 600 ms (current 90% threshold) — must NOT have fired yet
+    await act(() => vi.advanceTimersByTimeAsync(21_600));
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'HOLD_COMPLETE' }),
+    );
+
+    // Advance a further 1 900 ms (total 23 500 ms) — must fire by this point
+    await act(() => vi.advanceTimersByTimeAsync(1_900));
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'HOLD_COMPLETE' }),
+    );
+
+    vi.useRealTimers();
   });
 });

--- a/frontend/plugins/practice-view-plugin/useHoldProgress.ts
+++ b/frontend/plugins/practice-view-plugin/useHoldProgress.ts
@@ -37,7 +37,11 @@ export function useHoldProgress({
         const progress = required > 0 ? Math.min(elapsed / required, 1) : 0;
         setHoldProgress(progress);
 
-        if (progress >= 0.9) {
+        // Accept the hold at 90% of the required duration, but cap the
+        // early-acceptance window at 500 ms so long notes (≥ 5 000 ms) at
+        // ultra-low tempos are not accepted more than 500 ms early.
+        const acceptanceMs = required - Math.min(required * 0.1, 500);
+        if (elapsed >= acceptanceMs) {
           dispatchPractice({ type: 'HOLD_COMPLETE', holdDurationMs: elapsed });
           setHoldProgress(0);
           rafRef.current = null;

--- a/frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts
+++ b/frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import { usePracticeMidi } from './usePracticeMidi';
+import { usePracticeMidi, computeRequiredHoldMs } from './usePracticeMidi';
 import { INITIAL_PRACTICE_STATE } from './practiceEngine.types';
 import type { PluginContext, ScorePlayerState } from '../../src/plugin-api/index';
 
@@ -168,5 +168,296 @@ describe('usePracticeMidi', () => {
     const correctCalls = calls.filter(([a]: [{ type: string }]) => a.type === 'CORRECT_MIDI');
     expect(correctCalls).toHaveLength(1);
     expect(correctCalls[0][0].requiredHoldMs).toBe(6_000);
+  });
+
+  // ─── T004: US1 — whole note at 10 BPM (currently green, must stay green) ───
+  it('T004: at 10 BPM, whole note (3 840 ticks) dispatches CORRECT_MIDI with requiredHoldMs = 24 000', () => {
+    const params = makeMockParams();
+
+    const wholeNote = {
+      tick: 0,
+      durationTicks: 3_840,
+      midiPitches: [60] as readonly number[],
+      sustainedPitches: [] as readonly number[],
+      noteIds: ['n1'] as readonly string[],
+    };
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'active' as const,
+      currentIndex: 0,
+      notes: [wholeNote],
+    };
+    params.practiceState = practiceState;
+    params.practiceStateRef = { current: practiceState };
+    params.playerStateRef = {
+      current: { ...params.playerState, bpm: 10, status: 'ready' as const, staffCount: 1 },
+    };
+
+    const midiCallback = captureMidiCallback(params);
+    midiCallback({ type: 'attack', midiNote: 60, timestamp: Date.now() });
+
+    const correctCalls = (params.dispatchPractice as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([a]: [{ type: string }]) => a.type === 'CORRECT_MIDI',
+    );
+    expect(correctCalls).toHaveLength(1);
+    expect(correctCalls[0][0].requiredHoldMs).toBe(24_000);
+  });
+
+  // ─── T005: US1 — half note at measure end, 15 BPM ───────────────────────────
+  it('T005: at 15 BPM, half note at measure end (1 920 ticks) dispatches CORRECT_MIDI with requiredHoldMs = 8 000', () => {
+    const params = makeMockParams();
+
+    const halfNote = {
+      tick: 0,
+      durationTicks: 1_920,
+      midiPitches: [60] as readonly number[],
+      sustainedPitches: [] as readonly number[],
+      noteIds: ['n1'] as readonly string[],
+    };
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'active' as const,
+      currentIndex: 0,
+      notes: [halfNote],
+    };
+    params.practiceState = practiceState;
+    params.practiceStateRef = { current: practiceState };
+    params.playerStateRef = {
+      current: { ...params.playerState, bpm: 15, status: 'ready' as const, staffCount: 1 },
+    };
+
+    const midiCallback = captureMidiCallback(params);
+    midiCallback({ type: 'attack', midiNote: 60, timestamp: Date.now() });
+
+    const correctCalls = (params.dispatchPractice as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([a]: [{ type: string }]) => a.type === 'CORRECT_MIDI',
+    );
+    expect(correctCalls).toHaveLength(1);
+    expect(correctCalls[0][0].requiredHoldMs).toBe(8_000);
+  });
+
+  // ─── T009: US2 — eighth note at 10 BPM now requires a hold ────────────────
+  it('T009: at 10 BPM, eighth note (480 ticks) dispatches CORRECT_MIDI with requiredHoldMs = 3 000', () => {
+    const params = makeMockParams();
+
+    const eighthNote = {
+      tick: 0,
+      durationTicks: 480,
+      midiPitches: [60] as readonly number[],
+      sustainedPitches: [] as readonly number[],
+      noteIds: ['n1'] as readonly string[],
+    };
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'active' as const,
+      currentIndex: 0,
+      notes: [eighthNote],
+    };
+    params.practiceState = practiceState;
+    params.practiceStateRef = { current: practiceState };
+    params.playerStateRef = {
+      current: { ...params.playerState, bpm: 10, status: 'ready' as const, staffCount: 1 },
+    };
+
+    const midiCallback = captureMidiCallback(params);
+    midiCallback({ type: 'attack', midiNote: 60, timestamp: Date.now() });
+
+    const correctCalls = (params.dispatchPractice as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([a]: [{ type: string }]) => a.type === 'CORRECT_MIDI',
+    );
+    expect(correctCalls).toHaveLength(1);
+    // 480 / ((10/60)*960) * 1000 = 480 / 160 * 1000 = 3 000 ms
+    expect(correctCalls[0][0].requiredHoldMs).toBe(3_000);
+  });
+
+  // ─── T010: US2 — quarter note at 10 BPM, gap == duration (no clipping) ─────
+  it('T010: at 10 BPM, quarter note with gap == duration (960 ticks) is not clipped → requiredHoldMs = 6 000', () => {
+    const params = makeMockParams();
+
+    const quarterNote = {
+      tick: 0,
+      durationTicks: 960,
+      midiPitches: [60] as readonly number[],
+      sustainedPitches: [] as readonly number[],
+      noteIds: ['n1'] as readonly string[],
+    };
+    // nextEntry.tick - currentEntry.tick = 960 = durationTicks → no clipping
+    const nextNote = {
+      tick: 960,
+      durationTicks: 960,
+      midiPitches: [62] as readonly number[],
+      sustainedPitches: [] as readonly number[],
+      noteIds: ['n2'] as readonly string[],
+    };
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'active' as const,
+      currentIndex: 0,
+      notes: [quarterNote, nextNote],
+    };
+    params.practiceState = practiceState;
+    params.practiceStateRef = { current: practiceState };
+    params.playerStateRef = {
+      current: { ...params.playerState, bpm: 10, status: 'ready' as const, staffCount: 1 },
+    };
+
+    const midiCallback = captureMidiCallback(params);
+    midiCallback({ type: 'attack', midiNote: 60, timestamp: Date.now() });
+
+    const correctCalls = (params.dispatchPractice as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([a]: [{ type: string }]) => a.type === 'CORRECT_MIDI',
+    );
+    expect(correctCalls).toHaveLength(1);
+    expect(correctCalls[0][0].requiredHoldMs).toBe(6_000);
+  });
+
+  // ─── T012: regression — 120 BPM quarter note has no hold ──────────────────
+  it('T012: at 120 BPM, quarter note (960 ticks) dispatches CORRECT_MIDI with requiredHoldMs = 0', () => {
+    const params = makeMockParams();
+
+    const quarterNote = {
+      tick: 0,
+      durationTicks: 960,
+      midiPitches: [60] as readonly number[],
+      sustainedPitches: [] as readonly number[],
+      noteIds: ['n1'] as readonly string[],
+    };
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'active' as const,
+      currentIndex: 0,
+      notes: [quarterNote],
+    };
+    params.practiceState = practiceState;
+    params.practiceStateRef = { current: practiceState };
+    params.playerStateRef = {
+      current: { ...params.playerState, bpm: 120, status: 'ready' as const, staffCount: 1 },
+    };
+
+    const midiCallback = captureMidiCallback(params);
+    midiCallback({ type: 'attack', midiNote: 60, timestamp: Date.now() });
+
+    const correctCalls = (params.dispatchPractice as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([a]: [{ type: string }]) => a.type === 'CORRECT_MIDI',
+    );
+    expect(correctCalls).toHaveLength(1);
+    // 960 / ((120/60)*960) * 1000 = 500 ms; 500 is NOT > HOLD_FLOOR_MS (500) → 0
+    expect(correctCalls[0][0].requiredHoldMs).toBe(0);
+  });
+
+  // ─── T013: regression — 120 BPM half note still requires a hold ─────────────
+  it('T013: at 120 BPM, half note (1 920 ticks) dispatches CORRECT_MIDI with requiredHoldMs = 1 000', () => {
+    const params = makeMockParams();
+
+    const halfNote = {
+      tick: 0,
+      durationTicks: 1_920,
+      midiPitches: [60] as readonly number[],
+      sustainedPitches: [] as readonly number[],
+      noteIds: ['n1'] as readonly string[],
+    };
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'active' as const,
+      currentIndex: 0,
+      notes: [halfNote],
+    };
+    params.practiceState = practiceState;
+    params.practiceStateRef = { current: practiceState };
+    params.playerStateRef = {
+      current: { ...params.playerState, bpm: 120, status: 'ready' as const, staffCount: 1 },
+    };
+
+    const midiCallback = captureMidiCallback(params);
+    midiCallback({ type: 'attack', midiNote: 60, timestamp: Date.now() });
+
+    const correctCalls = (params.dispatchPractice as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([a]: [{ type: string }]) => a.type === 'CORRECT_MIDI',
+    );
+    expect(correctCalls).toHaveLength(1);
+    // 1920 / ((120/60)*960) * 1000 = 1 000 ms; 1 000 > 500 → hold required
+    expect(correctCalls[0][0].requiredHoldMs).toBe(1_000);
+  });
+
+  // ─── T016: edge case — computeRequiredHoldMs guards against BPM ≤ 0 ────────
+  it('T016: computeRequiredHoldMs(3_840, 0) returns 0 (BPM ≤ 0 guard)', () => {
+    expect(computeRequiredHoldMs(3_840, 0)).toBe(0);
+    expect(computeRequiredHoldMs(3_840, -1)).toBe(0);
+  });
+
+  // ─── T017: spec boundary — 20 BPM quarter note requires a hold ──────────────
+  it('T017: at exactly 20 BPM, quarter note (960 ticks) dispatches CORRECT_MIDI with requiredHoldMs = 3 000', () => {
+    const params = makeMockParams();
+
+    const quarterNote = {
+      tick: 0,
+      durationTicks: 960,
+      midiPitches: [60] as readonly number[],
+      sustainedPitches: [] as readonly number[],
+      noteIds: ['n1'] as readonly string[],
+    };
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'active' as const,
+      currentIndex: 0,
+      notes: [quarterNote],
+    };
+    params.practiceState = practiceState;
+    params.practiceStateRef = { current: practiceState };
+    params.playerStateRef = {
+      current: { ...params.playerState, bpm: 20, status: 'ready' as const, staffCount: 1 },
+    };
+
+    const midiCallback = captureMidiCallback(params);
+    midiCallback({ type: 'attack', midiNote: 60, timestamp: Date.now() });
+
+    const correctCalls = (params.dispatchPractice as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([a]: [{ type: string }]) => a.type === 'CORRECT_MIDI',
+    );
+    expect(correctCalls).toHaveLength(1);
+    // 960 / ((20/60)*960) * 1000 = 3 000 ms; 3 000 > 500 → hold required
+    expect(correctCalls[0][0].requiredHoldMs).toBe(3_000);
+  });
+
+  // ─── T018: gap-clipping still works after T008 ────────────────────────────
+  it('T018: at 10 BPM, note with gap < duration is clipped (durationTicks=3840, gap=1920) → requiredHoldMs = 12 000', () => {
+    const params = makeMockParams();
+
+    const longNote = {
+      tick: 0,
+      durationTicks: 3_840,
+      midiPitches: [60] as readonly number[],
+      sustainedPitches: [] as readonly number[],
+      noteIds: ['n1'] as readonly string[],
+    };
+    // gap = 1920 < 3840 → effectiveDurTicks = 1920
+    const nextNote = {
+      tick: 1_920,
+      durationTicks: 960,
+      midiPitches: [62] as readonly number[],
+      sustainedPitches: [] as readonly number[],
+      noteIds: ['n2'] as readonly string[],
+    };
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'active' as const,
+      currentIndex: 0,
+      notes: [longNote, nextNote],
+    };
+    params.practiceState = practiceState;
+    params.practiceStateRef = { current: practiceState };
+    params.playerStateRef = {
+      current: { ...params.playerState, bpm: 10, status: 'ready' as const, staffCount: 1 },
+    };
+
+    const midiCallback = captureMidiCallback(params);
+    midiCallback({ type: 'attack', midiNote: 60, timestamp: Date.now() });
+
+    const correctCalls = (params.dispatchPractice as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([a]: [{ type: string }]) => a.type === 'CORRECT_MIDI',
+    );
+    expect(correctCalls).toHaveLength(1);
+    // effectiveDurTicks = 1920; 1920 / ((10/60)*960) * 1000 = 12 000 ms
+    expect(correctCalls[0][0].requiredHoldMs).toBe(12_000);
   });
 });

--- a/frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts
+++ b/frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts
@@ -4,6 +4,9 @@ import { usePracticeMidi } from './usePracticeMidi';
 import { INITIAL_PRACTICE_STATE } from './practiceEngine.types';
 import type { PluginContext, ScorePlayerState } from '../../src/plugin-api/index';
 
+type MidiEvent = { type: string; midiNote: number; timestamp: number };
+type MidiCallback = (event: MidiEvent) => void;
+
 function makeMockParams() {
   const practiceState = { ...INITIAL_PRACTICE_STATE };
   const playerState: ScorePlayerState = {
@@ -37,6 +40,20 @@ function makeMockParams() {
     practiceStartTimeRef: { current: 0 },
     selectedStaffIndex: 0,
   };
+}
+
+/** Capture the MIDI subscribe callback by rendering the hook. */
+function captureMidiCallback(params: ReturnType<typeof makeMockParams>): MidiCallback {
+  let midiCallback: MidiCallback | null = null;
+  (params.context.midi as { subscribe: ReturnType<typeof vi.fn> }).subscribe.mockImplementation(
+    (cb: MidiCallback) => {
+      midiCallback = cb;
+      return vi.fn();
+    },
+  );
+  renderHook(() => usePracticeMidi(params));
+  if (!midiCallback) throw new Error('MIDI callback not captured');
+  return midiCallback;
 }
 
 describe('usePracticeMidi', () => {
@@ -119,5 +136,37 @@ describe('usePracticeMidi', () => {
 
     expect(correctCalls).toHaveLength(1);
     expect(wrongCalls).toHaveLength(0);
+  });
+
+  // ─── T003: RED gate — tick-based gate skips hold for ≤ 1 quarter-note ──────
+  it('T003: at 10 BPM, quarter note (960 ticks) dispatches CORRECT_MIDI with requiredHoldMs = 6 000', () => {
+    const params = makeMockParams();
+
+    const quarterNote = {
+      tick: 0,
+      durationTicks: 960,
+      midiPitches: [60] as readonly number[],
+      sustainedPitches: [] as readonly number[],
+      noteIds: ['n1'] as readonly string[],
+    };
+    const practiceState = {
+      ...INITIAL_PRACTICE_STATE,
+      mode: 'active' as const,
+      currentIndex: 0,
+      notes: [quarterNote],
+    };
+    params.practiceState = practiceState;
+    params.practiceStateRef = { current: practiceState };
+    params.playerStateRef = {
+      current: { ...params.playerState, bpm: 10, status: 'ready' as const, staffCount: 1 },
+    };
+
+    const midiCallback = captureMidiCallback(params);
+    midiCallback({ type: 'attack', midiNote: 60, timestamp: Date.now() });
+
+    const calls = (params.dispatchPractice as ReturnType<typeof vi.fn>).mock.calls;
+    const correctCalls = calls.filter(([a]: [{ type: string }]) => a.type === 'CORRECT_MIDI');
+    expect(correctCalls).toHaveLength(1);
+    expect(correctCalls[0][0].requiredHoldMs).toBe(6_000);
   });
 });

--- a/frontend/plugins/practice-view-plugin/usePracticeMidi.ts
+++ b/frontend/plugins/practice-view-plugin/usePracticeMidi.ts
@@ -300,7 +300,7 @@ export function usePracticeMidi({
             effectiveDurTicks = gapTicks;
           }
         }
-        const entryRequiredHoldMs = bpm > 0 && effectiveDurTicks > PPQ
+        const entryRequiredHoldMs = computeRequiredHoldMs(effectiveDurTicks, bpm) > HOLD_FLOOR_MS
           ? computeRequiredHoldMs(effectiveDurTicks, bpm)
           : 0;
         dispatchPractice({

--- a/frontend/plugins/practice-view-plugin/usePracticeMidi.ts
+++ b/frontend/plugins/practice-view-plugin/usePracticeMidi.ts
@@ -42,6 +42,25 @@ export interface UsePracticeMidiReturn {
 const PPQ = 960;
 
 // ---------------------------------------------------------------------------
+// Exported helpers (unit-testable hold-duration formula)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimum wall-clock hold duration (ms) required before the hold gate is
+ * engaged. Notes whose computed duration is ≤ this value need no hold.
+ * Used by T008 to replace the tick-based gate condition.
+ */
+export const HOLD_FLOOR_MS = 500;
+
+/**
+ * Compute the required hold duration in milliseconds for a note.
+ * Returns 0 when `bpm ≤ 0` (guards against division-by-zero).
+ */
+export function computeRequiredHoldMs(durationTicks: number, bpm: number): number {
+  return bpm > 0 ? (durationTicks / ((bpm / 60) * PPQ)) * 1000 : 0;
+}
+
+// ---------------------------------------------------------------------------
 // Hook implementation
 // ---------------------------------------------------------------------------
 
@@ -282,7 +301,7 @@ export function usePracticeMidi({
           }
         }
         const entryRequiredHoldMs = bpm > 0 && effectiveDurTicks > PPQ
-          ? (effectiveDurTicks / ((bpm / 60) * PPQ)) * 1000
+          ? computeRequiredHoldMs(effectiveDurTicks, bpm)
           : 0;
         dispatchPractice({
           type: 'CORRECT_MIDI',

--- a/frontend/plugins/practice-view-plugin/usePracticeMidi.ts
+++ b/frontend/plugins/practice-view-plugin/usePracticeMidi.ts
@@ -99,7 +99,7 @@ export function usePracticeMidi({
   // Guard: fire exactly once per practice session. Reset when practice stops.
   const hasCalledFirstNoteRef = useRef(false);
   useEffect(() => {
-    if (practiceState.mode === 'inactive') {
+    if (practiceState.mode === 'inactive' || practiceState.mode === 'waiting') {
       hasCalledFirstNoteRef.current = false;
     }
   }, [practiceState.mode]);

--- a/specs/086-fix-note-detection-slow-tempo/checklists/requirements.md
+++ b/specs/086-fix-note-detection-slow-tempo/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Fix Note Detection at Ultra-Low Tempos
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.
+- FR-002 mentions "wall-clock timeout" as a constraint on what NOT to use — this is a conceptual description of the failure mode, not an implementation prescription.
+- The ≤ 500 ms detection tolerance in SC-001–SC-004 is a user-perceptible measure, not a technical one, consistent with the tempo sync tolerance established in spec 085.

--- a/specs/086-fix-note-detection-slow-tempo/plan.md
+++ b/specs/086-fix-note-detection-slow-tempo/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: [FEATURE]
+
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+[Extract from feature spec: primary requirement + technical approach from research]
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Target Platform**: [e.g., Tablet devices (iPad/Surface/Android), iOS 15+, WASM, Linux server or NEEDS CLARIFICATION]
+**Project Type**: [single/web/mobile - determines source structure]  
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps, offline-capable or NEEDS CLARIFICATION]  
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-first, tablet-optimized or NEEDS CLARIFICATION]  
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+[Gates determined based on constitution file]
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
+```
+
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/086-fix-note-detection-slow-tempo/spec.md
+++ b/specs/086-fix-note-detection-slow-tempo/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: Fix Note Detection at Ultra-Low Tempos
+
+**Feature Branch**: `086-fix-note-detection-slow-tempo`  
+**Created**: 2026-04-26  
+**Status**: Draft  
+**Input**: User description: "Fix note detection at ultra-low tempos: long notes at end of measure require too long to be detected correctly at tempos below 20 BPM"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Long Notes at Measure End Detected Promptly at Ultra-Low Tempo (Priority: P1)
+
+A musician is practicing at a very slow tempo (e.g., 10 BPM) and plays a whole note or half note that falls at the end of a measure. The system should register the note as correctly played as soon as the musician has held it for its required musical duration — not require holding it for an unreasonably longer time before it is accepted.
+
+**Why this priority**: This is the core reported bug. At ultra-low tempos, the note duration in wall-clock time is very long (e.g., a quarter note at 10 BPM = 6 seconds). If the detection threshold doesn't scale with tempo, musicians must hold notes far longer than musically required, making ultra-slow practice frustrating and unusable.
+
+**Independent Test**: At 10 BPM, play a whole note (4 beats = 24 seconds). The system should accept the note after approximately 24 seconds, not require 40+ seconds.
+
+**Acceptance Scenarios**:
+
+1. **Given** tempo is set to 10 BPM, **When** the musician plays and holds a whole note for its exact musical duration (24 seconds), **Then** the note is detected and accepted without requiring additional hold time.
+2. **Given** tempo is set to 15 BPM, **When** the musician plays a half note at the end of a measure and holds it for its musical duration, **Then** the note is detected correctly at the expected time.
+3. **Given** tempo is set to 20 BPM, **When** the musician plays a long note at the end of a measure, **Then** detection latency is proportional to the note's musical duration at that tempo — no extra hold time needed.
+4. **Given** tempo is set to a normal value (e.g., 120 BPM), **When** the musician plays any note, **Then** note detection behaviour is unchanged from before this fix.
+
+---
+
+### User Story 2 - Consistent Detection Across All Note Values at Ultra-Low Tempos (Priority: P2)
+
+At ultra-low tempos, all note durations (whole, half, quarter, eighth) should be detected with the same proportional accuracy. The bug should not be limited to whole notes — any note that spans a long real-time duration should be detected correctly.
+
+**Why this priority**: If only one note value is fixed, musicians still encounter unpredictable detection at other durations, undermining trust in the system at slow tempos.
+
+**Independent Test**: At 10 BPM, play a quarter note, half note, and whole note in sequence. All three should be detected and accepted at the expected musical moment.
+
+**Acceptance Scenarios**:
+
+1. **Given** tempo is 10 BPM, **When** the musician plays a quarter note (6 seconds), **Then** it is detected correctly after ~6 seconds.
+2. **Given** tempo is 10 BPM, **When** the musician plays a half note (12 seconds), **Then** it is detected correctly after ~12 seconds.
+3. **Given** tempo is 10 BPM, **When** the musician plays a whole note (24 seconds), **Then** it is detected correctly after ~24 seconds.
+4. **Given** tempo is 10 BPM, **When** any note ends at a measure boundary, **Then** detection accuracy is the same as for notes ending mid-measure.
+
+---
+
+### Edge Cases
+
+- What happens when the musician releases a note just before the required duration at ultra-low tempo? The system should apply the same early-release tolerance as at normal tempos, scaled proportionally.
+- What happens when tempo changes mid-session from ultra-low to normal? Detection thresholds should adjust immediately for subsequent notes.
+- What happens at exactly 20 BPM (the boundary of the reported failure range)? Detection should work correctly at and around this threshold.
+- What happens with tied notes spanning multiple measures at ultra-low tempo? The full combined duration should be required, not each measure separately.
+- What happens if the musician holds a note past its required duration at ultra-low tempo? The note should be accepted at the correct time and not penalised for over-holding.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Note detection thresholds MUST scale proportionally with the current tempo so that the required hold time in real seconds equals the note's musical duration at that tempo.
+- **FR-002**: The note detection system MUST NOT use a fixed wall-clock timeout that is calibrated for normal tempos (e.g., 60–180 BPM) and applied unchanged at ultra-low tempos (< 20 BPM).
+- **FR-003**: All note durations (whole, half, quarter, eighth, and shorter) MUST be detected correctly at all tempos in the supported range (10–300 BPM).
+- **FR-004**: Notes positioned at the end of a measure MUST be detected with the same accuracy as notes positioned mid-measure, at any tempo.
+- **FR-005**: The fix MUST NOT regress note detection accuracy or latency at normal tempos (60–180 BPM).
+- **FR-006**: Early-release tolerance (if any) MUST be proportional to the note duration at the current tempo, not a fixed absolute value.
+
+### Assumptions
+
+- "Detected correctly" means the note is accepted within ≤ 500 ms of the note's musical end time (its onset time plus its theoretical duration at the current tempo).
+- The bug is isolated to the note detection/validation layer, not to audio input capture.
+- The supported tempo range is 10–300 BPM, consistent with the metronome fix in spec 085.
+- Normal tempo behaviour (60–180 BPM) must remain unchanged — no regressions.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: At 10 BPM, a whole note is accepted within ≤ 500 ms of its theoretical musical end (24 seconds after onset), with no requirement to hold it beyond that point.
+- **SC-002**: At 10 BPM, detection latency for a quarter note, half note, and whole note each fall within ≤ 500 ms of their respective expected musical durations.
+- **SC-003**: At 120 BPM, note detection latency and accuracy are unchanged compared to the pre-fix baseline — zero regressions at normal tempos.
+- **SC-004**: Notes at the end of a measure are detected with the same ≤ 500 ms tolerance as notes mid-measure, at any tempo in 10–300 BPM.
+
+## Known Issues & Regression Tests *(if applicable)*
+
+### Issue #1: Long Notes at Measure End Require Excessive Hold Time at Ultra-Low Tempos
+
+**Discovered**: 2026-04-26 during user testing
+
+**Symptom**: At tempos below 20 BPM, notes positioned at the end of a measure (especially long values like whole or half notes) are not detected as correctly played until the musician has held them for significantly longer than their musical duration requires. The detection appears to use a fixed timeout not scaled to the current tempo.
+
+**Root Cause**: To be determined during implementation — likely a hardcoded or insufficiently tempo-scaled duration threshold in the note detection/validation logic, causing the acceptance window to be calibrated for normal tempos and therefore far too long in absolute terms at ultra-low tempos.
+
+**Affected Components**: Note detection / score validation layer (frontend).
+
+**Regression Test**: To be created — unit test asserting that at 10 BPM, a whole-note detection fires within ≤ 500 ms of the 24-second mark, and at 120 BPM, detection timing is unchanged.
+

--- a/specs/086-fix-note-detection-slow-tempo/tasks.md
+++ b/specs/086-fix-note-detection-slow-tempo/tasks.md
@@ -1,0 +1,242 @@
+# Tasks: Fix Note Detection at Ultra-Low Tempos
+
+**Branch**: `086-fix-note-detection-slow-tempo`
+**Spec**: `specs/086-fix-note-detection-slow-tempo/spec.md`
+**Stack**: TypeScript (React + Vitest), `frontend/plugins/practice-view-plugin/`
+
+**Root Cause Summary** (identified via code reading before task generation):
+
+Two tempo-unscaled thresholds in the hold-detection pipeline combine to violate the ≤ 500 ms acceptance tolerance at ultra-low tempos:
+
+1. **Tick-based hold gate** (`usePracticeMidi.ts` line 284):
+   `effectiveDurTicks > PPQ` — silently skips hold enforcement for any note ≤ 1 quarter-note in ticks.
+   At 10 BPM a quarter note = 6 000 ms, but the gate returns `requiredHoldMs = 0` → note accepted
+   immediately on press instead of after 6 seconds.
+
+2. **Fixed 90 % hold-completion threshold** (`useHoldProgress.ts`):
+   `progress >= 0.9` fires HOLD_COMPLETE 10 % early in relative terms. For a 24 000 ms whole note
+   (10 BPM) that is 2 400 ms early — violating SC-001's ≤ 500 ms requirement. The same rule fires
+   only 200 ms early at 120 BPM (fine), so the bug is invisible at normal tempos.
+
+**Affected files**:
+- `frontend/plugins/practice-view-plugin/usePracticeMidi.ts` — hold gate + hold-ms calculation
+- `frontend/plugins/practice-view-plugin/useHoldProgress.ts` — 90 % completion threshold
+- Test files: `usePracticeMidi.test.ts`, `useHoldProgress.test.ts`
+
+**Unchanged files**: `practiceEngine.ts`, `practiceEngine.types.ts` (no hold logic lives there)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Extract the hold-duration formula into a named export so it can be unit-tested in
+isolation before its surrounding gate condition is changed.
+
+- [ ] T001 Extract `computeRequiredHoldMs(durationTicks: number, bpm: number): number` and
+  `HOLD_FLOOR_MS: number` as named exports from
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.ts`;
+  the function returns `(durationTicks / ((bpm / 60) * 960)) * 1000` when `bpm > 0`,
+  else `0`; leave all existing behaviour intact
+
+---
+
+## Phase 2: Foundational (TDD RED Gate)
+
+**Purpose**: Write the two key failing tests that prove the bugs are real and observable, before
+changing any implementation code.
+
+⚠️ **CRITICAL — TDD GATE**: Both tasks below MUST be committed as RED (failing) tests before
+any implementation work begins in Phase 3. Do not proceed to Phase 3 until both tests fail.
+
+- [ ] T002 [P] Write failing test in
+  `frontend/plugins/practice-view-plugin/useHoldProgress.test.ts`:
+  mock `requestAnimationFrame` with `vi.useFakeTimers()`; for `requiredHoldMs = 24_000`
+  (whole note at 10 BPM), assert HOLD_COMPLETE is dispatched only after ≥ 23 500 ms —
+  the current 90 % rule dispatches at 21 600 ms so this test MUST be RED
+
+- [ ] T003 [P] Write failing test in
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
+  at 10 BPM (`playerState.bpm = 10`), a quarter note (`durationTicks = 960`) should dispatch
+  `CORRECT_MIDI` with `requiredHoldMs = 6_000`; the current `effectiveDurTicks > PPQ` gate
+  returns `requiredHoldMs = 0` so this test MUST be RED
+
+**Checkpoint**: Run `pnpm test --run` in `frontend/`. T002 and T003 are RED. Proceed to Phase 3.
+
+---
+
+## Phase 3: User Story 1 — Long Notes at Measure End Detected Promptly at Ultra-Low Tempo (Priority: P1) 🎯 MVP
+
+**Goal**: At 10–20 BPM, whole and half notes (especially at measure end) are accepted within
+≤ 500 ms of their theoretical musical end — no over-holding required.
+
+**Independent Test**: `pnpm test --run` in `frontend/`; T002, T003, T004, T005, T006 are GREEN;
+manual smoke test at 10 BPM: whole note accepted ≈ 23 500 ms after onset.
+
+### Tests for User Story 1 ⚠️ Write FIRST — must be RED before T007/T008
+
+- [ ] T004 [P] [US1] Write failing test in
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
+  at 10 BPM, whole note (`durationTicks = 3_840`, no next-note gap clipping) →
+  `CORRECT_MIDI` dispatched with `requiredHoldMs = 24_000`
+  (currently passes only if the tick-gate allows it; create a note entry where
+  `durationTicks = 3_840` so `effectiveDurTicks = 3_840 > PPQ` — this test IS currently green;
+  confirms the formula is correct and must stay green after T008)
+
+- [ ] T005 [P] [US1] Write failing test in
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
+  at 15 BPM, half note at measure end (`durationTicks = 1_920`) →
+  `requiredHoldMs = 8_000` (= `1920 / ((15/60)*960) * 1000`)
+
+- [ ] T006 [P] [US1] Write failing test in
+  `frontend/plugins/practice-view-plugin/useHoldProgress.test.ts`:
+  for `requiredHoldMs = 24_000`, advance fake timers to 21_600 ms and assert
+  `HOLD_COMPLETE` has NOT yet fired; advance to 23_500 ms and assert it HAS fired
+  (this test is RED because the current 90 % rule fires at 21 600 ms)
+
+### Implementation for User Story 1
+
+- [ ] T007 [US1] Fix hold-completion threshold in
+  `frontend/plugins/practice-view-plugin/useHoldProgress.ts`:
+  replace `if (progress >= 0.9)` with
+  ```
+  const acceptanceMs = required - Math.min(required * 0.1, 500);
+  if (elapsed >= acceptanceMs)
+  ```
+  This keeps the 90 % rule for short notes (< 5 000 ms) where 10 % < 500 ms,
+  and caps the early-acceptance at 500 ms for long notes (≥ 5 000 ms);
+  update the `progress` computation accordingly (`elapsed / required` can stay for the UI bar)
+
+- [ ] T008 [US1] Fix hold-gate condition in
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.ts`:
+  replace `bpm > 0 && effectiveDurTicks > PPQ` with
+  `computeRequiredHoldMs(effectiveDurTicks, bpm) > HOLD_FLOOR_MS`
+  so the gate is time-based rather than tick-based;
+  set `HOLD_FLOOR_MS = 500` (notes whose wall-clock duration ≤ 500 ms need no hold)
+
+**Checkpoint**: T002 – T006 are GREEN. US1 is independently testable.
+
+---
+
+## Phase 4: User Story 2 — Consistent Detection Across All Note Values at Ultra-Low Tempos (Priority: P2)
+
+**Goal**: Quarter notes, half notes, and whole notes all enforce proportional holds at 10 BPM —
+not just notes longer than 1 quarter-note in ticks.
+
+**Independent Test**: `pnpm test --run` in `frontend/`; T009 and T010 are GREEN.
+
+### Tests for User Story 2 ⚠️ Write FIRST — must be RED before T011
+
+- [ ] T009 [P] [US2] Write failing test in
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
+  at 10 BPM, eighth note (`durationTicks = 480`) →
+  `CORRECT_MIDI` dispatched with `requiredHoldMs = 3_000`
+  (currently the tick-gate gives `requiredHoldMs = 0`; RED until T008 is implemented)
+
+- [ ] T010 [P] [US2] Write failing test in
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
+  at 10 BPM, quarter note (`durationTicks = 960`) next to another note (gap = 960 ticks) →
+  `effectiveDurTicks` stays 960 (no clipping since gap == duration) →
+  `requiredHoldMs = 6_000`
+  (verifies the gap-clipping logic does not accidentally suppress the hold for measure-end notes)
+
+### Implementation for User Story 2
+
+- [ ] T011 [US2] Verify `HOLD_FLOOR_MS = 500` (set in T008) is sufficient for sub-quarter-note
+  durations at ultra-low tempos — eighth note @ 10 BPM = 3 000 ms > 500 ms → hold required;
+  no additional code change required if T008 used the correct constant;
+  confirm by running T009 which must now be GREEN
+
+**Checkpoint**: T009 and T010 are GREEN. All note values at 10 BPM enforce proportional holds.
+
+---
+
+## Phase 5: Polish & Regression Tests
+
+**Goal**: Zero regressions at 120 BPM and edge cases from spec covered.
+
+- [ ] T012 [P] Write regression test in
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
+  at 120 BPM, quarter note (`durationTicks = 960`) → `requiredHoldMs = 0`
+  (500 ms is NOT > `HOLD_FLOOR_MS` = 500 ms using strict `>`; behaviour unchanged)
+
+- [ ] T013 [P] Write regression test in
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
+  at 120 BPM, half note (`durationTicks = 1_920`) → `requiredHoldMs = 1_000`
+  (1 000 ms > 500 ms → hold required; formula unchanged from before)
+
+- [ ] T014 [P] Write regression test in
+  `frontend/plugins/practice-view-plugin/useHoldProgress.test.ts`:
+  for `requiredHoldMs = 2_000` (120 BPM whole note), HOLD_COMPLETE fires between
+  1 800 ms and 1 850 ms (90 % rule still binds for T < 5 000 ms; no change)
+
+- [ ] T015 [P] Write regression test in
+  `frontend/plugins/practice-view-plugin/useHoldProgress.test.ts`:
+  for `requiredHoldMs = 1_000` (120 BPM half note), HOLD_COMPLETE fires between
+  900 ms and 950 ms (90 % rule: `1000 - min(100, 500) = 900 ms`)
+
+- [ ] T016 [P] Write edge-case test in
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
+  `computeRequiredHoldMs(3_840, 0)` returns 0 (BPM ≤ 0 guard, no division by zero)
+
+- [ ] T017 [P] Write edge-case test in
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
+  at exactly 20 BPM (spec boundary), quarter note (960 ticks) →
+  `requiredHoldMs = 3_000` (= `(960 / ((20/60)*960)) * 1000`; > 500 ms → hold required)
+
+- [ ] T018 [P] Write edge-case test in
+  `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
+  at 10 BPM, note with next-entry gap smaller than duration (e.g., `durationTicks = 3_840`,
+  `gapTicks = 1_920`) → `effectiveDurTicks = 1_920` (gap-clipped),
+  `requiredHoldMs = 12_000`; confirms clipping still works after T008
+
+- [ ] T019 [P] Write integration smoke test in
+  `frontend/plugins/practice-view-plugin/practiceEngine.test.ts`:
+  dispatch `CORRECT_MIDI` with `requiredHoldMs = 24_000` → engine mode becomes `'holding'` →
+  dispatch `HOLD_COMPLETE` → engine advances with outcome `'correct'`;
+  validates the pipeline end-to-end (no code change to `practiceEngine.ts` needed)
+
+**Checkpoint**: Run `pnpm test --run` in `frontend/`. All tests GREEN. Zero regressions.
+
+---
+
+## Dependencies
+
+```
+T001 (export helpers)
+  └─> T002, T003 (foundational RED tests — require exported symbols)
+        └─> T004, T005, T006 (US1 RED tests)
+              └─> T007 (fix useHoldProgress)
+              └─> T008 (fix usePracticeMidi gate)
+                    └─> T009, T010 (US2 RED tests — depend on new gate logic)
+                          └─> T011 (US2 confirm)
+                                └─> T012–T019 (regression + edge cases)
+```
+
+Stories US1 and US2 share the same two implementation tasks (T007, T008) because the root causes
+are the same two thresholds. US2 adds tests for shorter note values (quarter, eighth) to confirm
+the time-based gate catches them correctly.
+
+## Parallel Execution Examples
+
+Within each story phase, all `[P]`-marked test-writing tasks can run in parallel (different test
+files). Implementation tasks T007 (useHoldProgress.ts) and T008 (usePracticeMidi.ts) touch
+different files and can also be implemented in parallel.
+
+```
+Phase 2 parallel:  T002 ‖ T003
+Phase 3 parallel:  T004 ‖ T005 ‖ T006 → T007 ‖ T008
+Phase 4 parallel:  T009 ‖ T010
+Phase 5 parallel:  T012 ‖ T013 ‖ T014 ‖ T015 ‖ T016 ‖ T017 ‖ T018 ‖ T019
+```
+
+## Implementation Strategy
+
+**MVP scope (just US1 = T001 → T008)**: Fixes the P1 reported bug — whole/half notes at measure
+end at ultra-low tempos are accepted within ≤ 500 ms of their musical end. Already fixes
+most of US2 as a side effect (half notes and whole notes also get the fix via T007).
+
+**US2 addition (T009–T011)**: Adds test coverage for quarter and eighth note hold requirements
+at ultra-low tempos, which the time-based gate in T008 already handles. No new code — only
+test confirmation.
+
+**Phase 5 confirms** no regressions at 120 BPM and covers all spec edge cases.

--- a/specs/086-fix-note-detection-slow-tempo/tasks.md
+++ b/specs/086-fix-note-detection-slow-tempo/tasks.md
@@ -32,7 +32,7 @@ Two tempo-unscaled thresholds in the hold-detection pipeline combine to violate 
 **Purpose**: Extract the hold-duration formula into a named export so it can be unit-tested in
 isolation before its surrounding gate condition is changed.
 
-- [ ] T001 Extract `computeRequiredHoldMs(durationTicks: number, bpm: number): number` and
+- [X] T001 Extract `computeRequiredHoldMs(durationTicks: number, bpm: number): number` and
   `HOLD_FLOOR_MS: number` as named exports from
   `frontend/plugins/practice-view-plugin/usePracticeMidi.ts`;
   the function returns `(durationTicks / ((bpm / 60) * 960)) * 1000` when `bpm > 0`,
@@ -48,13 +48,13 @@ changing any implementation code.
 ⚠️ **CRITICAL — TDD GATE**: Both tasks below MUST be committed as RED (failing) tests before
 any implementation work begins in Phase 3. Do not proceed to Phase 3 until both tests fail.
 
-- [ ] T002 [P] Write failing test in
+- [X] T002 [P] Write failing test in
   `frontend/plugins/practice-view-plugin/useHoldProgress.test.ts`:
   mock `requestAnimationFrame` with `vi.useFakeTimers()`; for `requiredHoldMs = 24_000`
   (whole note at 10 BPM), assert HOLD_COMPLETE is dispatched only after ≥ 23 500 ms —
   the current 90 % rule dispatches at 21 600 ms so this test MUST be RED
 
-- [ ] T003 [P] Write failing test in
+- [X] T003 [P] Write failing test in
   `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
   at 10 BPM (`playerState.bpm = 10`), a quarter note (`durationTicks = 960`) should dispatch
   `CORRECT_MIDI` with `requiredHoldMs = 6_000`; the current `effectiveDurTicks > PPQ` gate
@@ -74,7 +74,7 @@ manual smoke test at 10 BPM: whole note accepted ≈ 23 500 ms after onset.
 
 ### Tests for User Story 1 ⚠️ Write FIRST — must be RED before T007/T008
 
-- [ ] T004 [P] [US1] Write failing test in
+- [X] T004 [P] [US1] Write failing test in
   `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
   at 10 BPM, whole note (`durationTicks = 3_840`, no next-note gap clipping) →
   `CORRECT_MIDI` dispatched with `requiredHoldMs = 24_000`
@@ -82,12 +82,12 @@ manual smoke test at 10 BPM: whole note accepted ≈ 23 500 ms after onset.
   `durationTicks = 3_840` so `effectiveDurTicks = 3_840 > PPQ` — this test IS currently green;
   confirms the formula is correct and must stay green after T008)
 
-- [ ] T005 [P] [US1] Write failing test in
+- [X] T005 [P] [US1] Write failing test in
   `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
   at 15 BPM, half note at measure end (`durationTicks = 1_920`) →
   `requiredHoldMs = 8_000` (= `1920 / ((15/60)*960) * 1000`)
 
-- [ ] T006 [P] [US1] Write failing test in
+- [X] T006 [P] [US1] Write failing test in
   `frontend/plugins/practice-view-plugin/useHoldProgress.test.ts`:
   for `requiredHoldMs = 24_000`, advance fake timers to 21_600 ms and assert
   `HOLD_COMPLETE` has NOT yet fired; advance to 23_500 ms and assert it HAS fired
@@ -95,7 +95,7 @@ manual smoke test at 10 BPM: whole note accepted ≈ 23 500 ms after onset.
 
 ### Implementation for User Story 1
 
-- [ ] T007 [US1] Fix hold-completion threshold in
+- [X] T007 [US1] Fix hold-completion threshold in
   `frontend/plugins/practice-view-plugin/useHoldProgress.ts`:
   replace `if (progress >= 0.9)` with
   ```
@@ -106,7 +106,7 @@ manual smoke test at 10 BPM: whole note accepted ≈ 23 500 ms after onset.
   and caps the early-acceptance at 500 ms for long notes (≥ 5 000 ms);
   update the `progress` computation accordingly (`elapsed / required` can stay for the UI bar)
 
-- [ ] T008 [US1] Fix hold-gate condition in
+- [X] T008 [US1] Fix hold-gate condition in
   `frontend/plugins/practice-view-plugin/usePracticeMidi.ts`:
   replace `bpm > 0 && effectiveDurTicks > PPQ` with
   `computeRequiredHoldMs(effectiveDurTicks, bpm) > HOLD_FLOOR_MS`
@@ -126,13 +126,13 @@ not just notes longer than 1 quarter-note in ticks.
 
 ### Tests for User Story 2 ⚠️ Write FIRST — must be RED before T011
 
-- [ ] T009 [P] [US2] Write failing test in
+- [X] T009 [P] [US2] Write failing test in
   `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
   at 10 BPM, eighth note (`durationTicks = 480`) →
   `CORRECT_MIDI` dispatched with `requiredHoldMs = 3_000`
   (currently the tick-gate gives `requiredHoldMs = 0`; RED until T008 is implemented)
 
-- [ ] T010 [P] [US2] Write failing test in
+- [X] T010 [P] [US2] Write failing test in
   `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
   at 10 BPM, quarter note (`durationTicks = 960`) next to another note (gap = 960 ticks) →
   `effectiveDurTicks` stays 960 (no clipping since gap == duration) →
@@ -141,7 +141,7 @@ not just notes longer than 1 quarter-note in ticks.
 
 ### Implementation for User Story 2
 
-- [ ] T011 [US2] Verify `HOLD_FLOOR_MS = 500` (set in T008) is sufficient for sub-quarter-note
+- [X] T011 [US2] Verify `HOLD_FLOOR_MS = 500` (set in T008) is sufficient for sub-quarter-note
   durations at ultra-low tempos — eighth note @ 10 BPM = 3 000 ms > 500 ms → hold required;
   no additional code change required if T008 used the correct constant;
   confirm by running T009 which must now be GREEN
@@ -154,42 +154,42 @@ not just notes longer than 1 quarter-note in ticks.
 
 **Goal**: Zero regressions at 120 BPM and edge cases from spec covered.
 
-- [ ] T012 [P] Write regression test in
+- [X] T012 [P] Write regression test in
   `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
   at 120 BPM, quarter note (`durationTicks = 960`) → `requiredHoldMs = 0`
   (500 ms is NOT > `HOLD_FLOOR_MS` = 500 ms using strict `>`; behaviour unchanged)
 
-- [ ] T013 [P] Write regression test in
+- [X] T013 [P] Write regression test in
   `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
   at 120 BPM, half note (`durationTicks = 1_920`) → `requiredHoldMs = 1_000`
   (1 000 ms > 500 ms → hold required; formula unchanged from before)
 
-- [ ] T014 [P] Write regression test in
+- [X] T014 [P] Write regression test in
   `frontend/plugins/practice-view-plugin/useHoldProgress.test.ts`:
   for `requiredHoldMs = 2_000` (120 BPM whole note), HOLD_COMPLETE fires between
   1 800 ms and 1 850 ms (90 % rule still binds for T < 5 000 ms; no change)
 
-- [ ] T015 [P] Write regression test in
+- [X] T015 [P] Write regression test in
   `frontend/plugins/practice-view-plugin/useHoldProgress.test.ts`:
   for `requiredHoldMs = 1_000` (120 BPM half note), HOLD_COMPLETE fires between
   900 ms and 950 ms (90 % rule: `1000 - min(100, 500) = 900 ms`)
 
-- [ ] T016 [P] Write edge-case test in
+- [X] T016 [P] Write edge-case test in
   `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
   `computeRequiredHoldMs(3_840, 0)` returns 0 (BPM ≤ 0 guard, no division by zero)
 
-- [ ] T017 [P] Write edge-case test in
+- [X] T017 [P] Write edge-case test in
   `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
   at exactly 20 BPM (spec boundary), quarter note (960 ticks) →
   `requiredHoldMs = 3_000` (= `(960 / ((20/60)*960)) * 1000`; > 500 ms → hold required)
 
-- [ ] T018 [P] Write edge-case test in
+- [X] T018 [P] Write edge-case test in
   `frontend/plugins/practice-view-plugin/usePracticeMidi.test.ts`:
   at 10 BPM, note with next-entry gap smaller than duration (e.g., `durationTicks = 3_840`,
   `gapTicks = 1_920`) → `effectiveDurTicks = 1_920` (gap-clipped),
   `requiredHoldMs = 12_000`; confirms clipping still works after T008
 
-- [ ] T019 [P] Write integration smoke test in
+- [X] T019 [P] Write integration smoke test in
   `frontend/plugins/practice-view-plugin/practiceEngine.test.ts`:
   dispatch `CORRECT_MIDI` with `requiredHoldMs = 24_000` → engine mode becomes `'holding'` →
   dispatch `HOLD_COMPLETE` → engine advances with outcome `'correct'`;


### PR DESCRIPTION
## Summary

Fixes note detection failures at ultra-low tempos (10–20 BPM) in Practice View.

## Root Causes Fixed

### T007 — Hold-completion threshold fires too early at slow tempos
At 10 BPM a whole note = 24 000 ms. The old 90% rule fired HOLD_COMPLETE 2 400 ms early — well beyond the 500 ms tolerance.

**Fix**: Cap early acceptance at 500 ms: `acceptanceMs = required - Math.min(required * 0.1, 500)`

### T008 — Hold gate condition skips enforcement at slow tempos
The old tick-based gate (`effectiveDurTicks > PPQ`) skipped hold enforcement for notes ≤ 1 quarter note in ticks. At 10 BPM a quarter note = 6 000 ms but `requiredHoldMs` returned 0.

**Fix**: Time-based gate — engage hold only when `computeRequiredHoldMs(effectiveDurTicks, bpm) > HOLD_FLOOR_MS` (500 ms).

### Metronome not starting on second practice session
React 18 batches STOP + START dispatches into a single render; the intermediate `'inactive'` state is never seen by effects. `hasCalledFirstNoteRef` was never reset between sessions.

**Fix**: Also reset the guard when mode becomes `'waiting'` (always the start of a new session).

### Metronome stops after first loop (pre-existing, from 085 not being in branch)
The 086 branch was forked from v0.1.217, before the 085 metronome loop fix landed. The `onTransportRestart` handler that re-registers the metronome schedule after a loop-boundary Transport restart was missing.

**Fix**: Rebased onto main (v0.1.219) — 085 fix is now included.

## Tests Added
- 12 unit tests in `usePracticeMidi.test.ts` (was 2)
- 5 unit tests in `useHoldProgress.test.ts` (was 1)
- 1 integration smoke test in `practiceEngine.test.ts`

All 242 practice plugin tests + 507 Rust tests pass.