### PR TITLE
feat(087): sessions rescheduling spec artifacts and copilot instructions update

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -172,6 +172,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-06
 - TypeScript 5.x / React 18 (frontend); Rust stable (backend — no changes needed) + Vite, vitest, Tone.js (audio), wasm-pack (WASM build) (083-one-hand-playback)
 - `localStorage` via `scopedStorage.ts` for session-persistent hand mode (profile-scoped per Constitution VIII); no IndexedDB changes needed (083-one-hand-playback)
 - TypeScript 5.x, React 18+ + Tone.js (Transport scheduling, audio synthesis), Vitest, React Testing Library (085-fix-metronome-issues)
+- TypeScript 5.5+, React 19 + React 19, Vitest 2, @testing-library/react 16, jsdom 24, Vite (build) (087-sessions-rescheduling)
+- IndexedDB (full `Session` objects via `saveSessionToIndexedDB`) + localStorage (lightweight `SessionIndexEntry[]` via `scopedSetItem`) — both already profile-scoped (087-sessions-rescheduling)
 
 - Rust (latest stable 1.75+) + serde 1.0+, serde_json 1.0+ (serialization), thiserror 1.0+ (errors); web framework TBD in contracts phase (axum or actix-web) (001-score-model)
 
@@ -192,9 +194,9 @@ cargo test [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECH
 Rust (latest stable 1.75+): Follow standard conventions
 
 ## Recent Changes
+- 087-sessions-rescheduling: Added TypeScript 5.5+, React 19 + React 19, Vitest 2, @testing-library/react 16, jsdom 24, Vite (build)
 - 085-fix-metronome-issues: Added TypeScript 5.x, React 18+ + Tone.js (Transport scheduling, audio synthesis), Vitest, React Testing Library
 - 083-tempo-metronome-practice: Added TypeScript 5.x (strict), Rust 1.x WASM (no backend changes required) + React 19.2, Tone.js 14.9, Vite 6.x, Vitest 3.x, @testing-library/react, Playwrigh
-- 083-one-hand-playback: Added TypeScript 5.x / React 18 (frontend); Rust stable (backend — no changes needed) + Vite, vitest, Tone.js (audio), wasm-pack (WASM build)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/087-sessions-rescheduling/checklists/requirements.md
+++ b/specs/087-sessions-rescheduling/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Sessions Rescheduling
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-28  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/087-sessions-rescheduling/contracts/reschedule-engine-api.ts
+++ b/specs/087-sessions-rescheduling/contracts/reschedule-engine-api.ts
@@ -1,0 +1,118 @@
+/**
+ * Contract: Reschedule Engine Public API
+ * Feature 087: Sessions Rescheduling
+ *
+ * Defines the public interface of rescheduleEngine.ts —
+ * the pure/async functions that implement all rescheduling logic.
+ * UI components import from this module; no business logic lives in JSX.
+ */
+
+import type { SessionIndexEntry } from '../sessionTypes';
+
+// ---------------------------------------------------------------------------
+// Value types
+// ---------------------------------------------------------------------------
+
+/**
+ * Partition of overdue sessions by linkage type.
+ * Used to populate the auto-reschedule dialog body.
+ */
+export interface RescheduleSummary {
+  /** Overdue sessions that belong to a goal (Session.goalId is set). */
+  goalLinked: SessionIndexEntry[];
+  /** Overdue sessions with no goal association. */
+  isolated: SessionIndexEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Pure detection functions (synchronous)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns all entries where status === 'scheduled' and targetDate < todayISO.
+ *
+ * @param entries   Full localStorage session index (from listSessionsIndex()).
+ * @param todayISO  Current date as "YYYY-MM-DD".
+ */
+export declare function detectOverdueSessions(
+  entries: SessionIndexEntry[],
+  todayISO: string,
+): SessionIndexEntry[];
+
+/**
+ * Partitions overdue sessions into goal-linked vs isolated buckets.
+ */
+export declare function classifyOverdueSessions(
+  overdue: SessionIndexEntry[],
+): RescheduleSummary;
+
+// ---------------------------------------------------------------------------
+// Async mutation functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Reschedules all pending sessions belonging to a goal, starting from todayISO.
+ *
+ * Algorithm:
+ *   1. Load Goal from IndexedDB.
+ *   2. Filter goal.sessionIds to sessions with status === 'scheduled' (pending).
+ *   3. Build adjustedOccupied = globalOccupied minus the goal's own pending targetDates.
+ *   4. findFreeDaysFrom(todayISO, pendingCount, adjustedOccupied).
+ *   5. Update each pending session's targetDate on index + IndexedDB.
+ *
+ * @param goalId          The goal whose sessions to redistribute.
+ * @param globalOccupied  Occupied dates from getOccupiedDates() — modified in-place as new dates are claimed.
+ * @param todayISO        Current date as "YYYY-MM-DD".
+ */
+export declare function rescheduleGoalSessions(
+  goalId: string,
+  globalOccupied: Set<string>,
+  todayISO: string,
+): Promise<void>;
+
+/**
+ * Reschedules a single isolated (non-goal) session to the next free day.
+ *
+ * @param entry    The overdue isolated session index entry.
+ * @param occupied Occupied date set — the new date is added before returning.
+ * @param todayISO Current date as "YYYY-MM-DD".
+ * @returns        The new targetDate assigned to the session.
+ */
+export declare function rescheduleIsolatedSession(
+  entry: SessionIndexEntry,
+  occupied: Set<string>,
+  todayISO: string,
+): Promise<string>;
+
+/**
+ * Top-level orchestrator called when the user accepts the auto-reschedule dialog.
+ *
+ * Order of operations:
+ *   1. Build globalOccupied from getOccupiedDates().
+ *   2. Collect unique goalIds from summary.goalLinked.
+ *   3. For each goalId: rescheduleGoalSessions(...).
+ *   4. For each isolated session: rescheduleIsolatedSession(...).
+ *
+ * @param summary   From classifyOverdueSessions() — drives what gets rescheduled.
+ * @param todayISO  Current date as "YYYY-MM-DD".
+ */
+export declare function applyAutoReschedule(
+  summary: RescheduleSummary,
+  todayISO: string,
+): Promise<void>;
+
+// ---------------------------------------------------------------------------
+// Manual date update (called from date picker onChange)
+// ---------------------------------------------------------------------------
+
+/**
+ * Updates a single session's targetDate (manual calendar pick).
+ * Sets status to 'scheduled' if not already, then persists to index + IndexedDB.
+ *
+ * @param sessionId   ID of the session to update.
+ * @param newDate     New date as "YYYY-MM-DD" (must be >= today; validated by caller via DatePicker min prop).
+ */
+export declare function updateSessionDate(
+  sessionId: string,
+  newDate: string,
+): Promise<void>;

--- a/specs/087-sessions-rescheduling/data-model.md
+++ b/specs/087-sessions-rescheduling/data-model.md
@@ -1,0 +1,158 @@
+# Data Model: Sessions Rescheduling (087)
+
+## Existing Entities (unchanged)
+
+### Session (sessionTypes.ts)
+
+```ts
+interface Session {
+  readonly id: string;
+  readonly profileId?: string;
+  name: string;
+  readonly createdAt: string;
+  status: 'active' | 'closed' | 'scheduled';
+  targetDate?: string;           // ISO date-only "YYYY-MM-DD"
+  tasks: SessionTask[];
+  activities: SessionActivity[];
+  readonly goalId?: string;      // set iff session belongs to a goal
+  readonly availableTime?: number;
+}
+```
+
+**Modified fields**: `targetDate` and `status` are written during rescheduling. Both fields are mutable in the type.
+
+### SessionIndexEntry (sessionTypes.ts)
+
+```ts
+interface SessionIndexEntry {
+  readonly id: string;
+  readonly profileId?: string;
+  name: string;
+  readonly createdAt: string;
+  status: 'active' | 'closed' | 'scheduled';
+  targetDate?: string;           // mirrors Session.targetDate
+  activityCount: number;
+  taskCount: number;
+  allTasksDone: boolean;
+  goalId?: string;               // mirrors Session.goalId for fast lookup
+  totalEstimatedDurationSecs?: number;
+  totalRealTimeSecs?: number;
+}
+```
+
+**Read during**: overdue detection (synchronous, from localStorage).  
+**Written during**: both auto-reschedule and manual date picker update.
+
+### Goal (goalTypes.ts)
+
+```ts
+interface Goal {
+  readonly id: string;
+  readonly profileId?: string;
+  readonly title: string;
+  status: GoalStatus;            // 'active' | 'completed'
+  sessionIds: string[];          // IDs of all sessions linked to this goal
+  // ... other fields unchanged
+}
+```
+
+**Read during**: goal-linked reschedule (to enumerate pending session IDs).  
+**Not written**: goal itself is not modified during rescheduling.
+
+---
+
+## New Pure Functions (rescheduleEngine.ts)
+
+### detectOverdueSessions
+
+```ts
+function detectOverdueSessions(
+  entries: SessionIndexEntry[],
+  todayISO: string,
+): SessionIndexEntry[]
+```
+
+Returns all entries where `status === 'scheduled'` and `targetDate < todayISO`.
+
+### RescheduleSummary
+
+```ts
+interface RescheduleSummary {
+  goalLinked: SessionIndexEntry[];   // overdue sessions with a goalId
+  isolated: SessionIndexEntry[];     // overdue sessions without a goalId
+}
+```
+
+Returned by `classifyOverdueSessions()` to drive the dialog body text.
+
+### classifyOverdueSessions
+
+```ts
+function classifyOverdueSessions(overdue: SessionIndexEntry[]): RescheduleSummary
+```
+
+Partitions overdue sessions into goal-linked vs isolated buckets.
+
+### rescheduleGoalSessions (async)
+
+```ts
+async function rescheduleGoalSessions(
+  goalId: string,
+  overdueSessions: SessionIndexEntry[],
+  globalOccupied: Set<string>,
+  todayISO: string,
+): Promise<void>
+```
+
+1. Load `Goal` from IndexedDB.  
+2. Collect all pending `sessionIds` from the goal (cross-referenced against the index — skip `'closed'` and `'active'` entries).  
+3. Build `adjustedOccupied = globalOccupied` minus the current `targetDate` values of this goal's own pending sessions.  
+4. Call `findFreeDaysFrom(todayISO, pendingCount, adjustedOccupied)`.  
+5. For each pending session, update `targetDate` on both index and IndexedDB.
+
+### rescheduleIsolatedSession (async)
+
+```ts
+async function rescheduleIsolatedSession(
+  entry: SessionIndexEntry,
+  occupied: Set<string>,
+  todayISO: string,
+): Promise<string>   // returns the new targetDate
+```
+
+Finds the next free day, updates the session, returns the new date so the caller can add it to `occupied`.
+
+---
+
+## State Additions (SessionsPlugin.tsx)
+
+| State | Type | Purpose |
+|-------|------|---------|
+| `reschedulePromptDismissedRef` | `useRef<boolean>` | In-memory suppression flag — set after dismiss |
+| `showRescheduleDialog` | `boolean` (useState) | Controls dialog visibility |
+| `rescheduleSummary` | `RescheduleSummary \| null` (useState) | Drives dialog body |
+| `datePickerSessionId` | `string \| null` (useState) | Tracks which session has the date picker open |
+
+---
+
+## Validation Rules
+
+- `targetDate` must be a valid `YYYY-MM-DD` ISO date string (`isValidTargetDate()` already exists in `sessionStorage.ts`).
+- Manual date picker enforces `min = todayISO` at the UI layer.
+- Auto-reschedule only moves `'scheduled'` sessions — never `'active'` or `'closed'`.
+- Completed/skipped tasks within a session are not affected — session-level rescheduling only touches `targetDate` and `status`.
+
+---
+
+## State Transitions
+
+```
+'scheduled' (targetDate in past)
+  → [auto-reschedule accept]  → 'scheduled' (targetDate = future free day)
+  → [manual date pick]        → 'scheduled' (targetDate = selected date ≥ today)
+
+'scheduled' (targetDate in future)
+  → [manual date pick]        → 'scheduled' (new targetDate ≥ today)
+```
+
+No new status values. Status stays `'scheduled'` — the date is what changes.

--- a/specs/087-sessions-rescheduling/plan.md
+++ b/specs/087-sessions-rescheduling/plan.md
@@ -1,0 +1,70 @@
+# Implementation Plan: Sessions Rescheduling
+
+**Branch**: `087-sessions-rescheduling` | **Date**: 2026-04-28 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/087-sessions-rescheduling/spec.md`
+
+## Summary
+
+Add rescheduling capabilities to the sessions plugin. Two stories: (1) when the Sessions view opens and one or more scheduled sessions have a `targetDate` in the past, show a one-time dialog (suppressed for the app session after dismiss) summarising how many sessions will be moved, then on accept bulk-reschedule goal-linked and isolated sessions via `findFreeDays()` logic; (2) when a session is in edit mode, clicking the `targetDate` label opens the existing `DatePicker` component (min=today) to let the user manually pick a new date, transitioning the session to `'scheduled'` status.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.5+, React 19  
+**Primary Dependencies**: React 19, Vitest 2, @testing-library/react 16, jsdom 24, Vite (build)  
+**Storage**: IndexedDB (full `Session` objects via `saveSessionToIndexedDB`) + localStorage (lightweight `SessionIndexEntry[]` via `scopedSetItem`) — both already profile-scoped  
+**Testing**: Vitest + @testing-library/react + jsdom (matching existing plugin test setup)  
+**Target Platform**: Tablet PWA — Chrome/Safari/Edge on iPad, Surface, Android tablets  
+**Project Type**: External plugin (`plugins-external/sessions-plugin/`) — TypeScript/React, compiled via esbuild + ZIP, symlinked into `frontend/plugins/` for local dev  
+**Performance Goals**: Auto-reschedule dialog must appear within 1 second of Sessions view open (SC-001); IndexedDB reads are async but the index is already in localStorage so detection is synchronous  
+**Constraints**: Offline-first (no network calls whatsoever); profile-aware (Principle VIII — all session writes go through existing profile-scoped helpers); date picker `min` = today
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Domain-Driven Design | ✅ PASS | Reschedule logic extracted as pure functions (`rescheduleEngine.ts`); no business logic in JSX |
+| II. Hexagonal Architecture | N/A | Backend-only principle; plugin is frontend only |
+| III. PWA / Offline-First | ✅ PASS | All operations use existing IndexedDB + localStorage helpers — no network calls |
+| IV. Precision & Fidelity | N/A | No music timing involved |
+| V. Test-First Development | ✅ REQUIRED | New pure functions in `rescheduleEngine.ts` get unit tests before implementation; UI interaction tested with @testing-library/react |
+| VI. Layout Engine Authority | N/A | No spatial/rendering changes |
+| VII. Regression Prevention | ✅ REQUIRED | Edge cases (all goal sessions past, no free days, mixed session types) must be covered by tests |
+| VIII. User Profile Awareness | ✅ PASS | All persistence goes through `updateSessionIndex` / `saveSessionToIndexedDB` which already profile-scope via `getActiveProfileId()`; `goalStorage` lookups are also profile-scoped |
+
+**Gate result**: PASS — no violations. Proceed to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/087-sessions-rescheduling/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+plugins-external/sessions-plugin/
+├── rescheduleEngine.ts          # NEW: pure reschedule logic (detect overdue, redistribute)
+├── rescheduleEngine.test.ts     # NEW: unit tests for reschedule engine
+├── SessionsPlugin.tsx           # MODIFIED: auto-reschedule dialog + date picker in edit mode
+├── SessionsPlugin.test.tsx      # MODIFIED: add dialog and date picker tests
+├── sessionDistribution.ts       # MODIFIED: export findFreeDaysFrom() (start-date variant)
+├── sessionDistribution.test.ts  # MODIFIED: add tests for findFreeDaysFrom()
+├── sessionStorage.ts            # MODIFIED: export updateSessionTargetDate() helper
+└── i18n.tsx / locales/          # MODIFIED: add i18n keys for reschedule dialog strings
+```
+
+**Structure Decision**: Single plugin directory (`plugins-external/sessions-plugin/`). All changes are self-contained in the external plugin with no backend changes. New business logic goes into a dedicated `rescheduleEngine.ts` to keep `SessionsPlugin.tsx` as a thin orchestrator.
+
+## Complexity Tracking
+
+No complexity violations — feature is contained within a single plugin with no new abstractions beyond what the existing codebase already uses.

--- a/specs/087-sessions-rescheduling/quickstart.md
+++ b/specs/087-sessions-rescheduling/quickstart.md
@@ -1,0 +1,135 @@
+# Quickstart: Sessions Rescheduling (087)
+
+## What This Feature Adds
+
+Two rescheduling capabilities to `plugins-external/sessions-plugin/`:
+
+1. **Auto-reschedule dialog** — shown once per app session on Sessions view open when overdue scheduled sessions are detected.
+2. **Manual date picker** — clicking the date label on a session in edit mode opens the existing `DatePicker` component to pick a new date (min = today).
+
+---
+
+## Files to Create
+
+### `rescheduleEngine.ts`
+
+New file containing all business logic as pure/async functions. Import into `SessionsPlugin.tsx`.
+
+```ts
+// Minimal skeleton — see contracts/reschedule-engine-api.ts for full signatures
+
+export function detectOverdueSessions(entries, todayISO) { ... }
+export function classifyOverdueSessions(overdue) { ... }
+export async function rescheduleGoalSessions(goalId, globalOccupied, todayISO) { ... }
+export async function rescheduleIsolatedSession(entry, occupied, todayISO) { ... }
+export async function applyAutoReschedule(summary, todayISO) { ... }
+export async function updateSessionDate(sessionId, newDate) { ... }
+```
+
+### `rescheduleEngine.test.ts`
+
+Unit tests for all functions above. Must be written **before** implementation (Principle V).
+
+Key test cases:
+- `detectOverdueSessions`: no overdue, some overdue, today boundary (today not overdue)
+- `classifyOverdueSessions`: all goal-linked, all isolated, mixed
+- `rescheduleGoalSessions`: goal with 2 pending sessions redistributed starting today; existing occupied dates skipped; goal's own dates excluded from occupied
+- `rescheduleIsolatedSession`: placed on first free day; occupied set updated
+- `applyAutoReschedule`: end-to-end with mocked storage
+
+---
+
+## Files to Modify
+
+### `sessionDistribution.ts`
+
+Add `findFreeDaysFrom(startISO, numDays, occupiedDates)` — variant of `findFreeDays()` with a configurable start date. Keep the existing `findFreeDays()` unchanged.
+
+### `sessionStorage.ts`
+
+Add `updateSessionTargetDate(id, newDate)` helper that writes `targetDate` + `status: 'scheduled'` to both the localStorage index (via `updateSessionIndex`) and the full session in IndexedDB (via `loadSessionFromIndexedDB` + `saveSessionToIndexedDB`).
+
+### `SessionsPlugin.tsx`
+
+Three changes:
+
+**1. Overdue detection + dialog on mount**
+```tsx
+const reschedulePromptDismissedRef = useRef(false);
+const [showRescheduleDialog, setShowRescheduleDialog] = useState(false);
+const [rescheduleSummary, setRescheduleSummary] = useState<RescheduleSummary | null>(null);
+
+useEffect(() => {
+  if (reschedulePromptDismissedRef.current) return;
+  const todayISO = formatDateOnly(new Date());
+  const overdue = detectOverdueSessions(listSessionsIndex(), todayISO);
+  if (overdue.length > 0) {
+    setRescheduleSummary(classifyOverdueSessions(overdue));
+    setShowRescheduleDialog(true);
+  }
+}, []); // run once on mount
+```
+
+**2. Dialog JSX** (render at top of return, before session list)
+```tsx
+{showRescheduleDialog && rescheduleSummary && (
+  <div className="sessions-plugin__reschedule-dialog" role="dialog" aria-modal="true">
+    <h3>{t('sessions.reschedule_dialog_title')}</h3>
+    <p>{t('sessions.reschedule_dialog_body', {
+      goalCount: new Set(rescheduleSummary.goalLinked.map(s => s.goalId)).size,
+      isolatedCount: rescheduleSummary.isolated.length,
+    })}</p>
+    <button onClick={handleRescheduleAccept}>{t('sessions.reschedule_dialog_accept')}</button>
+    <button onClick={handleRescheduleDismiss}>{t('sessions.reschedule_dialog_dismiss')}</button>
+  </div>
+)}
+```
+
+**3. Date picker in edit mode** (in the session row, where `entry.targetDate` is displayed)
+```tsx
+// Replace the static targetDate span with:
+{entry.targetDate && entry.status === 'scheduled' && editingSessionId === entry.id ? (
+  <DatePicker
+    value={entry.targetDate}
+    min={formatDateOnly(new Date())}
+    onChange={(date) => handleManualReschedule(entry.id, date)}
+    aria-label={t('sessions.change_date_aria')}
+  />
+) : entry.targetDate ? (
+  <span className="sessions-plugin__target-date">
+    📅 {new Date(entry.targetDate + 'T00:00:00').toLocaleDateString(...)}
+  </span>
+) : null}
+```
+
+### `i18n.tsx` + `locales/*.json`
+
+Add the 5 new translation keys from Research R7.
+
+---
+
+## Running Tests
+
+```bash
+cd plugins-external/sessions-plugin
+npm test                          # run all Vitest tests
+npm test -- rescheduleEngine      # run only rescheduleEngine tests
+npm run typecheck                 # verify TypeScript
+```
+
+## Building & Local Dev
+
+```bash
+npm run build                     # produces sessions-plugin.zip in dist/
+npm run dev                       # Vite dev server for isolated plugin testing
+```
+
+---
+
+## Key Invariants
+
+- `detectOverdueSessions` is **synchronous** — reads only the localStorage index.
+- `today` is never considered overdue — `targetDate < todayISO` (strict less-than).
+- `completed` and `skipped` tasks within a session are never touched — session-level rescheduling only changes `targetDate` and `status`.
+- The auto-reschedule dialog appears **at most once** per app session (suppressed by ref after first dismiss or accept).
+- The manual date picker enforces `min = today` via the `DatePicker` component's existing `min` prop.

--- a/specs/087-sessions-rescheduling/research.md
+++ b/specs/087-sessions-rescheduling/research.md
@@ -1,0 +1,118 @@
+# Research: Sessions Rescheduling (087)
+
+All unknowns resolved from direct codebase exploration of `plugins-external/sessions-plugin/`.
+
+---
+
+## R1 — Overdue Session Detection
+
+**Decision**: Use the existing localStorage index (`listSessionsIndex()`) synchronously on Sessions view mount.
+
+**Rationale**: The index is already in localStorage so detection is O(n) with zero async overhead, satisfying SC-001 (dialog within 1 second). An overdue session is any `SessionIndexEntry` where `status === 'scheduled'` and `targetDate < todayISO`.
+
+**Implementation**: New pure function `detectOverdueSessions(entries: SessionIndexEntry[], todayISO: string): SessionIndexEntry[]`.
+
+**Alternatives considered**: Loading full sessions from IndexedDB — rejected because `targetDate` is already mirrored in the index, making a full async load unnecessary.
+
+---
+
+## R2 — findFreeDays Extension
+
+**Decision**: Add `findFreeDaysFrom(startISO: string, numDays: number, occupiedDates: Set<string>): string[]` to `sessionDistribution.ts` alongside the existing `findFreeDays()`.
+
+**Rationale**: The existing `findFreeDays()` always starts from tomorrow. For rescheduling, we may want to start from today (so the first redistributed session can land on today if today is free). Extracting a `startISO` parameter makes both cases possible and keeps the original function unchanged for backward compatibility.
+
+**Implementation**:
+```ts
+export function findFreeDaysFrom(startISO: string, numDays: number, occupiedDates: Set<string>): string[] {
+  const [y, m, d] = startISO.split('-').map(Number);
+  const candidate = new Date(y, m - 1, d);
+  const occupied = new Set(occupiedDates);
+  const result: string[] = [];
+  while (result.length < numDays) {
+    const key = formatDateOnly(candidate);
+    if (!occupied.has(key)) {
+      result.push(key);
+      occupied.add(key);
+    }
+    candidate.setDate(candidate.getDate() + 1);
+  }
+  return result;
+}
+```
+
+**Alternatives considered**: Modifying `findFreeDays()` in-place — rejected to avoid breaking existing callers.
+
+---
+
+## R3 — Goal-Linked Session Redistribution
+
+**Decision**: For each goal touched by an overdue session:
+1. Load the full `Goal` from IndexedDB via `loadGoalFromIndexedDB(goalId)`.
+2. Filter `goal.sessionIds` to pending sessions (`status === 'scheduled'`, not closed, not active).
+3. Build `occupiedDates` from `getOccupiedDates()` **excluding** the goal's own pending sessions' current `targetDate` values (those slots are being vacated).
+4. Call `findFreeDaysFrom(todayISO, pendingCount, adjustedOccupied)` to get new dates.
+5. Update each session: `updateSessionIndex(id, { targetDate: newDate })` + `saveSessionToIndexedDB(...)` with updated `targetDate`.
+
+**Rationale**: This reuses all existing storage helpers. The "exclude own slots" rule matches the clarified answer from session Q3.
+
+**Implementation location**: New file `rescheduleEngine.ts` — pure async function `rescheduleGoalSessions(goalId, allIndexEntries, todayISO): Promise<void>`.
+
+---
+
+## R4 — Isolated Session Redistribution
+
+**Decision**: For each overdue isolated session (no `goalId`):
+1. Find next free day using `findFreeDaysFrom(todayISO, 1, occupiedSoFar)`.
+2. Update `targetDate` on both the index and IndexedDB.
+3. Add the new date to `occupiedSoFar` to avoid double-booking subsequent isolated sessions.
+
+**Rationale**: Simple single-day assignment; `getOccupiedDates()` is the baseline occupied set and is updated incrementally as each isolated session is assigned.
+
+---
+
+## R5 — Manual Date Picker Integration
+
+**Decision**: The existing `DatePicker.tsx` component (Feature 066) is reused directly. It already supports `value`, `min`, and `onChange` props.
+
+**Integration point**: In `SessionsPlugin.tsx`, when rendering the `entry.targetDate` span (line ~633), wrap it in a conditional: if `editingSessionId === entry.id`, render a `<button>` that opens a `<DatePicker>` inline (or in a popover). On `onChange`, call a new `handleRescheduleSession(id, newDate)` handler that calls `updateSessionIndex` + `saveSessionToIndexedDB`.
+
+**Edit mode**: The `editingSessionId` state already exists (set by the "Edit" / "Done" toggle button, shown for non-closed sessions). No new state needed.
+
+**State transition**: When a date changes via the picker, session `status` transitions to `'scheduled'` (FR-010). If the session was already `'scheduled'`, just the date updates. If `'active'`, the status cannot change to `'scheduled'` — the date picker should only appear for non-active sessions (i.e., `status === 'scheduled'`, since `'closed'` sessions have no Edit button).
+
+**Decision — date picker activation scope**: Only `'scheduled'` sessions have an Edit button *and* a `targetDate`, so the date picker naturally applies only to them. Active sessions can have a `targetDate` (preserved from scheduling) but the picker is not appropriate there (session is in progress). The implementation guards: `entry.status === 'scheduled' && editingSessionId === entry.id`.
+
+---
+
+## R6 — Auto-Reschedule Dialog Suppression
+
+**Decision**: An in-memory `useRef<boolean>` flag (`reschedulePromptDismissedRef`) in `SessionsPlugin`. Set to `true` after the user dismisses the dialog. Checked on each mount of the Sessions view component; if `true`, skip showing the dialog.
+
+**Rationale**: React `useRef` persists across re-renders and navigation within the same app session. No localStorage write needed. This correctly satisfies "suppress for the rest of the app session" (Q2 answer B).
+
+---
+
+## R7 — i18n Keys Required
+
+New keys to add to `i18n.tsx` + all locale files (`en`, any existing locales):
+
+| Key | Example value (en) |
+|-----|-------------------|
+| `sessions.reschedule_dialog_title` | `Rescheduling past sessions` |
+| `sessions.reschedule_dialog_body` | `{goalCount} goal-linked session(s) and {isolatedCount} isolated session(s) are in the past.` |
+| `sessions.reschedule_dialog_accept` | `Reschedule` |
+| `sessions.reschedule_dialog_dismiss` | `Skip` |
+| `sessions.change_date_aria` | `Change scheduled date` |
+
+---
+
+## R8 — Post-Design Constitution Re-Check
+
+| Principle | Post-Design Status | Notes |
+|-----------|-------------------|-------|
+| I. DDD | ✅ PASS | `rescheduleEngine.ts` contains pure domain functions; UI is a thin caller |
+| III. PWA | ✅ PASS | All storage via existing IndexedDB/localStorage helpers |
+| V. Test-First | ✅ REQUIRED | `rescheduleEngine.test.ts` covers detection, goal redistribution, isolated redistribution, and edge cases |
+| VII. Regression | ✅ REQUIRED | Edge cases: all sessions past, no free days, mixed types, skipped/completed exclusion |
+| VIII. Profile Awareness | ✅ PASS | `getOccupiedDates()` and `listSessionsIndex()` are already profile-scoped; `loadGoalFromIndexedDB` uses `getActiveProfileId()` index internally |

--- a/specs/087-sessions-rescheduling/spec.md
+++ b/specs/087-sessions-rescheduling/spec.md
@@ -5,6 +5,16 @@
 **Status**: Draft  
 **Input**: User description: "Sessions rescheduling"
 
+## Clarifications
+
+### Session 2026-04-28
+
+- Q: Where are sessions persisted (storage layer)? → A: Local-only — IndexedDB (full session objects) + localStorage (session index). No backend API. Confirmed from `sessionStorage.ts` which uses `openDB()` and `scopedGetItem/SetItem`.
+- Q: Should the auto-reschedule dialog re-appear if the user dismisses it, navigates away, then returns to the Sessions view in the same app session? → A: No — suppress for the rest of the app session using an in-memory flag (e.g. a React ref). No persistence needed.
+- Q: What is the spacing rule for redistributing goal-linked sessions during auto-reschedule? → A: Reuse `findFreeDays()` logic — skip all occupied days (active + scheduled), but exclude the current dates of the goal's own sessions being rescheduled (since those slots are being vacated).
+- Q: Should the manual date picker restrict past dates? → A: Yes — set `min` to today. Prevents scheduling sessions in the past, avoiding an immediate re-trigger of the auto-reschedule dialog.
+- Q: Should the auto-reschedule dialog display a summary of what will change before the user accepts? → A: Yes — show a concise count summary (e.g. "2 goal sessions, 1 isolated session") so the user can make an informed decision before accepting the bulk action.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Auto-Reschedule Past Sessions on View Open (Priority: P1)
@@ -17,7 +27,7 @@ When a user opens the Sessions view, the system automatically scans for sessions
 
 **Acceptance Scenarios**:
 
-1. **Given** the user has sessions scheduled in the past, **When** they open the Sessions view, **Then** a dialog appears asking if they want to auto-reschedule past sessions.
+1. **Given** the user has sessions scheduled in the past, **When** they open the Sessions view, **Then** a dialog appears showing a summary of past sessions to reschedule (e.g. "2 goal-linked sessions, 1 isolated session") and asking if they want to auto-reschedule them.
 2. **Given** the dialog is shown, **When** the user dismisses it, **Then** no sessions are modified and the dialog closes.
 3. **Given** the dialog is shown and past sessions include goal-linked sessions, **When** the user accepts, **Then** all pending sessions for those goals are rescheduled starting from today, preserving their relative ordering.
 4. **Given** the dialog is shown and past sessions include isolated (non-goal) sessions, **When** the user accepts, **Then** those sessions are moved to the next available day.
@@ -46,7 +56,7 @@ When a session is in edit mode, the user can tap or click the date displayed jus
 
 ### Edge Cases
 
-- What happens when a goal has all its sessions in the past with no future sessions remaining? All pending sessions for the goal are redistributed starting from today.
+- What happens when a goal has all its sessions in the past with no future sessions remaining? All pending sessions for the goal are redistributed starting from today using free-day allocation, excluding the goal's own (vacated) dates from the occupied set.
 - What happens when there are no available days for isolated sessions (all near-future days are fully booked)? The system places the session on the earliest unoccupied day within a reasonable future window, or at the end of the queue.
 - How does the system handle sessions already marked "Completed"? They are never rescheduled — completed sessions are immutable.
 - What if a user accepts auto-reschedule and then manually changes a date via the calendar? The manually selected date takes precedence.
@@ -57,13 +67,15 @@ When a session is in edit mode, the user can tap or click the date displayed jus
 ### Functional Requirements
 
 - **FR-001**: The system MUST detect sessions with a scheduled date in the past when the Sessions view is opened.
-- **FR-002**: The system MUST display a dialog to the user when one or more past-scheduled sessions are detected on Sessions view open.
+- **FR-002**: The system MUST display a dialog to the user when one or more past-scheduled sessions are detected on Sessions view open, unless the dialog was already dismissed in the current app session.
+- **FR-002a**: The dialog MUST include a concise summary of sessions to be rescheduled, broken down by type (e.g. "2 goal-linked sessions, 1 isolated session").
+- **FR-002b**: Once dismissed, the dialog MUST NOT reappear during the same app session (controlled via an in-memory flag; no persistence required).
 - **FR-003**: The dialog MUST allow the user to accept auto-rescheduling or dismiss without changes.
-- **FR-004**: On accepting auto-reschedule, goal-linked sessions MUST trigger rescheduling of all pending (non-completed, non-skipped) sessions within the same goal, starting from today and preserving relative order.
+- **FR-004**: On accepting auto-reschedule, goal-linked sessions MUST trigger rescheduling of all pending (non-completed, non-skipped) sessions within the same goal, starting from today and preserving relative order. Free days are computed using `findFreeDays()` logic — skipping all occupied days (active + scheduled sessions) — but the goal's own sessions being rescheduled are excluded from the occupied set (their current dates are treated as vacated).
 - **FR-005**: On accepting auto-reschedule, isolated (non-goal) sessions MUST be moved to the next available day.
 - **FR-006**: Completed or skipped sessions MUST NOT be rescheduled under any circumstances.
 - **FR-007**: When a session is in edit mode, the scheduled date displayed below the session title MUST be interactive (tappable/clickable).
-- **FR-008**: Clicking the date in edit mode MUST open a calendar date picker.
+- **FR-008**: Clicking the date in edit mode MUST open a calendar date picker with `min` set to today's date, preventing selection of past dates.
 - **FR-009**: Selecting a date from the calendar MUST update the session's scheduled date to the selected value.
 - **FR-010**: When a session's date is changed via the calendar picker, the session's state MUST transition to "Scheduled".
 - **FR-011**: If the user dismisses the calendar without selecting a date, the session MUST remain unchanged.
@@ -71,7 +83,7 @@ When a session is in edit mode, the user can tap or click the date displayed jus
 
 ### Key Entities
 
-- **Session**: A scheduled practice unit with a date, a state (Scheduled, Completed, Skipped), and a list of tasks. May be linked to a Goal or standalone (isolated).
+- **Session**: A scheduled practice unit with a `targetDate` (ISO date, e.g. `"2026-04-15"`), a status (`'active' | 'closed' | 'scheduled'`), and a list of tasks. May be linked to a Goal or standalone (isolated). Persisted in IndexedDB; indexed in localStorage.
 - **Goal**: A collection of related sessions that together accomplish a practice objective; sessions within a goal share a sequential ordering.
 - **Isolated Session**: A session not linked to any goal; rescheduled independently to the next available day.
 - **Available Day**: A future calendar day that does not already have a session scheduled for the user.

--- a/specs/087-sessions-rescheduling/spec.md
+++ b/specs/087-sessions-rescheduling/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: Sessions Rescheduling
+
+**Feature Branch**: `087-sessions-rescheduling`  
+**Created**: 2026-04-28  
+**Status**: Draft  
+**Input**: User description: "Sessions rescheduling"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Auto-Reschedule Past Sessions on View Open (Priority: P1)
+
+When a user opens the Sessions view, the system automatically scans for sessions whose scheduled date is in the past. If any are found, a dialog is presented offering to auto-reschedule them. The user can accept or dismiss. On acceptance, the system applies the appropriate rescheduling strategy for each session: goal-linked sessions have all pending sessions for the goal redistributed starting from today; isolated sessions are simply moved to the next available day.
+
+**Why this priority**: This is the core user-facing need — stale scheduled sessions cause confusion and friction. Auto-detection and bulk rescheduling on view open is the primary value of this feature.
+
+**Independent Test**: Can be fully tested by creating sessions in the past (both goal-linked and isolated), opening the Sessions view, and verifying the dialog appears with correct options and that accepting it reschedules sessions as expected.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has sessions scheduled in the past, **When** they open the Sessions view, **Then** a dialog appears asking if they want to auto-reschedule past sessions.
+2. **Given** the dialog is shown, **When** the user dismisses it, **Then** no sessions are modified and the dialog closes.
+3. **Given** the dialog is shown and past sessions include goal-linked sessions, **When** the user accepts, **Then** all pending sessions for those goals are rescheduled starting from today, preserving their relative ordering.
+4. **Given** the dialog is shown and past sessions include isolated (non-goal) sessions, **When** the user accepts, **Then** those sessions are moved to the next available day.
+5. **Given** the Sessions view is opened, **When** there are no past sessions, **Then** no dialog appears.
+6. **Given** the dialog is shown, **When** past sessions include a mix of goal-linked and isolated sessions, **Then** both rescheduling strategies are applied correctly to each respective session type.
+
+---
+
+### User Story 2 - Manual Reschedule via In-Session Date Picker (Priority: P2)
+
+When a session is in edit mode, the user can tap or click the date displayed just below the session title to open a calendar date picker. Selecting a new date reschedules that individual session and transitions it to "Scheduled" state.
+
+**Why this priority**: Provides fine-grained control when the automatic approach doesn't meet the user's needs, or when the user wants to set a specific date for a single session.
+
+**Independent Test**: Can be fully tested by opening a session in edit mode, clicking the date label below the title, selecting a date in the calendar, and verifying the session's date updates and its state changes to "Scheduled".
+
+**Acceptance Scenarios**:
+
+1. **Given** a session is in edit mode, **When** the user clicks/taps the date shown below the session title, **Then** a calendar date picker opens.
+2. **Given** the calendar is open, **When** the user selects a date, **Then** the session's scheduled date is updated to the selected date and the calendar closes.
+3. **Given** the user selects a new date, **When** the date differs from the original, **Then** the session's state transitions to "Scheduled".
+4. **Given** the calendar is open, **When** the user dismisses it without selecting a date, **Then** the session's date and state remain unchanged.
+5. **Given** a session is NOT in edit mode, **When** the user views the session, **Then** clicking the date does not open a calendar (date is not an interactive control).
+
+---
+
+### Edge Cases
+
+- What happens when a goal has all its sessions in the past with no future sessions remaining? All pending sessions for the goal are redistributed starting from today.
+- What happens when there are no available days for isolated sessions (all near-future days are fully booked)? The system places the session on the earliest unoccupied day within a reasonable future window, or at the end of the queue.
+- How does the system handle sessions already marked "Completed"? They are never rescheduled — completed sessions are immutable.
+- What if a user accepts auto-reschedule and then manually changes a date via the calendar? The manually selected date takes precedence.
+- What happens to "Skipped" sessions? Treated as non-pending — not rescheduled by the auto-reschedule flow.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST detect sessions with a scheduled date in the past when the Sessions view is opened.
+- **FR-002**: The system MUST display a dialog to the user when one or more past-scheduled sessions are detected on Sessions view open.
+- **FR-003**: The dialog MUST allow the user to accept auto-rescheduling or dismiss without changes.
+- **FR-004**: On accepting auto-reschedule, goal-linked sessions MUST trigger rescheduling of all pending (non-completed, non-skipped) sessions within the same goal, starting from today and preserving relative order.
+- **FR-005**: On accepting auto-reschedule, isolated (non-goal) sessions MUST be moved to the next available day.
+- **FR-006**: Completed or skipped sessions MUST NOT be rescheduled under any circumstances.
+- **FR-007**: When a session is in edit mode, the scheduled date displayed below the session title MUST be interactive (tappable/clickable).
+- **FR-008**: Clicking the date in edit mode MUST open a calendar date picker.
+- **FR-009**: Selecting a date from the calendar MUST update the session's scheduled date to the selected value.
+- **FR-010**: When a session's date is changed via the calendar picker, the session's state MUST transition to "Scheduled".
+- **FR-011**: If the user dismisses the calendar without selecting a date, the session MUST remain unchanged.
+- **FR-012**: The date control MUST only be interactive when the session is in edit mode.
+
+### Key Entities
+
+- **Session**: A scheduled practice unit with a date, a state (Scheduled, Completed, Skipped), and a list of tasks. May be linked to a Goal or standalone (isolated).
+- **Goal**: A collection of related sessions that together accomplish a practice objective; sessions within a goal share a sequential ordering.
+- **Isolated Session**: A session not linked to any goal; rescheduled independently to the next available day.
+- **Available Day**: A future calendar day that does not already have a session scheduled for the user.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users with past sessions see the auto-reschedule dialog within 1 second of opening the Sessions view, 100% of the time.
+- **SC-002**: After accepting auto-reschedule, no sessions remain with a scheduled date in the past.
+- **SC-003**: Users can manually change a session's date in 3 interactions or fewer (enter edit mode → click date → select date).
+- **SC-004**: 100% of sessions changed via the calendar correctly reflect the "Scheduled" state after the change.
+- **SC-005**: Auto-rescheduling correctly preserves goal session ordering — no pending goal session ends up scheduled before a previously completed session.
+
+## Known Issues & Regression Tests *(if applicable)*
+
+*None at this time. This section will be updated during development and testing.*
+

--- a/specs/087-sessions-rescheduling/tasks.md
+++ b/specs/087-sessions-rescheduling/tasks.md
@@ -1,0 +1,173 @@
+# Tasks: Sessions Rescheduling
+
+**Input**: Design documents from `/specs/087-sessions-rescheduling/`
+**Prerequisites**: plan.md ✅ spec.md ✅ research.md ✅ data-model.md ✅ contracts/ ✅ quickstart.md ✅
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no deps on incomplete tasks)
+- **[Story]**: User story label — US1 or US2
+- All paths relative to repo root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create new file skeleton before any implementation begins.
+
+- [x] T001 Create `plugins-external/sessions-plugin/rescheduleEngine.ts` with exported function stubs matching `contracts/reschedule-engine-api.ts` (all functions throw `'not implemented'`)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared utilities required by both user stories. All tasks touch different files and can run in parallel.
+
+**⚠️ CRITICAL**: Both user stories depend on these. Complete Phase 2 before starting Phase 3 or 4 implementation.
+
+- [x] T002 [P] Add `findFreeDaysFrom(startISO: string, numDays: number, occupiedDates: Set<string>): string[]` to `plugins-external/sessions-plugin/sessionDistribution.ts` alongside the existing `findFreeDays()` (keep existing function unchanged)
+- [x] T003 [P] Add `findFreeDaysFrom` unit tests to `plugins-external/sessions-plugin/sessionDistribution.test.ts`: start-from-today, skip occupied days, stop when enough days found
+- [x] T004 [P] Add `updateSessionTargetDate(id: string, newDate: string): Promise<void>` helper to `plugins-external/sessions-plugin/sessionStorage.ts` — writes `targetDate` + `status: 'scheduled'` to both localStorage index (`updateSessionIndex`) and IndexedDB (`loadSessionFromIndexedDB` + `saveSessionToIndexedDB`)
+- [x] T005 [P] Add 5 i18n keys to `plugins-external/sessions-plugin/i18n.tsx` and all locale files in `plugins-external/sessions-plugin/locales/`: `sessions.reschedule_dialog_title`, `sessions.reschedule_dialog_body` (with `goalCount`/`isolatedCount` placeholders), `sessions.reschedule_dialog_accept`, `sessions.reschedule_dialog_dismiss`, `sessions.change_date_aria`
+
+**Checkpoint**: Shared utilities ready — both user story phases can now proceed.
+
+---
+
+## Phase 3: User Story 1 — Auto-Reschedule Past Sessions on View Open (Priority: P1) 🎯 MVP
+
+**Goal**: When the Sessions view opens with overdue scheduled sessions, show a one-time dialog (per app session) summarising goal-linked and isolated counts; on accept, bulk-reschedule all pending sessions using `findFreeDaysFrom`.
+
+**Independent Test**: Create sessions in the past (one with `goalId`, one without), open the Sessions view, verify the dialog appears with correct counts; accept — verify all sessions have future `targetDate` values; dismiss — verify no sessions changed. Reload Sessions view after dismiss — verify no dialog.
+
+### Tests for User Story 1
+
+> **Write these FIRST — verify they FAIL before implementing (Constitution Principle V)**
+
+- [x] T006 [P] [US1] Write failing unit tests for `detectOverdueSessions` (no overdue, some overdue, today boundary — today is NOT overdue) and `classifyOverdueSessions` (all goal-linked, all isolated, mixed) in `plugins-external/sessions-plugin/rescheduleEngine.test.ts`
+- [x] T007 [P] [US1] Write failing unit tests for `rescheduleGoalSessions` (2 pending sessions redistributed from today; occupied dates skipped; goal's own dates excluded from occupied set; ordering preserved) in `plugins-external/sessions-plugin/rescheduleEngine.test.ts`
+- [x] T008 [P] [US1] Write failing unit tests for `rescheduleIsolatedSession` (placed on first free day; occupied set updated after assignment) and `applyAutoReschedule` (end-to-end: mocked storage, mixed summary, both strategies applied) in `plugins-external/sessions-plugin/rescheduleEngine.test.ts`
+
+### Implementation for User Story 1
+
+- [x] T009 [US1] Implement `detectOverdueSessions` and `classifyOverdueSessions` in `plugins-external/sessions-plugin/rescheduleEngine.ts` — verify T006 tests pass
+- [x] T010 [US1] Implement `rescheduleGoalSessions` in `plugins-external/sessions-plugin/rescheduleEngine.ts` — loads Goal from IndexedDB, filters pending sessionIds, builds adjustedOccupied (excluding goal's own current targetDates), calls `findFreeDaysFrom`, updates index + IndexedDB for each session — verify T007 tests pass
+- [x] T011 [US1] Implement `rescheduleIsolatedSession` and `applyAutoReschedule` in `plugins-external/sessions-plugin/rescheduleEngine.ts` — verify T008 tests pass
+- [x] T012 [US1] Add `reschedulePromptDismissedRef` (useRef\<boolean\>), `showRescheduleDialog` (useState), `rescheduleSummary` (useState\<RescheduleSummary | null\>), and a mount-only `useEffect` that synchronously checks `listSessionsIndex()` for overdue sessions (using `detectOverdueSessions` + `classifyOverdueSessions`) and sets dialog state in `plugins-external/sessions-plugin/SessionsPlugin.tsx`
+- [x] T013 [US1] Add auto-reschedule dialog JSX to `plugins-external/sessions-plugin/SessionsPlugin.tsx` — rendered above the session list; includes `role="dialog"`, `aria-modal="true"`, summary paragraph using `rescheduleSummary` (unique goal count + isolated count), Accept and Skip buttons
+- [x] T014 [US1] Add `handleRescheduleAccept` (calls `applyAutoReschedule`, then `refreshSessions`, then closes dialog) and `handleRescheduleDismiss` (sets `reschedulePromptDismissedRef.current = true`, closes dialog without modifying sessions) in `plugins-external/sessions-plugin/SessionsPlugin.tsx`
+- [x] T015 [P] [US1] Add `.sessions-plugin__reschedule-dialog` CSS rules (modal overlay positioning, dialog card styling, button row) to `plugins-external/sessions-plugin/SessionsPlugin.css`
+- [x] T016 [P] [US1] Add `SessionsPlugin` tests to `plugins-external/sessions-plugin/SessionsPlugin.test.tsx`: dialog renders when past sessions exist; dialog does NOT render when no past sessions; clicking Skip closes dialog and leaves sessions unchanged; clicking Reschedule triggers `applyAutoReschedule`
+
+**Checkpoint**: User Story 1 fully functional. Auto-reschedule dialog shows, dismisses (suppressed for session), and applies bulk rescheduling correctly.
+
+---
+
+## Phase 4: User Story 2 — Manual Reschedule via In-Session Date Picker (Priority: P2)
+
+**Goal**: When a `'scheduled'` session is in edit mode, the `targetDate` label becomes a clickable `DatePicker` (min=today). Selecting a date updates `targetDate` + confirms `'scheduled'` status.
+
+**Independent Test**: Open a scheduled session in edit mode, click the date label, verify `DatePicker` opens with today as minimum. Select a future date — verify the session's `targetDate` updates and status remains `'scheduled'`. Exit edit mode — verify date label is no longer interactive (click has no effect).
+
+### Tests for User Story 2
+
+> **Write these FIRST — verify they FAIL before implementing (Constitution Principle V)**
+
+- [x] T017 [P] [US2] Write failing unit tests for `updateSessionDate` in `plugins-external/sessions-plugin/rescheduleEngine.test.ts`: updates targetDate in index and IndexedDB; sets status to `'scheduled'`; handles session not found gracefully
+- [x] T018 [P] [US2] Write failing `SessionsPlugin` tests in `plugins-external/sessions-plugin/SessionsPlugin.test.tsx`: `DatePicker` is visible for a `'scheduled'` session in edit mode; `DatePicker` is NOT visible when session is not in edit mode; selecting a date via `DatePicker` triggers the update handler
+
+### Implementation for User Story 2
+
+- [x] T019 [US2] Implement `updateSessionDate` in `plugins-external/sessions-plugin/rescheduleEngine.ts` — calls `updateSessionTargetDate(id, newDate)` from `sessionStorage.ts` — verify T017 tests pass
+- [x] T020 [US2] Replace static `targetDate` span in `plugins-external/sessions-plugin/SessionsPlugin.tsx` with conditional: when `entry.status === 'scheduled' && editingSessionId === entry.id`, render `<DatePicker value={entry.targetDate} min={todayISO} onChange={handleManualReschedule} />` with `aria-label` from `sessions.change_date_aria`; otherwise render the existing static `📅 …` span — verify T018 tests pass
+- [x] T021 [US2] Add `handleManualReschedule(sessionId: string, newDate: string)` callback to `plugins-external/sessions-plugin/SessionsPlugin.tsx` — calls `updateSessionDate`, then `refreshSessions`, then reloads the expanded session if it is in `loadedSessions`
+
+**Checkpoint**: User Stories 1 and 2 are both independently functional.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+- [x] T022 [P] Run `npm run typecheck` in `plugins-external/sessions-plugin/` — fix any TypeScript errors introduced by new types/imports
+- [x] T023 [P] Run `npm test` in `plugins-external/sessions-plugin/` — all tests (rescheduleEngine, sessionDistribution, SessionsPlugin) must pass
+- [x] T024 Run `npm run build` in `plugins-external/sessions-plugin/` — verify ZIP artifact builds without errors
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1 (Setup)
+  └─> Phase 2 (Foundational) — T002–T005 in parallel
+        └─> Phase 3 (US1) — tests T006–T008 in parallel, then implementation T009→T010→T011→T012→T013→T014, T015/T016 parallel
+        └─> Phase 4 (US2) — tests T017–T018 in parallel, then T019→T020→T021
+              └─> Phase 5 (Polish) — T022/T023 in parallel, then T024
+```
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Phase 2 only. Independent — no dep on US2.
+- **US2 (P2)**: Depends on Phase 2 (`updateSessionTargetDate` from T004) and US1 completion (`updateSessionDate` extends `rescheduleEngine.ts`). Can begin test writing (T017–T018) in parallel with US1 implementation.
+
+### Within Each User Story
+
+- Tests (T006–T008, T017–T018) must be written and failing **before** implementation starts.
+- Engine implementations (T009, T010, T011, T019) must be sequential — each adds functions to `rescheduleEngine.ts`.
+- `SessionsPlugin.tsx` changes (T012, T013, T014, T020, T021) must be sequential — same file.
+- CSS (T015) and test additions (T016, T018) are parallel to each other and to `SessionsPlugin.tsx` changes.
+
+### Parallel Execution Examples
+
+**Phase 2** (all parallel):
+```
+T002 (sessionDistribution.ts) ‖ T003 (sessionDistribution.test.ts) ‖ T004 (sessionStorage.ts) ‖ T005 (i18n)
+```
+
+**Phase 3 tests** (all parallel, start after T001):
+```
+T006 ‖ T007 ‖ T008
+```
+
+**Phase 3 implementation** (sequential for same file, parallel for different files):
+```
+T009 → T010 → T011 → T012 → T013 → T014
+T015 ‖ T016  (parallel to T012–T014)
+```
+
+**Phase 4**:
+```
+T017 ‖ T018  (parallel, write before T019)
+T019 → T020 → T021
+```
+
+---
+
+## Implementation Strategy
+
+### MVP Scope (Phase 1 + 2 + 3 only)
+
+Complete Phase 3 (US1) first — it delivers the primary value (auto-reschedule on view open). This can ship independently before the manual date picker (US2).
+
+### Incremental Delivery Order
+
+1. Phase 1 + 2: File skeleton + shared utilities (no visible change to users)
+2. Phase 3: Auto-reschedule dialog fully working ← **shippable MVP**
+3. Phase 4: Manual date picker added ← **full feature**
+4. Phase 5: Final verification pass
+
+---
+
+## Format Validation
+
+- Total tasks: **24**
+- US1 tasks: 11 (T006–T016)
+- US2 tasks: 5 (T017–T021)
+- Foundational tasks: 4 (T002–T005)
+- Setup tasks: 1 (T001)
+- Polish tasks: 3 (T022–T024)
+- All tasks: ✅ checkbox + ID + [P/Story labels] + file path
+- Parallel opportunities identified: Phase 2 (4-way), Phase 3 tests (3-way), Phase 4 tests (2-way), Phase 5 (2-way)
+- Independent test criteria: defined per story
+- MVP scope: Phase 1 + 2 + 3 (US1 auto-reschedule dialog)


### PR DESCRIPTION
Adds spec artifacts for feature 087 (sessions rescheduling) and updates copilot instructions with new tech stack entries.

Plugin implementation (rescheduling engine, DatePicker portal fix, auto-expand active session on open) is in graditone-pro-plugins PR #47.