### PR TITLE
feat(089): violin accompaniment plays during practice step-by-step mode

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -176,6 +176,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-06
 - localStorage (profile-scoped via `scopedSetItem`) — per-instrument volumes only (088-piano-violin-playback)
 - TypeScript 5.5+, React 19 + React 19, Vitest 2, @testing-library/react 16, jsdom 24, Vite (build) (087-sessions-rescheduling)
 - IndexedDB (full `Session` objects via `saveSessionToIndexedDB`) + localStorage (lightweight `SessionIndexEntry[]` via `scopedSetItem`) — both already profile-scoped (087-sessions-rescheduling)
+- TypeScript 5.x (React 18+); no Rust/WASM changes + React 18+, Vite, Tone.js, Plugin API (`PluginScorePlayerContext`), `ToneAdapter`/`PlaybackChannel` (Feature 088) (089-piano-violin-practice)
+- Page-session module state only — no `localStorage`, no `IndexedDB` (089-piano-violin-practice)
 
 - Rust (latest stable 1.75+) + serde 1.0+, serde_json 1.0+ (serialization), thiserror 1.0+ (errors); web framework TBD in contracts phase (axum or actix-web) (001-score-model)
 
@@ -196,10 +198,9 @@ cargo test [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECH
 Rust (latest stable 1.75+): Follow standard conventions
 
 ## Recent Changes
+- 089-piano-violin-practice: Added TypeScript 5.x (React 18+); no Rust/WASM changes + React 18+, Vite, Tone.js, Plugin API (`PluginScorePlayerContext`), `ToneAdapter`/`PlaybackChannel` (Feature 088)
 - 088-piano-violin-playback: Added Rust (stable 1.75+), TypeScript 5, React 18 + Tone.js (existing), wasm-pack/wasm-bindgen (existing), React 18, Vite
 - 087-sessions-rescheduling: Added TypeScript 5.5+, React 19 + React 19, Vitest 2, @testing-library/react 16, jsdom 24, Vite (build)
-- 085-fix-metronome-issues: Added TypeScript 5.x, React 18+ + Tone.js (Transport scheduling, audio synthesis), Vitest, React Testing Library
-- 083-tempo-metronome-practice: Added TypeScript 5.x (strict), Rust 1.x WASM (no backend changes required) + React 19.2, Tone.js 14.9, Vite 6.x, Vitest 3.x, @testing-library/react, Playwrigh
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx
@@ -154,6 +154,11 @@ function createMockContext(
       getCurrentTickLive: () => 0,
       extractPracticeNotes: mockExtractPracticeNotes,
       setPlaybackStaffFilter: vi.fn(),
+      // v11 additions (Feature 089)
+      getInstruments: vi.fn(() => []),
+      setPartVolume: vi.fn(),
+      getAccompanimentNotesAtTick: vi.fn(() => []),
+      playAccompanimentAtTick: vi.fn(),
     },
     metronome: {
       toggle: vi.fn().mockResolvedValue(undefined),

--- a/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
+++ b/frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx
@@ -38,6 +38,7 @@ import { usePracticeMidi } from './usePracticeMidi';
 import { usePracticeHighlights } from './usePracticeHighlights';
 import { usePhantomTempo } from './usePhantomTempo';
 import { useHoldProgress } from './useHoldProgress';
+import { useAccompaniment } from './useAccompaniment';
 import { useMidiConnectivity } from './useMidiConnectivity';
 import { measureRangeToTicks } from './measureRangeToTicks';
 import { ResultsOverlay } from './ResultsOverlay';
@@ -127,6 +128,10 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
   const [tempoMultiplier, setTempoMultiplier] = useState(1.0);
   const tempoMultiplierRef = useRef(tempoMultiplier);
   tempoMultiplierRef.current = tempoMultiplier;
+
+  // ─── Accompaniment (Feature 089) ───────────────────────────────────────────
+  const { playAccompanimentAtTick } =
+    useAccompaniment(context.scorePlayer);
 
   // ─── Metronome state ───────────────────────────────────────────────────────
   const [metronomeState, setMetronomeState] = useState<MetronomeState>(INITIAL_METRONOME_STATE);
@@ -491,6 +496,11 @@ export function PracticeViewPlugin({ context }: PracticeViewPluginProps) {
     practiceStartTimeRef,
     selectedStaffIndex,
     onFirstNoteAttack,
+    onCorrectNote: (tick) => {
+      // Feature 089: trigger accompaniment (violin etc.) notes aligned with
+      // this practice step. PPQ=960 matches the usePracticeMidi constant.
+      playAccompanimentAtTick(tick, playerState.bpm, 960);
+    },
   });
 
   // ─── Teardown (SC-006) ──────────────────────────────────────────────────────

--- a/frontend/plugins/practice-view-plugin/practiceToolbar.tsx
+++ b/frontend/plugins/practice-view-plugin/practiceToolbar.tsx
@@ -18,7 +18,6 @@ import type { PluginPlaybackStatus, MetronomeSubdivision } from '../../src/plugi
 import { ProfileIcon, computeEffectiveMinMultiplier, MIN_TEMPO_MULTIPLIER, ABSOLUTE_BPM_FLOOR } from '../../src/plugin-api/index';
 import type { PracticeMode } from './practiceEngine.types';
 import { useTranslation } from '../../src/i18n';
-
 // Mirror of PlaybackScheduler.PPQ — no host imports allowed
 const PPQ = 960;
 

--- a/frontend/plugins/practice-view-plugin/useAccompaniment.test.ts
+++ b/frontend/plugins/practice-view-plugin/useAccompaniment.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Feature 089: Tests for useAccompaniment hook.
+ *
+ * Coverage:
+ *   T008 — Fundamental behavior (US1: has accompaniment detection)
+ *   T011 — Regression: piano-only score
+ *   T015 — playAccompanimentAtTick delegates to scorePlayer.playAccompanimentAtTick
+ *   T016 — playAccompanimentAtTick is a no-op when no accompaniment parts
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { PluginScorePlayerContext, PluginInstrumentInfo } from '../../src/plugin-api/types';
+
+// ---------------------------------------------------------------------------
+// useAccompaniment is a practice-plugin hook — import from the plugin dir
+// ---------------------------------------------------------------------------
+
+import { useAccompaniment } from './useAccompaniment';
+
+// ---------------------------------------------------------------------------
+// Test double factory
+// ---------------------------------------------------------------------------
+
+function makeScorePlayer(
+  instruments: PluginInstrumentInfo[] = [],
+): PluginScorePlayerContext {
+  return {
+    getCatalogue: () => [],
+    loadScore: vi.fn(),
+    play: vi.fn(),
+    pause: vi.fn(),
+    stop: vi.fn(),
+    seekToTick: vi.fn(),
+    setPinnedStart: vi.fn(),
+    setLoopEnd: vi.fn(),
+    setTempoMultiplier: vi.fn(),
+    snapToScoreTempo: vi.fn(),
+    subscribe: vi.fn((handler) => {
+      handler({
+        status: 'ready' as const,
+        currentTick: 0,
+        totalDurationTicks: 0,
+        highlightedNoteIds: new Set<string>(),
+        bpm: 120,
+        exactBpm: 120,
+        title: null,
+        error: null,
+        staffCount: 2,
+        timeSignature: { numerator: 4, denominator: 4 },
+        pickupTicks: 0,
+      });
+      return () => {};
+    }),
+    getCurrentTickLive: () => 0,
+    extractPracticeNotes: () => null,
+    getMeasureEndTicks: () => null,
+    rawTickToExpandedTick: (t) => t,
+    getPhrases: () => null,
+    getRegionDifficulty: () => null,
+    getRegionDifficultyForScore: async () => null,
+    setPlaybackStaffFilter: vi.fn(),
+    getInstruments: vi.fn(() => instruments),
+    setPartVolume: vi.fn(),
+    getAccompanimentNotesAtTick: vi.fn(() => []),
+    playAccompanimentAtTick: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// T008 — Fundamental behavior: hasAccompaniment detection
+// ---------------------------------------------------------------------------
+
+describe('useAccompaniment — fundamental behavior (T008)', () => {
+  it('US1: hasAccompaniment=true for violin+piano score', () => {
+    const player = makeScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+    ]);
+    const { result } = renderHook(() => useAccompaniment(player));
+    expect(result.current.hasAccompaniment).toBe(true);
+  });
+
+  it('US1: hasAccompaniment=false for piano-only score', () => {
+    const player = makeScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+    ]);
+    const { result } = renderHook(() => useAccompaniment(player));
+    expect(result.current.hasAccompaniment).toBe(false);
+  });
+
+  it('US1: hasAccompaniment=false when no score loaded (empty instruments)', () => {
+    const player = makeScorePlayer([]);
+    const { result } = renderHook(() => useAccompaniment(player));
+    expect(result.current.hasAccompaniment).toBe(false);
+  });
+
+  it('US1: hasAccompaniment=false when no piano exists (violin-only)', () => {
+    const player = makeScorePlayer([
+      { partIndex: 0, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+    ]);
+    const { result } = renderHook(() => useAccompaniment(player));
+    expect(result.current.hasAccompaniment).toBe(false);
+  });
+
+  it('does NOT call setPartVolume on mount (volume is managed by InstrumentMixerOverlay)', () => {
+    const player = makeScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+    ]);
+    renderHook(() => useAccompaniment(player));
+    expect(player.setPartVolume).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T011 — Regression: piano-only score
+// ---------------------------------------------------------------------------
+
+describe('useAccompaniment — piano-only regression (T011)', () => {
+  it('piano-only score: setPartVolume never called', () => {
+    const player = makeScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+    ]);
+    renderHook(() => useAccompaniment(player));
+    expect(player.setPartVolume).not.toHaveBeenCalled();
+  });
+
+  it('piano-only score: playAccompanimentAtTick does not delegate to scorePlayer', () => {
+    const player = makeScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+    ]);
+    const { result } = renderHook(() => useAccompaniment(player));
+    act(() => { result.current.playAccompanimentAtTick(0, 120, 960); });
+    expect(player.playAccompanimentAtTick).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T015 — playAccompanimentAtTick delegates to scorePlayer API
+// ---------------------------------------------------------------------------
+
+describe('useAccompaniment — playAccompanimentAtTick (T015)', () => {
+  it('calls scorePlayer.playAccompanimentAtTick with tick, bpm, ticksPerBeat', () => {
+    const player = makeScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+    ]);
+    const { result } = renderHook(() => useAccompaniment(player));
+    act(() => { result.current.playAccompanimentAtTick(480, 120, 960); });
+    expect(player.playAccompanimentAtTick).toHaveBeenCalledWith(480, 120, 960);
+  });
+
+  it('passes bpm and ticksPerBeat through unchanged', () => {
+    const player = makeScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+    ]);
+    const { result } = renderHook(() => useAccompaniment(player));
+    act(() => { result.current.playAccompanimentAtTick(1920, 80, 960); });
+    expect(player.playAccompanimentAtTick).toHaveBeenCalledWith(1920, 80, 960);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T016 — no-op when no accompaniment parts
+// ---------------------------------------------------------------------------
+
+describe('useAccompaniment — no-op path (T016)', () => {
+  it('playAccompanimentAtTick is a no-op when hasAccompaniment is false', () => {
+    const player = makeScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+    ]);
+    const { result } = renderHook(() => useAccompaniment(player));
+    act(() => { result.current.playAccompanimentAtTick(9999, 120, 960); });
+    expect(player.playAccompanimentAtTick).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple accompaniment parts
+// ---------------------------------------------------------------------------
+
+describe('useAccompaniment — multiple accompaniment parts', () => {
+  it('hasAccompaniment=true for piano + multiple accompaniment parts', () => {
+    const player = makeScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+      { partIndex: 2, instrumentType: 'cello', name: 'Cello', staffCount: 1 },
+    ]);
+    const { result } = renderHook(() => useAccompaniment(player));
+    expect(result.current.hasAccompaniment).toBe(true);
+  });
+
+  it('does NOT call setPartVolume for any part (volume owned by mixer)', () => {
+    const player = makeScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+      { partIndex: 2, instrumentType: 'cello', name: 'Cello', staffCount: 1 },
+    ]);
+    renderHook(() => useAccompaniment(player));
+    expect(player.setPartVolume).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/plugins/practice-view-plugin/useAccompaniment.ts
+++ b/frontend/plugins/practice-view-plugin/useAccompaniment.ts
@@ -1,0 +1,63 @@
+/**
+ * Feature 089: useAccompaniment hook
+ *
+ * Detects whether the loaded score has accompaniment parts (non-piano instruments
+ * when a piano part is also present), and provides a callback to trigger
+ * accompaniment audio during step-by-step practice.
+ *
+ * Volume and mute are managed externally via the InstrumentMixerOverlay — this
+ * hook intentionally does NOT set any channel volume, so user-configured
+ * mute/volume state is preserved.
+ */
+
+import { useCallback } from 'react';
+import type { PluginScorePlayerContext } from '../../src/plugin-api/types';
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseAccompanimentResult {
+  /** True when the loaded score has both a piano part AND at least one non-piano part. */
+  hasAccompaniment: boolean;
+  /**
+   * Feature 089: Play accompaniment notes at the given tick immediately.
+   * Called by the practice engine when the user hits a correct note so that
+   * the accompaniment (violin, etc.) sounds in sync with each practice step.
+   * Respects the channel's mute state — no-op when the part is muted.
+   * No-op when there are no accompaniment parts or no score is loaded.
+   *
+   * @param tick           Repeat-expanded tick of the practice entry
+   * @param bpm            Current score BPM (used to convert durationTicks → seconds)
+   * @param ticksPerBeat   Ticks per quarter-note (from score; typically 960)
+   */
+  playAccompanimentAtTick: (tick: number, bpm: number, ticksPerBeat: number) => void;
+}
+
+/**
+ * Hook that manages violin/cello/etc accompaniment volume in the Practice plugin.
+ *
+ * @param scorePlayer - The plugin score player context (v11+ with getInstruments / setPartVolume)
+ */
+export function useAccompaniment(
+  scorePlayer: PluginScorePlayerContext,
+): UseAccompanimentResult {
+  // Derive instrument info synchronously from the current score
+  const instruments = scorePlayer.getInstruments();
+
+  const hasPiano = instruments.some((i) => i.instrumentType === 'piano');
+  const hasAccompaniment = hasPiano && instruments.some((i) => i.instrumentType !== 'piano');
+
+  const playAccompanimentAtTick = useCallback(
+    (tick: number, bpm: number, ticksPerBeat: number) => {
+      if (!hasAccompaniment) return;
+      scorePlayer.playAccompanimentAtTick(tick, bpm, ticksPerBeat);
+    },
+    [scorePlayer, hasAccompaniment],
+  );
+
+  return {
+    hasAccompaniment,
+    playAccompanimentAtTick,
+  };
+}

--- a/frontend/plugins/practice-view-plugin/usePracticeMidi.ts
+++ b/frontend/plugins/practice-view-plugin/usePracticeMidi.ts
@@ -29,6 +29,12 @@ export interface UsePracticeMidiParams {
    * is in 'waiting' mode. Used to trigger deferred metronome start.
    */
   onFirstNoteAttack?: () => void;
+  /**
+   * Feature 089: Called when the user correctly plays a practice note.
+   * Used to trigger accompaniment (violin, etc.) audio in sync with the
+   * practice step. Receives the expanded tick and BPM for timing calculation.
+   */
+  onCorrectNote?: (tick: number, durationTicks: number) => void;
 }
 
 export interface UsePracticeMidiReturn {
@@ -78,6 +84,7 @@ export function usePracticeMidi({
   practiceStartTimeRef,
   selectedStaffIndex: _selectedStaffIndex,
   onFirstNoteAttack,
+  onCorrectNote,
 }: UsePracticeMidiParams): UsePracticeMidiReturn {
   // ─── Chord detector ─────────────────────────────────────────────────────────
   const chordDetectorRef = useRef(new ChordDetector());
@@ -312,6 +319,8 @@ export function usePracticeMidi({
           pressTimeMs: Date.now(),
           requiredHoldMs: entryRequiredHoldMs,
         });
+        // Feature 089: Sound the accompaniment notes that align with this practice tick.
+        onCorrectNote?.(currentEntry.tick, currentEntry.durationTicks);
       } else if (!isInChord && !isSustained) {
         const wrongResponseTimeMs = ps.mode === 'waiting' ? 0 : Date.now() - practiceStartTimeRef.current;
         dispatchPractice({ type: 'WRONG_MIDI', midiNote: event.midiNote, responseTimeMs: wrongResponseTimeMs });

--- a/frontend/src/plugin-api/scorePlayerContext.ts
+++ b/frontend/src/plugin-api/scorePlayerContext.ts
@@ -40,6 +40,7 @@ import type { TaggedNote } from '../types/playback';
 import { expandNotesWithRepeats } from '../services/playback/RepeatNoteExpander';
 import { ToneAdapter } from '../services/playback/ToneAdapter';
 import { resolveInstrumentType } from '../services/playback/InstrumentTimbres';
+import * as Tone from 'tone';
 
 // ---------------------------------------------------------------------------
 // Bridge type (T005) — internal state exposed to the HOST only, never plugins
@@ -186,6 +187,25 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
   // ─── Score state ────────────────────────────────────────────────────────
 
   const [score, setScore] = useState<Score | null>(null);
+  /**
+   * Feature 089: Ref kept in sync with the `score` state so that
+   * getInstruments() can capture it with [] deps (stable callback).
+   */
+  const scoreRef = useRef<Score | null>(null);
+  /**
+   * Feature 089: 0-based index into expandedNotesByStaff where the piano
+   * instrument's staves begin. For single-instrument (piano-only) scores this
+   * is always 0. For violin+piano it is the violin's stave count (1).
+   * Stored as a ref so setPlaybackStaffFilter / extractPracticeNotes can
+   * use it with [] deps without stale-closure risk.
+   */
+  const pianoStaffOffsetRef = useRef(0);
+  /**
+   * Feature 089: Flat array of all notes from non-piano (accompaniment)
+   * instrument staves. Rebuilt at score load. Kept in a ref so
+   * getAccompanimentNotesAtTick() can use [] deps.
+   */
+  const accompanimentNotesRef = useRef<Array<{ pitch: number; partIndex: number; durationTicks: number; startTick: number }>>([]);
   const [notes, setNotes] = useState<Note[]>([]);
   const [rawNotes, setRawNotes] = useState<Note[]>([]);
   /** Expanded notes per staff (indexed by staff position), used by extractPracticeNotes. */
@@ -218,7 +238,13 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
     if (playbackStaffFilter === null) return notes;
     const staffNotes = expandedNotesByStaff[playbackStaffFilter];
     if (!staffNotes) return notes; // out-of-range: fall back to all notes
-    return staffNotes;
+    // Feature 089: accompaniment staves (e.g. violin) live at global indices
+    // 0..(pianoStaffOffset-1). They must always play regardless of which piano
+    // hand is selected. Concatenate them with the selected piano staff's notes.
+    const offset = pianoStaffOffsetRef.current;
+    if (offset === 0) return staffNotes;
+    const accompanimentNotes = expandedNotesByStaff.slice(0, offset).flat() as Note[];
+    return [...accompanimentNotes, ...staffNotes];
   }, [notes, expandedNotesByStaff, playbackStaffFilter]);
 
   // ─── Playback engine ─────────────────────────────────────────────────────
@@ -300,7 +326,12 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
 
   // Notify all subscribers when state changes
   useEffect(() => {
-    const staffCount = score ? (score.instruments[0]?.staves.length ?? 0) : 0;
+    // Feature 089: use piano instrument's stave count so the hands dropdown
+    // shows correctly in multi-instrument scores (violin+piano).
+    const pianoInst = score?.instruments.find(i =>
+      resolveInstrumentType(i.instrument_type, i.name) === 'piano'
+    ) ?? score?.instruments[0];
+    const staffCount = pianoInst?.staves.length ?? 0;
     const newState: ScorePlayerState = {
       status: pluginStatus,
       currentTick: playbackState.currentTick,
@@ -432,7 +463,19 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
         const resolvedType = resolveInstrumentType(instrument.instrument_type, instrument.name);
         toneAdapter.initChannel(partIndex, resolvedType);
       });
-
+      // Feature 089: Find the piano instrument's global staff offset so that
+      // hand selection and practice note extraction target the piano part in
+      // multi-instrument scores (e.g. violin+piano where violin is part 0).
+      // Fall back to instrument[0] for single-instrument / non-piano scores.
+      const pianoInstIndex = scoreObject.instruments.findIndex(inst =>
+        resolveInstrumentType(inst.instrument_type, inst.name) === 'piano'
+      );
+      const practiceInstIndex = pianoInstIndex >= 0 ? pianoInstIndex : 0;
+      let pianoOffset = 0;
+      for (let i = 0; i < practiceInstIndex; i++) {
+        pianoOffset += scoreObject.instruments[i].staves.length;
+      }
+      pianoStaffOffsetRef.current = pianoOffset;
       // Per-staff expanded notes — used by extractPracticeNotes so the
       // practice engine sees repeat-expanded ticks matching the playback engine.
       const rawNotesByStaff = extractNotesByStaff(scoreObject);
@@ -440,10 +483,35 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
         expandNotesWithRepeats(staffNotes, scoreObject!.repeat_barlines, scoreObject!.volta_brackets)
       );
 
+      // Feature 089: Build flat accompaniment note list from the pre-piano staves.
+      // Uses repeat-expanded ticks so they match the practice engine's tick space.
+      // partIndex is the instrument index (same as ToneAdapter channel index).
+      {
+        const accompNotes: Array<{ pitch: number; partIndex: number; durationTicks: number; startTick: number }> = [];
+        let staffGlobalIdx = 0;
+        for (let instrIdx = 0; instrIdx < practiceInstIndex; instrIdx++) {
+          const instr = scoreObject.instruments[instrIdx];
+          for (let staffIdx = 0; staffIdx < instr.staves.length; staffIdx++) {
+            const expanded = parsedNotesByStaff[staffGlobalIdx] ?? [];
+            for (const note of expanded) {
+              accompNotes.push({
+                pitch: note.pitch,
+                partIndex: instrIdx,
+                durationTicks: note.duration_ticks,
+                startTick: note.start_tick,
+              });
+            }
+            staffGlobalIdx++;
+          }
+        }
+        accompanimentNotesRef.current = accompNotes;
+      }
+
       // Reset playback state for the new score
       playbackState.resetPlayback();
 
       setScore(scoreObject);
+      scoreRef.current = scoreObject;
       setNotes(parsedNotes);
       setRawNotes(extractedNotes);
       setExpandedNotesByStaff(parsedNotesByStaff);
@@ -528,7 +596,10 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
 
       // Use pre-expanded per-staff notes so the practice engine sees repeat-
       // expanded ticks that match the playback engine tick space.
-      const staffNotes = expandedNotesByStaff[staffIndex] ?? expandedNotesByStaff[0] ?? [];
+      // Feature 089: map the piano-local staffIndex to the global index in
+      // expandedNotesByStaff by adding the piano instrument's staff offset.
+      const globalStaffIndex = pianoStaffOffsetRef.current + staffIndex;
+      const staffNotes = expandedNotesByStaff[globalStaffIndex] ?? expandedNotesByStaff[pianoStaffOffsetRef.current] ?? [];
 
       // Feature 051: Exclude tie continuation notes — only independently-attacked notes
       // should appear as practice steps.
@@ -721,8 +792,87 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
    * Pass null to restore full (all-staves) playback.
    */
   const setPlaybackStaffFilter = useCallback((staffIndex: number | null): void => {
-    setPlaybackStaffFilterState(staffIndex);
+    // Feature 089: map the piano-local staff index to the global index in
+    // expandedNotesByStaff by adding the piano instrument's staff offset.
+    // For single-instrument piano scores the offset is always 0.
+    if (staffIndex === null) {
+      setPlaybackStaffFilterState(null);
+    } else {
+      setPlaybackStaffFilterState(pianoStaffOffsetRef.current + staffIndex);
+    }
   }, []);
+  // ─── getInstruments (Feature 089) ───────────────────────────────────────────────────
+
+  /**
+   * Returns the instrument list from the currently-loaded score.
+   * Reads from scoreRef (stable ref kept in sync with score state) so this
+   * callback can be memoized with [] deps.
+   */
+  const getInstruments = useCallback((): ReadonlyArray<import('./types').PluginInstrumentInfo> => {
+    const currentScore = scoreRef.current;
+    if (!currentScore) return [];
+    return currentScore.instruments.map((instrument, index) => ({
+      partIndex: index,
+      instrumentType: resolveInstrumentType(instrument.instrument_type, instrument.name),
+      name: instrument.name,
+      staffCount: instrument.staves.length,
+    }));
+  }, []);
+
+  // ─── setPartVolume (Feature 089) ─────────────────────────────────────────────────────
+
+  /**
+   * Set the audio gain for a specific instrument channel.
+   * Delegates to ToneAdapter.getInstance().getChannel(partIndex)?.setVolume().
+   * Volume is clamped to [0.0, 1.0]. Out-of-range partIndex silently ignored.
+   */
+  const setPartVolume = useCallback((partIndex: number, volume: number): void => {
+    const clamped = Math.max(0, Math.min(1, volume));
+    ToneAdapter.getInstance().getChannel(partIndex)?.setVolume(clamped);
+  }, []);
+
+  // ─── getAccompanimentNotesAtTick (Feature 089) ───────────────────────────
+
+  /**
+   * Returns all accompaniment (non-piano) notes whose start_tick is within
+   * `tickWindow` ticks of `tick`. Used by the practice plugin to sound the
+   * accompaniment note that corresponds to a correct piano key press.
+   *
+   * Notes use the raw (non-repeat-expanded) score ticks because the practice
+   * engine operates in expanded tick space; callers should provide the
+   * expanded tick and a generous window (default 240 = 1/8 note at 120 BPM).
+   */
+  const getAccompanimentNotesAtTick = useCallback(
+    (tick: number, tickWindow = 240): ReadonlyArray<{ pitch: number; partIndex: number; durationTicks: number }> => {
+      const notes = accompanimentNotesRef.current;
+      if (notes.length === 0) return [];
+      return notes.filter(n => Math.abs(n.startTick - tick) <= tickWindow);
+    },
+    [],
+  );
+
+  // ─── playAccompanimentAtTick (Feature 089) ────────────────────────────────
+
+  /**
+   * Immediately plays all accompaniment notes at the given tick via ToneAdapter.
+   * Host-side implementation: plugins call this via the API without needing to
+   * import ToneAdapter directly (plugin API boundary enforcement).
+   */
+  const playAccompanimentAtTick = useCallback(
+    (tick: number, bpm: number, ticksPerBeat: number): void => {
+      const notes = accompanimentNotesRef.current;
+      if (notes.length === 0 || bpm <= 0 || ticksPerBeat <= 0) return;
+      const matching = notes.filter(n => Math.abs(n.startTick - tick) <= 240);
+      if (matching.length === 0) return;
+      const secondsPerTick = (60 / bpm) / ticksPerBeat;
+      const now = Tone.now();
+      for (const note of matching) {
+        const durationSec = note.durationTicks * secondsPerTick;
+        ToneAdapter.getInstance().getChannel(note.partIndex)?.playNote(note.pitch, durationSec, now, 64);
+      }
+    },
+    [],
+  );
 
   // ─── Return the bridge object ─────────────────────────────────────────────
 
@@ -746,6 +896,10 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
     getRegionDifficulty,
     getRegionDifficultyForScore,
     setPlaybackStaffFilter,
+    getInstruments,
+    setPartVolume,
+    getAccompanimentNotesAtTick,
+    playAccompanimentAtTick,
   }), [
     getCatalogue,
     loadScore,
@@ -766,6 +920,10 @@ export function useScorePlayerBridge(): ScorePlayerBridge {
     getRegionDifficulty,
     getRegionDifficultyForScore,
     setPlaybackStaffFilter,
+    getInstruments,
+    setPartVolume,
+    getAccompanimentNotesAtTick,
+    playAccompanimentAtTick,
   ]);
 
   const internal = useMemo((): ScorePlayerInternal => ({
@@ -844,6 +1002,10 @@ export function createNoOpScorePlayer(): PluginScorePlayerContext {
     getRegionDifficulty: () => null,
     getRegionDifficultyForScore: async () => null,
     setPlaybackStaffFilter: (_staffIndex: number | null) => {},
+    getInstruments: () => [],
+    setPartVolume: (_partIndex: number, _volume: number) => {},
+    getAccompanimentNotesAtTick: () => [],
+    playAccompanimentAtTick: () => {},
   };
 }
 
@@ -884,5 +1046,9 @@ export function createScorePlayerProxy(
     getRegionDifficulty: (...args) => proxyRef.current.getRegionDifficulty(...args),
     getRegionDifficultyForScore: (...args) => proxyRef.current.getRegionDifficultyForScore(...args),
     setPlaybackStaffFilter: (...args) => proxyRef.current.setPlaybackStaffFilter(...args),
+    getInstruments: () => proxyRef.current.getInstruments(),
+    setPartVolume: (...args) => proxyRef.current.setPartVolume(...args),
+    getAccompanimentNotesAtTick: (...args) => proxyRef.current.getAccompanimentNotesAtTick(...args),
+    playAccompanimentAtTick: (...args) => proxyRef.current.playAccompanimentAtTick(...args),
   };
 }

--- a/frontend/src/plugin-api/types.ts
+++ b/frontend/src/plugin-api/types.ts
@@ -1,5 +1,5 @@
 /**
- * Graditone Plugin API — Types (v10)
+ * Graditone Plugin API — Types (v11)
  * Feature 030: Plugin Architecture (v1 baseline)
  * Feature 031: Practice View Plugin — adds recording namespace and offsetMs (v2)
  * Feature 033: Play Score Plugin — adds scorePlayer namespace, ScoreRenderer component (v3)
@@ -12,6 +12,8 @@
  *              protectedPracticeIds on ScoreSelector (v8)
  * Feature 067: Practice Goals — adds getPhrases() to PluginScorePlayerContext (v9)
  * Feature 070: Session task distribution — adds getRegionDifficulty() (v10)
+ * Feature 089: Piano practice with violin accompaniment — adds PluginInstrumentInfo,
+ *              getInstruments(), setPartVolume() (v11)
  *
  * Defines all public types for the Graditone Plugin API.
  * See specs/030-plugin-architecture/contracts/plugin-api.ts for the v1 canonical contract.
@@ -534,6 +536,35 @@ export interface ScorePlayerState {
 export type HandMode = 'both' | 'right' | 'left';
 
 /**
+ * Feature 089: Descriptor for a single instrument part from the loaded score.
+ * Returned by PluginScorePlayerContext.getInstruments().
+ *
+ * Piano detection: `instrumentType === "piano"`
+ * Accompaniment parts: all entries where `instrumentType !== "piano"`
+ */
+export interface PluginInstrumentInfo {
+  /**
+   * 0-based part index.
+   * Matches ToneAdapter channel keys and TaggedNote._partIndex.
+   * Used as the `partIndex` argument to setPartVolume().
+   */
+  partIndex: number;
+  /**
+   * Canonical instrument type resolved from MusicXML metadata.
+   * Resolved at score load via resolveInstrumentType() in InstrumentTimbres.ts.
+   * Examples: "piano", "violin", "cello", "viola", "flute", "guitar"
+   */
+  instrumentType: string;
+  /** Human-readable display name from the MusicXML <part-name> element. */
+  name: string;
+  /**
+   * Number of staves for this instrument.
+   * Piano typically has 2 (treble + bass grand staff); most others have 1.
+   */
+  staffCount: number;
+}
+
+/**
  * Score player context injected into plugins via context.scorePlayer.
  * v3 extension enabling score loading, playback control, and subscriptions.
  * For v2 plugins this namespace is injected as a no-op stub.
@@ -686,6 +717,69 @@ export interface PluginScorePlayerContext {
    * (full playback restored).
    */
   setPlaybackStaffFilter(staffIndex: number | null): void;
+
+  // ─── v11 additions ────────────────────────────────────────────────────────
+
+  /**
+   * Feature 089: Returns the instrument list from the currently-loaded score.
+   *
+   * Returns an empty array when no score is loaded.
+   * Parts are ordered by their 0-based partIndex (matching MusicXML part order).
+   *
+   * Use case: detect whether the score has piano and non-piano parts (accompaniment).
+   * Piano detection: `info.instrumentType === "piano"`
+   * Accompaniment parts: all entries where `instrumentType !== "piano"`
+   */
+  getInstruments(): ReadonlyArray<PluginInstrumentInfo>;
+
+  /**
+   * Feature 089: Set the audio gain for a specific instrument part channel.
+   *
+   * `volume` is a linear scalar in [0.0, 1.0]:
+   *   - 0.0 = fully muted (silence)
+   *   - 1.0 = full channel volume (default at score load)
+   *   - 0.7 = the recommended accompaniment default
+   *
+   * The change takes effect immediately on the Tone.js Volume node (≤16ms).
+   * `volume` is clamped to [0.0, 1.0] by the host. Out-of-range `partIndex`
+   * values are silently ignored. Has no effect before a score is loaded.
+   *
+   * @param partIndex 0-based instrument part index from PluginInstrumentInfo.partIndex
+   * @param volume    Linear gain scalar, clamped to [0.0, 1.0]
+   */
+  setPartVolume(partIndex: number, volume: number): void;
+
+  /**
+   * Feature 089: Returns all accompaniment (non-piano) notes whose
+   * start_tick is within `tickWindow` ticks of `tick`.
+   * Ticks are in repeat-expanded space (same as the practice engine).
+   * Used by the practice plugin to trigger accompaniment audio when
+   * a correct piano note is played in step-by-step practice mode.
+   *
+   * Returns an empty array if there are no accompaniment instruments
+   * or no score is loaded.
+   *
+   * @param tick       Expanded tick of the practice entry
+   * @param tickWindow Search radius in ticks (default 240)
+   */
+  getAccompanimentNotesAtTick(tick: number, tickWindow?: number): ReadonlyArray<{
+    pitch: number;
+    partIndex: number;
+    durationTicks: number;
+  }>;
+
+  /**
+   * Feature 089: Immediately play the accompaniment notes that align with
+   * the given tick (repeat-expanded tick space, same as the practice engine).
+   *
+   * Respects each channel's mute state — muted parts are silently skipped.
+   * No-op when there are no accompaniment instruments or no score is loaded.
+   *
+   * @param tick         Expanded tick of the practice entry
+   * @param bpm          Effective BPM (used to convert durationTicks → seconds)
+   * @param ticksPerBeat Ticks per quarter-note (typically 960)
+   */
+  playAccompanimentAtTick(tick: number, bpm: number, ticksPerBeat: number): void;
 }
 
 /**

--- a/frontend/tests/integration/accompaniment.test.ts
+++ b/frontend/tests/integration/accompaniment.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PluginScorePlayerContext, PluginInstrumentInfo } from '../../src/plugin-api/types';
+
+/**
+ * Feature 089: Contract tests for Plugin API v11 additions.
+ *
+ * Tests the contracts for:
+ *   - getInstruments(): ReadonlyArray<PluginInstrumentInfo>
+ *   - setPartVolume(partIndex: number, volume: number): void
+ *
+ * These tests use a mock scorePlayer that implements the v11 interface.
+ * They validate contract shape, clamping, and accompaniment detection logic.
+ *
+ * TDD: Written BEFORE implementation. Must be red until T005/T006/T009 complete.
+ */
+
+// ---------------------------------------------------------------------------
+// Mock score player factory (v11 shape)
+// ---------------------------------------------------------------------------
+
+function makeMockScorePlayer(
+  instruments: PluginInstrumentInfo[] = [],
+): PluginScorePlayerContext & { _partVolumes: Map<number, number> } {
+  const partVolumes = new Map<number, number>();
+  return {
+    getCatalogue: () => [],
+    loadScore: vi.fn(),
+    play: vi.fn(),
+    pause: vi.fn(),
+    stop: vi.fn(),
+    seekToTick: vi.fn(),
+    setPinnedStart: vi.fn(),
+    setLoopEnd: vi.fn(),
+    setTempoMultiplier: vi.fn(),
+    snapToScoreTempo: vi.fn(),
+    subscribe: vi.fn((handler) => {
+      handler({
+        status: 'ready',
+        currentTick: 0,
+        totalDurationTicks: 0,
+        highlightedNoteIds: new Set(),
+        bpm: 120,
+        exactBpm: 120,
+        title: null,
+        error: null,
+        staffCount: 2,
+        timeSignature: { numerator: 4, denominator: 4 },
+        pickupTicks: 0,
+      });
+      return () => {};
+    }),
+    getCurrentTickLive: () => 0,
+    extractPracticeNotes: () => null,
+    getMeasureEndTicks: () => null,
+    rawTickToExpandedTick: (t) => t,
+    getPhrases: () => null,
+    getRegionDifficulty: () => null,
+    getRegionDifficultyForScore: async () => null,
+    setPlaybackStaffFilter: vi.fn(),
+    // v11
+    getInstruments: () => instruments,
+    setPartVolume: vi.fn((partIndex: number, volume: number) => {
+      partVolumes.set(partIndex, volume);
+    }),
+    // test helper
+    _partVolumes: partVolumes,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Contract tests: PluginInstrumentInfo shape
+// ---------------------------------------------------------------------------
+
+describe('PluginInstrumentInfo — contract shape', () => {
+  it('has required fields: partIndex, instrumentType, name, staffCount', () => {
+    const info: PluginInstrumentInfo = {
+      partIndex: 0,
+      instrumentType: 'piano',
+      name: 'Piano',
+      staffCount: 2,
+    };
+    expect(info.partIndex).toBe(0);
+    expect(info.instrumentType).toBe('piano');
+    expect(info.name).toBe('Piano');
+    expect(info.staffCount).toBe(2);
+  });
+
+  it('violin instrument has staffCount 1', () => {
+    const info: PluginInstrumentInfo = {
+      partIndex: 1,
+      instrumentType: 'violin',
+      name: 'Violin',
+      staffCount: 1,
+    };
+    expect(info.instrumentType).toBe('violin');
+    expect(info.staffCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract tests: getInstruments()
+// ---------------------------------------------------------------------------
+
+describe('getInstruments() — contract', () => {
+  it('returns empty array when no score is loaded', () => {
+    const player = makeMockScorePlayer([]);
+    expect(player.getInstruments()).toEqual([]);
+  });
+
+  it('returns instrument list for violin+piano score', () => {
+    const instruments: PluginInstrumentInfo[] = [
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+    ];
+    const player = makeMockScorePlayer(instruments);
+    const result = player.getInstruments();
+    expect(result).toHaveLength(2);
+    expect(result[0].instrumentType).toBe('piano');
+    expect(result[1].instrumentType).toBe('violin');
+  });
+
+  it('accompaniment detection: piano-only → no accompaniment parts', () => {
+    const instruments: PluginInstrumentInfo[] = [
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+    ];
+    const player = makeMockScorePlayer(instruments);
+    const result = player.getInstruments();
+    const accompanimentParts = result.filter((i) => i.instrumentType !== 'piano');
+    expect(accompanimentParts).toHaveLength(0);
+  });
+
+  it('accompaniment detection: violin+piano → violin is accompaniment part', () => {
+    const instruments: PluginInstrumentInfo[] = [
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+    ];
+    const player = makeMockScorePlayer(instruments);
+    const result = player.getInstruments();
+    const accompanimentParts = result.filter((i) => i.instrumentType !== 'piano');
+    expect(accompanimentParts).toHaveLength(1);
+    expect(accompanimentParts[0].partIndex).toBe(1);
+  });
+
+  it('multiple non-piano parts: all are accompaniment', () => {
+    const instruments: PluginInstrumentInfo[] = [
+      { partIndex: 0, instrumentType: 'violin', name: 'Violin I', staffCount: 1 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin II', staffCount: 1 },
+      { partIndex: 2, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+    ];
+    const player = makeMockScorePlayer(instruments);
+    const result = player.getInstruments();
+    const accompanimentParts = result.filter((i) => i.instrumentType !== 'piano');
+    expect(accompanimentParts).toHaveLength(2);
+  });
+
+  it('fail-closed: no piano part → hasPiano=false, hasAccompaniment=false', () => {
+    const instruments: PluginInstrumentInfo[] = [
+      { partIndex: 0, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+    ];
+    const player = makeMockScorePlayer(instruments);
+    const result = player.getInstruments();
+    const hasPiano = result.some((i) => i.instrumentType === 'piano');
+    const hasNonPiano = result.some((i) => i.instrumentType !== 'piano');
+    const hasAccompaniment = hasPiano && hasNonPiano;
+    expect(hasPiano).toBe(false);
+    expect(hasAccompaniment).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract tests: setPartVolume()
+// ---------------------------------------------------------------------------
+
+describe('setPartVolume() — contract', () => {
+  let player: ReturnType<typeof makeMockScorePlayer>;
+
+  beforeEach(() => {
+    const instruments: PluginInstrumentInfo[] = [
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+    ];
+    player = makeMockScorePlayer(instruments);
+  });
+
+  it('accepts volume=0.7 (default accompaniment volume)', () => {
+    player.setPartVolume(1, 0.7);
+    expect(player.setPartVolume).toHaveBeenCalledWith(1, 0.7);
+  });
+
+  it('accepts volume=0.0 (mute)', () => {
+    player.setPartVolume(1, 0.0);
+    expect(player.setPartVolume).toHaveBeenCalledWith(1, 0.0);
+  });
+
+  it('accepts volume=1.0 (full)', () => {
+    player.setPartVolume(1, 1.0);
+    expect(player.setPartVolume).toHaveBeenCalledWith(1, 1.0);
+  });
+
+  it('signature: takes partIndex and volume', () => {
+    player.setPartVolume(0, 0.5);
+    expect(player.setPartVolume).toHaveBeenCalledWith(0, 0.5);
+  });
+
+  it('is called for each accompaniment part index', () => {
+    const accompanimentParts = player.getInstruments().filter((i) => i.instrumentType !== 'piano');
+    for (const part of accompanimentParts) {
+      player.setPartVolume(part.partIndex, 0.7);
+    }
+    expect(player.setPartVolume).toHaveBeenCalledTimes(accompanimentParts.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration scenario: US3 — tempo sync is architectural (no extra logic needed)
+// ---------------------------------------------------------------------------
+
+describe('US3 — tempo sync (architectural guarantee)', () => {
+  it('setTempoMultiplier exists and setPartVolume are independent operations', () => {
+    const player = makeMockScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+    ]);
+    // Both can be called independently without conflict
+    player.setTempoMultiplier(0.6);
+    player.setPartVolume(1, 0.7);
+    expect(player.setTempoMultiplier).toHaveBeenCalledWith(0.6);
+    expect(player.setPartVolume).toHaveBeenCalledWith(1, 0.7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration scenario: US4 — staff filter + accompaniment are orthogonal
+// ---------------------------------------------------------------------------
+
+describe('US4 — staff filter and accompaniment volume are orthogonal', () => {
+  it('setPlaybackStaffFilter and setPartVolume can be called independently', () => {
+    const player = makeMockScorePlayer([
+      { partIndex: 0, instrumentType: 'piano', name: 'Piano', staffCount: 2 },
+      { partIndex: 1, instrumentType: 'violin', name: 'Violin', staffCount: 1 },
+    ]);
+    player.setPlaybackStaffFilter(0); // one-hand mode (piano treble only)
+    player.setPartVolume(1, 0.7);    // violin accompaniment at 70%
+    expect(player.setPlaybackStaffFilter).toHaveBeenCalledWith(0);
+    expect(player.setPartVolume).toHaveBeenCalledWith(1, 0.7);
+  });
+});

--- a/specs/089-piano-violin-practice/checklists/requirements.md
+++ b/specs/089-piano-violin-practice/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Piano Practice with Violin Accompaniment Playback
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan` or `/speckit.clarify`.
+- Scope is explicitly limited to the Train plugin's score-preset mode; future expansion to other modes is out of scope.
+- "MusicXML" appears in Assumptions as domain-level terminology (a score format), not as an implementation detail.

--- a/specs/089-piano-violin-practice/contracts/plugin-api-v11.ts
+++ b/specs/089-piano-violin-practice/contracts/plugin-api-v11.ts
@@ -1,0 +1,157 @@
+/**
+ * Plugin API Contract — v11
+ * Feature 089: Piano Practice with Violin Accompaniment Playback
+ *
+ * Changes from v10:
+ *   + PluginInstrumentInfo  — new type: instrument part descriptor
+ *   + PluginScorePlayerContext.getInstruments() — expose loaded score's instrument list
+ *   + PluginScorePlayerContext.setPartVolume()  — control per-instrument audio gain
+ *
+ * v10 was defined in Feature 070 (getRegionDifficulty).
+ * v11 adds instrument metadata access and per-part volume control.
+ *
+ * Implementation targets:
+ *   - frontend/src/plugin-api/types.ts              (interface definitions)
+ *   - frontend/src/plugin-api/scorePlayerContext.ts  (implementation)
+ *
+ * Stub targets (must also be updated):
+ *   - createNoOpScorePlayer() in scorePlayerContext.ts
+ *   - proxy delegation object in scorePlayerContext.ts
+ */
+
+// ---------------------------------------------------------------------------
+// New type: PluginInstrumentInfo
+// ---------------------------------------------------------------------------
+
+/**
+ * Descriptor for a single instrument part from the loaded score.
+ * Returned by PluginScorePlayerContext.getInstruments().
+ *
+ * Feature 089: Piano Practice with Violin Accompaniment Playback
+ */
+export interface PluginInstrumentInfo {
+  /**
+   * 0-based part index.
+   * Matches ToneAdapter channel keys and TaggedNote._partIndex.
+   * Used as the `partIndex` argument to setPartVolume().
+   */
+  partIndex: number;
+
+  /**
+   * Canonical instrument type resolved from MusicXML metadata.
+   * Resolved at score load via resolveInstrumentType() in InstrumentTimbres.ts.
+   *
+   * Examples: "piano", "violin", "cello", "viola", "flute", "guitar"
+   *
+   * Piano part detection: `instrumentType === "piano"`
+   * Accompaniment parts: any part where `instrumentType !== "piano"`
+   */
+  instrumentType: string;
+
+  /**
+   * Human-readable display name from the MusicXML <part-name> element.
+   * Examples: "Piano", "Violin", "Violoncello"
+   */
+  name: string;
+
+  /**
+   * Number of staves for this instrument.
+   * Piano typically has 2 (treble + bass grand staff).
+   * Most other instruments have 1.
+   */
+  staffCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Extension to PluginScorePlayerContext
+// ---------------------------------------------------------------------------
+
+/**
+ * v11 additions to PluginScorePlayerContext.
+ * These methods are appended to the existing PluginScorePlayerContext interface
+ * in frontend/src/plugin-api/types.ts.
+ *
+ * Feature 089: Piano Practice with Violin Accompaniment Playback
+ */
+export interface PluginScorePlayerContext_v11_additions {
+  /**
+   * Feature 089: Returns the instrument list from the currently-loaded score.
+   *
+   * Returns an empty array when no score is loaded (status !== 'ready').
+   * Parts are ordered by their 0-based partIndex (matching MusicXML part order).
+   *
+   * Use case: detect whether the score contains piano and non-piano parts
+   * to determine whether accompaniment playback should be active.
+   *
+   * Piano detection: `info.instrumentType === "piano"`
+   * Accompaniment parts: all entries where `instrumentType !== "piano"`
+   *
+   * @returns Instrument descriptors, empty array if no score loaded.
+   */
+  getInstruments(): ReadonlyArray<PluginInstrumentInfo>;
+
+  /**
+   * Feature 089: Set the audio gain for a specific instrument part channel.
+   *
+   * `volume` is a linear scalar in [0.0, 1.0]:
+   *   - 0.0 = fully muted (silence)
+   *   - 1.0 = full channel volume (default at score load)
+   *   - 0.7 = the recommended accompaniment default
+   *
+   * The change takes effect immediately — already-scheduled Tone.js notes
+   * playing through the channel's Volume node will be affected within one
+   * audio processing block (≤16ms at 60fps).
+   *
+   * Out-of-range `partIndex` values are silently ignored (no-op).
+   * `volume` is clamped to [0.0, 1.0] by the host before application.
+   *
+   * Must only be called when a score is loaded (status === 'ready').
+   * Has no effect if called before a score is loaded.
+   *
+   * @param partIndex 0-based instrument part index from PluginInstrumentInfo.partIndex
+   * @param volume    Linear gain scalar, clamped to [0.0, 1.0]
+   */
+  setPartVolume(partIndex: number, volume: number): void;
+}
+
+// ---------------------------------------------------------------------------
+// Stub / no-op implementations
+// ---------------------------------------------------------------------------
+
+/**
+ * No-op implementations for createNoOpScorePlayer() stub.
+ * Add these to the stub object in scorePlayerContext.ts.
+ */
+export const noOpV11Additions: PluginScorePlayerContext_v11_additions = {
+  getInstruments: () => [],
+  setPartVolume: (_partIndex: number, _volume: number) => {},
+};
+
+// ---------------------------------------------------------------------------
+// Implementation sketch (for implementor reference — not normative)
+// ---------------------------------------------------------------------------
+
+/*
+// In scorePlayerContext.ts, inside useScorePlayerContext():
+
+// getInstruments — reads from the loaded score's instruments array
+const getInstruments = useCallback((): ReadonlyArray<PluginInstrumentInfo> => {
+  const currentScore = scoreRef.current;
+  if (!currentScore) return [];
+  return currentScore.instruments.map((instrument, partIndex) => ({
+    partIndex,
+    instrumentType: resolveInstrumentType(instrument.instrument_type, instrument.name),
+    name: instrument.name,
+    staffCount: instrument.staves.length,
+  }));
+}, []); // stable — reads from ref, no reactive dependencies
+
+// setPartVolume — delegates to ToneAdapter channel
+const setPartVolume = useCallback((partIndex: number, volume: number): void => {
+  const clamped = Math.max(0, Math.min(1, volume));
+  const toneAdapter = ToneAdapter.getInstance();
+  toneAdapter.getChannel(partIndex)?.setVolume(clamped);
+}, []); // stable — no reactive dependencies
+
+// Add both to the api useMemo and proxy object
+*/

--- a/specs/089-piano-violin-practice/data-model.md
+++ b/specs/089-piano-violin-practice/data-model.md
@@ -1,0 +1,181 @@
+# Data Model: Piano Practice with Violin Accompaniment Playback
+
+**Feature**: 089-piano-violin-practice  
+**Date**: 2026-04-29  
+**Phase**: 1 — Design
+
+---
+
+## Domain Entities
+
+### PluginInstrumentInfo *(new — Plugin API v11)*
+
+Represents a single instrument part from the loaded score, as exposed to plugins via `getInstruments()`.
+
+```typescript
+/**
+ * Feature 089: Instrument part descriptor exposed to plugins.
+ * Returned by PluginScorePlayerContext.getInstruments().
+ */
+export interface PluginInstrumentInfo {
+  /** 0-based index; matches ToneAdapter channel key and TaggedNote._partIndex */
+  partIndex: number;
+  /**
+   * Canonical instrument type resolved from MusicXML metadata.
+   * Examples: "piano", "violin", "cello", "viola", "flute".
+   * Resolved by resolveInstrumentType() in InstrumentTimbres.ts at score load.
+   */
+  instrumentType: string;
+  /** Display name from MusicXML <part-name> element. */
+  name: string;
+  /** Number of staves for this instrument (2 for piano grand staff, 1 for most others). */
+  staffCount: number;
+}
+```
+
+---
+
+### AccompanimentState *(runtime — computed from PluginInstrumentInfo[])*
+
+Derived state managed by the `useAccompaniment` hook. Not persisted.
+
+```typescript
+interface AccompanimentState {
+  /**
+   * All non-piano instrument parts from the loaded score.
+   * Empty array when no score is loaded or score has no non-piano parts.
+   */
+  accompanimentParts: ReadonlyArray<PluginInstrumentInfo>;
+
+  /**
+   * True when the loaded score has ≥1 piano part AND ≥1 non-piano part.
+   * Controls visibility of the AccompanimentVolumeSlider in the toolbar.
+   */
+  hasAccompaniment: boolean;
+
+  /**
+   * Current accompaniment volume as a linear scalar 0.0–1.0.
+   * Default: 0.7 (70%). Sourced from module-level page-session state.
+   */
+  volume: number;
+
+  /**
+   * Callback to update accompaniment volume.
+   * Immediately applies to all accompanimentParts via setPartVolume.
+   */
+  setVolume: (volume: number) => void;
+}
+```
+
+---
+
+### AccompanimentVolumeStore *(page-session singleton)*
+
+Module-level state that survives component remounts within a page session (score changes). Initialised fresh on page reload.
+
+```typescript
+// Module-level singleton in useAccompaniment.ts
+const DEFAULT_ACCOMPANIMENT_VOLUME = 0.7;
+let pageSessionVolume: number = DEFAULT_ACCOMPANIMENT_VOLUME;
+```
+
+---
+
+## State Transitions
+
+### Score Load → Accompaniment Detection
+
+```
+State: no score loaded
+  → Action: loadScore() called
+  → Score resolves, instruments[] populated by WASM parser
+  → getInstruments() returns PluginInstrumentInfo[]
+  → hasPiano = instruments.some(i => i.instrumentType === 'piano')
+  → hasNonPiano = instruments.some(i => i.instrumentType !== 'piano')
+  → hasAccompaniment = hasPiano && hasNonPiano
+
+If hasAccompaniment:
+  → setPartVolume(partIndex, pageSessionVolume) applied to each non-piano partIndex
+  → AccompanimentVolumeSlider renders in toolbar
+
+If !hasAccompaniment:
+  → AccompanimentVolumeSlider not rendered (FR-008)
+  → No setPartVolume calls made
+```
+
+### Score Change Mid-Session
+
+```
+State: score A loaded (hasAccompaniment = true, volume = 0.5)
+  → Action: loadScore(B) called
+  → ToneAdapter.destroyChannels() called (existing behaviour)
+  → New channels created for score B instruments
+  → useAccompaniment re-evaluates: hasAccompaniment for score B?
+    If yes: setPartVolume applied at volume = 0.5 (pageSessionVolume preserved)
+    If no: slider hidden
+```
+
+### Volume Adjustment
+
+```
+State: hasAccompaniment = true, volume = 0.7
+  → Action: user drags slider to 0.4
+  → setVolume(0.4) called
+  → pageSessionVolume = 0.4
+  → setPartVolume(partIndex, 0.4) called for each accompanimentPart
+  → ToneAdapter.getChannel(partIndex)?.setVolume(0.4) → Tone.Volume node adjusted
+  → Audio output changes immediately (≤16ms via Tone.js audio scheduling)
+```
+
+### Playback Start/Stop/Pause
+
+```
+Volume node state is orthogonal to playback state.
+setVolume() on a PlaybackChannel affects the Tone.Volume node directly.
+No volume recalculation needed on play/stop/pause events.
+```
+
+### Page Session Boundary
+
+```
+State: accompaniment volume = 0.4
+  → Action: user reloads page
+  → pageSessionVolume re-initialised to DEFAULT_ACCOMPANIMENT_VOLUME (0.7)
+  → All ToneAdapter channels destroyed and recreated
+```
+
+---
+
+## Validation Rules
+
+| Field | Rule |
+|-------|------|
+| `volume` | Clamped to `[0.0, 1.0]` before calling `setVolume()` on ToneAdapter channel |
+| `partIndex` | Only valid indices (0 to instruments.length - 1) are passed to `setPartVolume` |
+| `instrumentType` | Canonical string; piano detection uses strict equality: `instrumentType === 'piano'` |
+| Default volume | `0.7` (70% linear gain); initialised in module scope, not in component state |
+
+---
+
+## Relationships
+
+```
+PluginScorePlayerContext
+  ├── getInstruments() → PluginInstrumentInfo[]   (NEW v11)
+  └── setPartVolume(partIndex, volume)             (NEW v11)
+        └── ToneAdapter.getChannel(partIndex)
+              └── IPlaybackChannel.setVolume(volume)
+                    └── Tone.Volume node (per instrument)
+                          └── Tone.Limiter (shared)
+                                └── AudioDestination
+
+useAccompaniment (Practice plugin hook)
+  ├── reads: getInstruments()
+  ├── derives: hasAccompaniment, accompanimentParts
+  ├── reads/writes: pageSessionVolume (module singleton)
+  └── calls: setPartVolume() for each accompanimentPart
+
+AccompanimentVolumeSlider (Practice toolbar component)
+  ├── props: { volume, onVolumeChange, visible }
+  └── renders: slider (0–100%) + label, only when visible=true
+```

--- a/specs/089-piano-violin-practice/plan.md
+++ b/specs/089-piano-violin-practice/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: Piano Practice with Violin Accompaniment Playback
+
+**Branch**: `089-piano-violin-practice` | **Date**: 2026-04-29 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/089-piano-violin-practice/spec.md`
+
+## Summary
+
+When a violin+piano score is loaded in the Practice plugin, the violin (and all non-piano parts) play back automatically as accompaniment during practice sessions. An independent volume slider in the Practice plugin's toolbar controls accompaniment gain (default 70%), persisting across runs within the same page session. The implementation extends the Plugin API with two new methods — `getInstruments()` and `setPartVolume()` — and adds a `useAccompaniment` hook plus an `AccompanimentVolumeSlider` component in the Practice plugin. No backend or WASM changes required; the feature routes through the existing per-instrument `ToneAdapter` channels introduced in Feature 088.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (React 18+); no Rust/WASM changes  
+**Primary Dependencies**: React 18+, Vite, Tone.js, Plugin API (`PluginScorePlayerContext`), `ToneAdapter`/`PlaybackChannel` (Feature 088)  
+**Storage**: Page-session module state only — no `localStorage`, no `IndexedDB`  
+**Testing**: Vitest + `@testing-library/react` (frontend unit/component tests); no new Playwright e2e tests  
+**Target Platform**: Tablet PWA (iPad, Surface, Android tablets) — Chrome 57+, Safari 11+, Edge 16+  
+**Project Type**: Web application (frontend only)  
+**Performance Goals**: Volume slider audio feedback ≤16ms; no new scheduling overhead on score playback  
+**Constraints**: No new synthesis engine; accompaniment uses existing ToneAdapter channels; volume is page-session transient (not profile-scoped)  
+**Scale/Scope**: ~6 modified/created source files, 2 new Plugin API methods, 1 new hook, 1 new component
+
+## Constitution Check (Pre-Design Gate)
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Domain-Driven Design | ✅ PASS | Entities named in music domain: `AccompanimentPart`, `AccompanimentVolume` |
+| II. Hexagonal Architecture | ✅ PASS | Plugin API is the port; `ToneAdapter` channel is the adapter; no domain logic leaks into UI |
+| III. PWA / Offline | ✅ PASS | Entirely local; no network calls introduced |
+| IV. Precision & Fidelity | ✅ PASS | No tick/timing changes; volume is a gain node scalar, not schedule manipulation |
+| V. Test-First (NON-NEGOTIABLE) | ✅ REQUIRED | Tests written before implementation. Red-green-refactor enforced in tasks. |
+| VI. Layout Engine Authority | ✅ PASS | No coordinate calculations; volume slider is a CSS-positioned toolbar element |
+| VII. Regression Prevention | ✅ REQUIRED | Explicit regression tests for FR-008 (piano-only scores unaffected), FR-007 (staff filter coexistence), SC-005 (note detection accuracy) |
+| VIII. User Profile Awareness | ⚠️ JUSTIFIED EXEMPTION | Accompaniment volume is page-session transient state (spec: "resets on full page reload"). Not a persisted user preference — equivalent to current playback position or MIDI routing. No new `localStorage` keys introduced. `ProfileIcon` already present in Practice toolbar (Feature 080). |
+
+**Gate result: PASS** — Principle VIII exemption is justified. The volume setting is transient (page-session only), not a user-profile-scoped preference, so no `localStorage` scoping is required.
+
+### Documentation (this feature)
+
+```text
+specs/089-piano-violin-practice/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── plugin-api-v11.ts  # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+├── src/
+│   └── plugin-api/
+│       ├── types.ts                               # MODIFY: PluginInstrumentInfo, extend PluginScorePlayerContext (v11)
+│       └── scorePlayerContext.ts                  # MODIFY: implement getInstruments(), setPartVolume()
+├── plugins/
+│   └── practice-view-plugin/
+│       ├── PracticeViewPlugin.tsx                 # MODIFY: wire useAccompaniment hook
+│       ├── practiceToolbar.tsx                    # MODIFY: add AccompanimentVolumeSlider to toolbar
+│       ├── useAccompaniment.ts                    # CREATE: accompaniment detection + volume hook
+│       ├── useAccompaniment.test.ts               # CREATE: unit tests (TDD — written first)
+│       ├── AccompanimentVolumeSlider.tsx          # CREATE: volume slider component
+│       └── AccompanimentVolumeSlider.test.tsx     # CREATE: component tests (TDD — written first)
+└── tests/
+    └── integration/
+        └── accompaniment.test.ts                  # CREATE: integration test with score player mock
+```
+
+**Structure Decision**: Frontend-only web application. All source changes are in `frontend/`. No backend or WASM changes.
+
+## Complexity Tracking
+
+No constitution violations that require complexity justification.
+
+---
+
+## Constitution Check (Post-Design Re-evaluation)
+
+*Re-checked after Phase 1 design. All findings consistent with pre-design gate.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. DDD | ✅ PASS | `PluginInstrumentInfo`, `AccompanimentState`, `AccompanimentVolume` — all music-domain language |
+| II. Hexagonal | ✅ PASS | `useAccompaniment` hook calls only Plugin API methods; `ToneAdapter` never imported in plugin code |
+| III. PWA / Offline | ✅ PASS | No network calls; module-level state works offline |
+| IV. Precision & Fidelity | ✅ PASS | `setVolume(linear)` → `linearToDb()` → Tone.Volume dB — no integer pulse manipulation |
+| V. Test-First | ✅ REQUIRED | `useAccompaniment.test.ts` and `AccompanimentVolumeSlider.test.tsx` must be written **before** implementation files |
+| VI. Layout Engine | ✅ PASS | `AccompanimentVolumeSlider` is a CSS flex slider with no spatial geometry computations |
+| VII. Regression Prevention | ✅ REQUIRED | Regression tests: FR-008 (no slider on piano-only score), FR-007 (staff filter unchanged), SC-005 (note detection accuracy) |
+| VIII. Profile Awareness | ⚠️ JUSTIFIED | Post-design: confirmed no `localStorage` keys added. Module-level singleton `pageSessionVolume` is analogous to playback position — correct scope for this preference. |
+
+**Post-design gate: PASS** — design is consistent with all constitution principles.
+

--- a/specs/089-piano-violin-practice/quickstart.md
+++ b/specs/089-piano-violin-practice/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart: Piano Practice with Violin Accompaniment Playback
+
+**Feature**: 089-piano-violin-practice  
+**Date**: 2026-04-29
+
+---
+
+## What This Feature Does
+
+When a violin+piano score is loaded in the Practice plugin, the violin (and all non-piano parts) automatically play back as accompaniment during practice sessions. An independent volume slider in the Practice plugin's toolbar lets the student balance the accompaniment against their piano feedback.
+
+**Before this feature**: Only the piano part is played back (for note detection feedback). In a violin+piano sonata, the student practices in silence without the violin melody.
+
+**After this feature**: The violin plays back automatically. A volume slider lets the student set accompaniment to 0–100% (default 70%).
+
+---
+
+## How to Verify It Works
+
+1. Open the Practice plugin.
+2. Load a score with both violin and piano parts (e.g. `Beethoven_FurElise.mxl` does NOT have violin — use a violin+piano sonata score).
+3. The Practice toolbar now shows an **Accompaniment** volume slider.
+4. Press play — the violin part plays back automatically.
+5. Adjust the slider — the violin gets louder/quieter without affecting piano note detection.
+6. Load a piano-only score — the slider disappears (FR-008).
+
+---
+
+## Architecture Overview
+
+```
+Practice plugin (PracticeViewPlugin.tsx)
+  └── useAccompaniment(scorePlayer)
+        ├── scorePlayer.getInstruments()     → PluginInstrumentInfo[]  [NEW v11]
+        ├── derives: accompanimentParts, hasAccompaniment
+        └── setVolume(v) → scorePlayer.setPartVolume(partIndex, v)  [NEW v11]
+                              └── ToneAdapter.getChannel(partIndex).setVolume(v)
+                                    └── Tone.Volume node (per instrument)
+
+Practice toolbar (practiceToolbar.tsx)
+  └── <AccompanimentVolumeSlider>  [NEW — rendered only when hasAccompaniment=true]
+```
+
+---
+
+## Key Files
+
+| File | Status | Purpose |
+|------|--------|---------|
+| `frontend/src/plugin-api/types.ts` | MODIFY | Add `PluginInstrumentInfo` type, extend `PluginScorePlayerContext` with `getInstruments()` + `setPartVolume()` (v11) |
+| `frontend/src/plugin-api/scorePlayerContext.ts` | MODIFY | Implement `getInstruments()` + `setPartVolume()` |
+| `frontend/plugins/practice-view-plugin/useAccompaniment.ts` | CREATE | Hook: detects accompaniment parts, manages volume |
+| `frontend/plugins/practice-view-plugin/AccompanimentVolumeSlider.tsx` | CREATE | Component: volume slider in toolbar |
+| `frontend/plugins/practice-view-plugin/PracticeViewPlugin.tsx` | MODIFY | Wire `useAccompaniment`, pass props to toolbar |
+| `frontend/plugins/practice-view-plugin/practiceToolbar.tsx` | MODIFY | Render `AccompanimentVolumeSlider` |
+
+---
+
+## Adding a New Test Score
+
+To test with a violin+piano score during development:
+
+1. Add a MusicXML file with violin and piano parts to `scores/` (or use an existing score in the preloaded catalogue that contains both instruments).
+2. Check instrument types are correctly identified: open DevTools, run `getInstruments()` via the practice plugin and inspect the console output (available in dev builds).
+3. Verify `hasAccompaniment === true` and the slider appears.
+
+---
+
+## Volume Control Behaviour
+
+| Scenario | Volume state |
+|----------|-------------|
+| Page reload | Reset to 70% (default) |
+| Score change (same page session) | Preserved (carries over) |
+| Practice stop/restart | Preserved (volume is on audio node, not playback state) |
+| Staff filter change (one-hand mode) | Unaffected — orthogonal to accompaniment volume |
+
+---
+
+## Constitution Notes
+
+- **Principle V (TDD)**: Tests are written *before* implementation. See `useAccompaniment.test.ts` and `AccompanimentVolumeSlider.test.tsx`.
+- **Principle VIII**: Accompaniment volume is page-session transient — no `localStorage` key added. Profile scoping is not required.
+- **Principle VI**: No coordinate calculations anywhere in this feature. The slider is a CSS flex element.
+- **Principle II**: All cross-boundary calls go through `PluginScorePlayerContext`. The hook never imports `ToneAdapter` directly.

--- a/specs/089-piano-violin-practice/research.md
+++ b/specs/089-piano-violin-practice/research.md
@@ -1,0 +1,138 @@
+# Research: Piano Practice with Violin Accompaniment Playback
+
+**Feature**: 089-piano-violin-practice  
+**Date**: 2026-04-29  
+**Phase**: 0 — Pre-implementation research
+
+---
+
+## R-001: Audio Pipeline Architecture
+
+**Question**: How does multi-part playback work and how is per-part volume controlled?
+
+**Decision**: Use the existing per-instrument `PlaybackChannel` architecture introduced in Feature 088. Each instrument part gets its own `Tone.Volume` node connected to a shared `Tone.Limiter`. Volume is controlled via `IPlaybackChannel.setVolume(volume: number)` where `volume` is a linear gain scalar (0.0–1.0).
+
+**Rationale**: The infrastructure already exists. Feature 088 added `ToneAdapter.channels: Map<number, PlaybackChannel>` — one channel per `partIndex`. The `PlaybackChannel.setVolume()` method adjusts the `Tone.Volume` node for that instrument in real time. No new audio engine work is needed.
+
+**Alternatives considered**:
+- Adding a Web Audio API `GainNode` at the output stage: Rejected — the Tone.js `Volume` node already provides this at the per-instrument level.
+- Multiplying velocity values: Rejected — would require rescheduling all notes; `setVolume` works at the audio node level, affecting already-scheduled notes instantly.
+
+**Key references**:
+- `frontend/src/services/playback/PlaybackChannel.ts` — `IPlaybackChannel.setVolume(volume: number)`
+- `frontend/src/services/playback/ToneAdapter.ts` — `getChannel(partIndex): IPlaybackChannel | null`
+
+---
+
+## R-002: Plugin API Gap Analysis
+
+**Question**: Does the current Plugin API expose per-part instrument info and per-part volume control?
+
+**Decision**: The Plugin API (`PluginScorePlayerContext` at v10) does NOT expose instrument metadata or per-part volume methods. Two new methods must be added at v11:
+
+1. `getInstruments(): ReadonlyArray<PluginInstrumentInfo>` — exposes the instrument list from the loaded score.
+2. `setPartVolume(partIndex: number, volume: number): void` — applies a linear gain to a specific instrument channel.
+
+**Rationale**: The Practice plugin cannot access `ToneAdapter` directly (hexagonal architecture boundary — Principle II). All cross-boundary communication goes through the Plugin API. The two new methods follow the exact same pattern as `setPlaybackStaffFilter` (Feature 083): a `useCallback` wrapping a `ToneAdapter` call, added to the `api` useMemo and stub/proxy objects.
+
+**Alternatives considered**:
+- Exposing `setAccompanimentVolume(volume: number)` (host identifies non-piano parts): Would be simpler but hides instrument identity from the plugin, preventing future per-instrument volume controls (e.g., cello vs. violin separate sliders). `getInstruments()` + `setPartVolume()` is more composable.
+- Leaking `ToneAdapter` reference into the plugin: Violates Principle II (hexagonal architecture). Rejected.
+
+**Key references**:
+- `frontend/src/plugin-api/types.ts` (v10) — `PluginScorePlayerContext` interface
+- `frontend/src/plugin-api/scorePlayerContext.ts` — `setPlaybackStaffFilter` implementation pattern
+- Feature 083 spec/contracts — precedent for Plugin API extension
+
+---
+
+## R-003: Instrument Part Identification
+
+**Question**: How are instrument parts identified as piano vs. violin (or "other")?
+
+**Decision**: Use `Score.instruments[partIndex].instrument_type` (canonical string, already resolved by `resolveInstrumentType()` during score load). Piano parts have `instrument_type === 'piano'`. Any part with a different type is an accompaniment part.
+
+**Rationale**: `resolveInstrumentType()` in `InstrumentTimbres.ts` normalises MusicXML instrument names to canonical types. This resolution already happens during `toneAdapter.initChannel()` on score load. The `Score.instruments[]` array is populated by the WASM parser from MusicXML `<score-part>` metadata. The `PluginInstrumentInfo` type simply surfaces what is already computed.
+
+**Alternatives considered**:
+- Matching on display name strings (e.g. "Violin", "Piano"): Fragile, locale-sensitive, already rejected by `resolveInstrumentType()` in favour of canonical types.
+- Treating instruments[0] as always piano: Wrong — MusicXML part order is not guaranteed.
+
+**Piano part detection rule**: `instrumentType === 'piano'`. All other types are accompaniment parts.
+
+**Fail-closed rule (FR-011)**: If the score has no part with `instrumentType === 'piano'`, the feature does not activate (no accompaniment slider shown). The `hasAccompaniment` flag is `false` when there are zero piano parts OR zero non-piano parts.
+
+**Key references**:
+- `frontend/src/services/playback/InstrumentTimbres.ts` — `resolveInstrumentType()`
+- `frontend/src/types/score.ts` — `Score.instruments[].instrument_type`
+
+---
+
+## R-004: Staff Filter Coexistence (Feature 084)
+
+**Question**: Does `setPlaybackStaffFilter` (one-hand mode) conflict with per-part volume control?
+
+**Decision**: No conflict. `setPlaybackStaffFilter` filters which staff of `instruments[0]` (the piano instrument) produces audio. It operates on staff-level note filtering in the playback scheduler, not on `ToneAdapter` channels. `setPartVolume` operates on the `Tone.Volume` node for a specific `partIndex`. The two mechanisms are orthogonal.
+
+**Rationale**: `setPlaybackStaffFilter` sets a filter state that is checked in `PlaybackScheduler` when scheduling notes from the piano staff array. The accompaniment parts (violin, etc.) have their own `partIndex` channels and are unaffected by piano staff filtering. The violin notes are tagged with `_partIndex = violinPartIndex` and routed to the violin channel regardless of the piano staff filter state.
+
+**Key references**:
+- `frontend/src/plugin-api/scorePlayerContext.ts` line 203 — `playbackStaffFilter` state
+- `frontend/src/services/playback/PlaybackScheduler.ts` — staff filter application point
+
+---
+
+## R-005: Accompaniment Volume Persistence Strategy
+
+**Question**: Where should accompaniment volume state live, given it must persist across score changes but reset on page reload?
+
+**Decision**: Module-level singleton or React context value outside the Practice plugin component tree — essentially page-session state. The simplest implementation is a module-level variable in `useAccompaniment.ts` that survives component unmount/remount (score changes) but is initialised fresh on page load.
+
+**Rationale**: The spec explicitly states: "resets to the default only on a full page reload." This rules out `localStorage` (survives reload) and per-render state (resets on unmount). Module-level state in the hook file is the standard React pattern for this use case — used elsewhere in the codebase (e.g., `ToneAdapter` singleton, `ScoreCache` singleton).
+
+**Alternatives considered**:
+- `useRef` inside PracticeViewPlugin: Resets on plugin unmount — does not survive score changes that cause remount.
+- `localStorage` with profile scoping: Over-engineered for a transient audio preference; Principle VIII exemption justified.
+- React context: Valid but adds a Provider wrapper; module-level state is simpler for a single scalar.
+
+**Default value**: `0.7` (70%, per FR-004).
+
+---
+
+## R-006: Toolbar Integration Point
+
+**Question**: Where in the Practice plugin toolbar should the accompaniment volume slider be placed?
+
+**Decision**: In `practiceToolbar.tsx`, after the tempo multiplier slider and before the MIDI connectivity controls, conditionally rendered only when `hasAccompaniment === true`.
+
+**Rationale**: The toolbar already contains: profile icon (rightmost), MIDI connectivity, staff dropdown, and tempo multiplier. The accompaniment volume slider is logically adjacent to the tempo multiplier (both affect the sound of the current practice session). Conditional rendering on `hasAccompaniment` satisfies FR-008 (no new UI for piano-only scores) and SC-004.
+
+**Key references**:
+- `frontend/plugins/practice-view-plugin/practiceToolbar.tsx` — existing toolbar layout
+- Profile icon at line 484 (Feature 080) — must remain rightmost
+
+---
+
+## R-007: ToneAdapter `setPartVolume` Public Method
+
+**Question**: Does `ToneAdapter` need a new public method, or can `scorePlayerContext.ts` call `getChannel()` directly?
+
+**Decision**: `scorePlayerContext.ts` calls `toneAdapter.getChannel(partIndex)?.setVolume(volume)` directly — no new public method on `ToneAdapter` is needed. `getChannel()` is already public (line 734 of `ToneAdapter.ts`).
+
+**Rationale**: The pattern is consistent with Feature 088's `ToneAdapter.initChannel()` call in `scorePlayerContext.ts`. Adding a `setPartVolume` wrapper on `ToneAdapter` would be an unnecessary layer of indirection for a single-line delegation.
+
+**Clamp behaviour**: Volume is clamped to `[0, 1]` before calling `setVolume()` to guard against invalid plugin inputs.
+
+---
+
+## Summary Table
+
+| # | Question | Decision |
+|---|----------|----------|
+| R-001 | Audio pipeline for per-part volume | Existing `PlaybackChannel.setVolume()` via `ToneAdapter.getChannel()` |
+| R-002 | Plugin API gaps | Add `getInstruments()` + `setPartVolume()` as Plugin API v11 |
+| R-003 | Piano part identification | `instrumentType === 'piano'` (canonical, resolved at load) |
+| R-004 | Feature 084 coexistence | No conflict; staff filter and part volume are orthogonal |
+| R-005 | Volume persistence | Module-level singleton in hook file; resets on page reload |
+| R-006 | Toolbar placement | After tempo slider, before MIDI controls; conditionally rendered |
+| R-007 | ToneAdapter API | Call `getChannel(partIndex)?.setVolume()` directly; no new ToneAdapter method |

--- a/specs/089-piano-violin-practice/spec.md
+++ b/specs/089-piano-violin-practice/spec.md
@@ -9,17 +9,17 @@
 
 ### User Story 1 - Violin Plays Back Automatically During Piano Practice (Priority: P1)
 
-A piano student opens a violin+piano sonata score. They enter the Train plugin in score-preset mode to practice the piano part. As the exercise begins, the violin part plays back automatically as accompaniment. The student hears the full musical context of the piece — the violin melody against their piano performance — making it easier to stay in time and match phrasing.
+A piano student opens a violin+piano sonata score. They open the Practice plugin to practice the piano part. As they start playback in practice mode, the violin part plays back automatically as accompaniment. The student hears the full musical context of the piece — the violin melody against their piano performance — making it easier to stay in time and match phrasing.
 
 **Why this priority**: This is the core value of the feature. Without the violin playing, a pianist practicing an ensemble piece lacks the melodic context that drives their accompaniment choices. Hearing the partner instrument is the primary reason such scores exist in this context.
 
-**Independent Test**: Load a two-instrument score (violin + piano) in the Train plugin score-preset mode, start an exercise, and verify that the violin part plays back throughout the exercise while the piano practice proceeds normally.
+**Independent Test**: Load a two-instrument score (violin + piano) in the Practice plugin, enable practice mode, start playback, and verify that the violin part plays back throughout the practice session while the piano practice proceeds normally.
 
 **Acceptance Scenarios**:
 
 1. **Given** a score containing a violin part and a piano part is loaded, **When** the user starts a piano practice exercise, **Then** the violin part plays back automatically in sync with the exercise.
-2. **Given** a violin+piano exercise is active, **When** playback reaches a measure where only the violin has notes, **Then** the violin audio is heard and no piano notes are expected from the user at that moment.
-3. **Given** a violin+piano exercise is active, **When** playback reaches a measure where both instruments have simultaneous notes, **Then** the violin plays back and the user is expected to play the piano notes.
+2. **Given** a violin+piano practice session is active, **When** playback reaches a measure where only the violin has notes, **Then** the violin audio is heard and no piano notes are expected from the user at that moment.
+3. **Given** a violin+piano practice session is active, **When** playback reaches a measure where both instruments have simultaneous notes, **Then** the violin plays back and the user is expected to play the piano notes.
 4. **Given** a score containing only piano parts (no violin), **When** the user starts a practice exercise, **Then** behaviour is identical to today — no accompaniment plays and no violin-related UI is shown.
 
 ---
@@ -30,43 +30,43 @@ A student finds the violin playback too loud relative to their piano playing and
 
 **Why this priority**: Accompaniment balance is a core musical need. A single global volume knob would not allow the student to choose how prominent the violin is relative to their own playing feedback.
 
-**Independent Test**: Load a violin+piano score, start a practice exercise, adjust the violin accompaniment volume control, and confirm that the violin gets louder/quieter without affecting the piano note feedback volume.
+**Independent Test**: Load a violin+piano score in the Practice plugin, start playback in practice mode, adjust the violin accompaniment volume control, and confirm that the violin gets louder/quieter without affecting the piano note feedback volume.
 
 **Acceptance Scenarios**:
 
-1. **Given** a violin+piano exercise is active, **When** the user decreases the violin volume control, **Then** the violin accompaniment becomes quieter while piano note playback volume is unchanged.
-2. **Given** a violin+piano exercise is active, **When** the user sets the violin volume to zero (mute), **Then** the violin is completely silent for that and subsequent rounds until the volume is raised.
-3. **Given** the user has adjusted the violin volume, **When** they restart the exercise, **Then** the adjusted volume level is retained.
+1. **Given** a violin+piano practice session is active, **When** the user decreases the violin volume control, **Then** the violin accompaniment becomes quieter while piano note playback volume is unchanged.
+2. **Given** a violin+piano practice session is active, **When** the user sets the violin volume to zero (mute), **Then** the violin is completely silent for that and subsequent rounds until the volume is raised.
+3. **Given** the user has adjusted the violin volume, **When** they stop and restart the practice session, **Then** the adjusted volume level is retained.
 
 ---
 
 ### User Story 3 - Violin Accompaniment Follows Practice Tempo (Priority: P2)
 
-A student is practicing a difficult passage at 60% of the score's original tempo using the tempo setting. The violin accompaniment plays back at the same reduced tempo, staying perfectly in sync with the slowed-down piano exercise.
+A student is practicing a difficult passage at 60% of the score's original tempo using the Practice plugin's tempo multiplier. The violin accompaniment plays back at the same reduced tempo, staying perfectly in sync with the slowed-down practice session.
 
 **Why this priority**: If the violin plays at full tempo while the piano practice is slowed down, the two are out of sync, making the accompaniment useless or distracting.
 
-**Independent Test**: Load a violin+piano score, set practice tempo to below 100%, start an exercise, and verify the violin playback is aligned with the adjusted tempo.
+**Independent Test**: Load a violin+piano score in the Practice plugin, set the tempo multiplier to below 100%, start playback in practice mode, and verify the violin playback is aligned with the adjusted tempo.
 
 **Acceptance Scenarios**:
 
-1. **Given** the practice tempo is set to a value less than 100%, **When** a violin+piano exercise starts, **Then** the violin plays back at the same tempo as the practice exercise.
-2. **Given** the user changes the tempo mid-session, **When** the next exercise round begins, **Then** the violin accompaniment starts at the newly selected tempo.
+1. **Given** the tempo multiplier is set to a value less than 100%, **When** a violin+piano practice session starts, **Then** the violin plays back at the same scaled tempo as the practice session.
+2. **Given** the user changes the tempo multiplier mid-session, **When** playback is restarted, **Then** the violin accompaniment plays at the newly selected tempo.
 
 ---
 
 ### User Story 4 - Violin Accompaniment Works With One-Hand Practice Mode (Priority: P3)
 
-A student practices only the right hand of the piano part while hearing the violin. They select "Right hand" in the Train plugin; only piano treble-staff notes are expected from the user, but the violin still plays back in full as accompaniment.
+A student practices only the right hand of the piano part while hearing the violin. They select the piano treble staff in the Practice plugin's staff dropdown (feature 084); only treble-staff piano notes are expected from the user, but the violin still plays back in full as accompaniment.
 
-**Why this priority**: One-hand mode (feature 084) is a sibling feature; both must coexist without conflict. A student isolating one piano hand still benefits from hearing the violin partner.
+**Why this priority**: One-hand mode (feature 084) is a sibling feature in the Practice plugin; both must coexist without conflict. A student isolating one piano hand still benefits from hearing the violin partner.
 
-**Independent Test**: Load a violin+piano score, select right-hand-only piano mode, start an exercise, and verify that the violin plays back while only right-hand piano notes are active in the exercise.
+**Independent Test**: Load a violin+piano score in the Practice plugin, select the piano treble staff from the staff dropdown, start practice mode, and verify that the violin plays back while only right-hand piano notes are active.
 
 **Acceptance Scenarios**:
 
-1. **Given** a violin+piano score is loaded and right-hand-only piano mode is selected, **When** the exercise runs, **Then** the violin accompaniment plays in full while only treble-staff piano notes are expected from the user.
-2. **Given** a violin+piano score is loaded and left-hand-only piano mode is selected, **When** the exercise runs, **Then** the violin plays and only bass-staff piano notes are expected.
+1. **Given** a violin+piano score is loaded and the piano treble staff is selected in the staff dropdown, **When** the practice session runs, **Then** the violin accompaniment plays in full while only treble-staff piano notes are expected from the user.
+2. **Given** a violin+piano score is loaded and the piano bass staff is selected in the staff dropdown, **When** the practice session runs, **Then** the violin plays and only bass-staff piano notes are expected.
 
 ---
 
@@ -74,48 +74,61 @@ A student practices only the right hand of the piano part while hearing the viol
 
 - What happens when the score has two violin parts and one piano part? All non-piano parts play back together as accompaniment; both violin parts are heard.
 - What happens when the score has violin but no piano part? The feature does not activate; the score is treated as a non-piano score and is not available for piano practice.
-- What happens if the violin part and piano part have different lengths? Violin playback follows the piano exercise measure range; if the violin has no notes in a given measure it is silent for that measure.
-- What happens during the lead-in / count-in before the exercise? The violin starts playback from the same point as the piano exercise, including any lead-in measures.
-- What happens when the user pauses or restarts mid-exercise? Violin playback pauses and restarts in lockstep with the piano exercise state.
+- What happens when MusicXML instrument metadata is absent or ambiguous and the piano part cannot be identified? Piano practice mode is unavailable for that score; the system fails closed rather than guessing.
+- What happens if the violin part and piano part have different lengths? Violin playback follows the loaded score's measure range; if the violin has no notes in a given measure it is silent for that measure.
+- What happens during the lead-in / count-in before the session? The violin plays its notated score notes during lead-in measures (same behaviour as the Play view); it does not stay silent during the lead-in.
+- What happens when the user pauses or restarts mid-session? Violin playback pauses and restarts in lockstep with the Practice plugin's playback state.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: When the loaded score contains at least one violin part and at least one piano part, the system MUST play back the violin part during piano practice exercises.
-- **FR-002**: Violin accompaniment playback MUST be synchronised with the piano exercise at all times — same tempo, same current measure, same start/stop events.
+- **FR-001**: When the loaded score contains at least one violin part and at least one piano part, the system MUST play back the violin part during Practice plugin sessions.
+- **FR-002**: Violin accompaniment playback MUST be synchronised with the practice session at all times — same tempo multiplier, same current measure, same start/stop/pause events — including lead-in measures, during which the violin plays its notated score notes.
 - **FR-003**: The system MUST provide an independent volume control for the violin accompaniment, separate from the piano note feedback volume.
-- **FR-004**: The violin accompaniment volume control MUST support the full range from fully muted (silent) to fully audible, defaulting to a clearly audible but not dominant level.
-- **FR-005**: The violin accompaniment volume setting MUST persist across exercise rounds within the same session.
-- **FR-006**: Violin accompaniment MUST play back at whatever tempo the practice session is set to, matching the exercise tempo exactly.
-- **FR-007**: Violin accompaniment MUST coexist with one-hand piano practice mode: the violin plays in full regardless of which piano hand is selected.
+- **FR-004**: The violin accompaniment volume control MUST support the full range from fully muted (silent) to fully audible, defaulting to **70%**.
+- **FR-005**: The violin accompaniment volume setting MUST persist across practice runs and across score changes within the same page session; it resets to the default only on a full page reload.
+- **FR-006**: Violin accompaniment MUST play back at the tempo produced by the Practice plugin's tempo multiplier, staying in sync with the score player at all times.
+- **FR-007**: Violin accompaniment MUST coexist with one-hand mode (feature 084 — Practice plugin staff dropdown): the violin plays in full regardless of which piano staff is selected.
 - **FR-008**: For scores with no violin part, no violin-related controls or behaviour MUST be visible or active.
 - **FR-009**: For scores with multiple non-piano instrument parts, all non-piano parts MUST play back together as accompaniment.
-- **FR-010**: Violin accompaniment MUST pause, resume, and restart in lockstep with the piano exercise playback state.
+- **FR-010**: Violin accompaniment MUST pause, resume, and restart in lockstep with the Practice plugin's playback state.
+- **FR-011**: If the loaded score's piano part cannot be unambiguously identified from MusicXML instrument metadata, the piano practice mode MUST be unavailable for that score; no violin accompaniment controls are shown.
 
 ### Key Entities
 
 - **Accompaniment Part**: One or more non-piano instrument parts from the loaded score that play back automatically during piano practice. For violin+piano scores, this is the violin part(s).
 - **Piano Part**: The part(s) in the score assigned to piano; this is the instrument the user practices and is detected via MIDI.
-- **Accompaniment Volume**: An independent gain setting (0–100%) for the accompaniment parts, distinct from piano feedback volume. Persists within a session.
-- **Practice Exercise**: A single run of the Train plugin from start to results screen; violin accompaniment is active for its full duration.
+- **Accompaniment Volume**: An independent gain setting (0–100%) for the accompaniment parts, distinct from the piano note feedback volume. Persists across practice runs within the same page session.
+- **Practice Session**: A single playback run in the Practice plugin from play to stop; violin accompaniment is active for its full duration.
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
-- **SC-001**: When a violin+piano score is loaded, violin accompaniment plays back during 100% of exercise runs without any additional user setup required.
-- **SC-002**: The violin accompaniment and piano exercise remain in sync — no audible drift across any score at any supported tempo.
+- **SC-001**: When a violin+piano score is loaded in the Practice plugin, violin accompaniment plays back during 100% of practice sessions without any additional user setup required.
+- **SC-002**: The violin accompaniment and piano practice session remain in sync — no audible drift across any score at any supported tempo multiplier.
 - **SC-003**: Adjusting the violin volume takes no more than one user interaction (a single slider move or tap).
-- **SC-004**: Scores without a violin part show zero new UI elements — existing behaviour is fully preserved.
-- **SC-005**: One-hand piano practice exercises with violin accompaniment produce no regressions in note detection or scoring accuracy compared to one-hand exercises without accompaniment.
+- **SC-004**: Scores without a violin part show zero new UI elements — existing Practice plugin behaviour is fully preserved.
+- **SC-005**: One-hand piano practice with violin accompaniment produces no regressions in note detection or scoring accuracy compared to one-hand practice without accompaniment.
 
 ## Assumptions
 
 - The system can identify which parts in a loaded MusicXML score are piano parts and which are violin (or other non-piano) parts, using instrument metadata already present in MusicXML.
 - The violin accompaniment is rendered from the score's notation data (same source as piano note scheduling), not from a separate audio file.
-- The accompaniment volume control is placed in the Train plugin's configuration panel, near the existing tempo and MIDI volume controls.
+- **Audio synthesis uses the same pipeline as the Play view**, which already plays piano and violin parts together. No separate engine or instance is introduced; the accompaniment is routed through the existing shared audio engine with an independent gain node for volume control.
+- The accompaniment volume control is placed in the Practice plugin's toolbar, near the existing tempo multiplier and MIDI controls.
 - "Violin" in this context means any part tagged as a violin instrument in the MusicXML; the feature is generalised to "all non-piano parts" to avoid instrument-by-instrument special casing.
-- The feature applies to the Train plugin's score-preset mode; free-practice or scales modes are unaffected.
-- Accompaniment volume is stored in component or session state and does not need to survive full page reloads for the initial implementation.
+- The feature applies to the Practice plugin only; the Train plugin (note drills) is unaffected.
+- Accompaniment volume is stored in global page-session state (e.g. a shared store or context), shared across all loaded scores; it does not need to survive full page reloads.
+
+## Clarifications
+
+### Session 2026-04-29
+
+- Q: What audio synthesis approach should be used for violin accompaniment playback? → A: Use the same pipeline as the Play view, which already supports playing piano and violin together (shared engine, independent gain channel).
+- Q: What is the default accompaniment volume level? → A: 70%.
+- Q: What is the persistence scope for the accompaniment volume setting? → A: Global per page session — shared across score changes, resets on full page reload.
+- Q: What is the fallback when piano part identification from MusicXML metadata is ambiguous? → A: Fail closed — piano practice mode is unavailable for that score.
+- Q: Does the violin play during the count-in / lead-in measures? → A: Yes — plays notated score notes during lead-in (same as Play view).
 

--- a/specs/089-piano-violin-practice/spec.md
+++ b/specs/089-piano-violin-practice/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Piano Practice with Violin Accompaniment Playback
+
+**Feature Branch**: `089-piano-violin-practice`  
+**Created**: 2026-04-29  
+**Status**: Draft  
+**Input**: User description: "Support Piano Practice with Violin playback - If the practice score has a violin and a piano, when you practice piano performance, you can hear the violin playback to pair with the piano practice"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Violin Plays Back Automatically During Piano Practice (Priority: P1)
+
+A piano student opens a violin+piano sonata score. They enter the Train plugin in score-preset mode to practice the piano part. As the exercise begins, the violin part plays back automatically as accompaniment. The student hears the full musical context of the piece — the violin melody against their piano performance — making it easier to stay in time and match phrasing.
+
+**Why this priority**: This is the core value of the feature. Without the violin playing, a pianist practicing an ensemble piece lacks the melodic context that drives their accompaniment choices. Hearing the partner instrument is the primary reason such scores exist in this context.
+
+**Independent Test**: Load a two-instrument score (violin + piano) in the Train plugin score-preset mode, start an exercise, and verify that the violin part plays back throughout the exercise while the piano practice proceeds normally.
+
+**Acceptance Scenarios**:
+
+1. **Given** a score containing a violin part and a piano part is loaded, **When** the user starts a piano practice exercise, **Then** the violin part plays back automatically in sync with the exercise.
+2. **Given** a violin+piano exercise is active, **When** playback reaches a measure where only the violin has notes, **Then** the violin audio is heard and no piano notes are expected from the user at that moment.
+3. **Given** a violin+piano exercise is active, **When** playback reaches a measure where both instruments have simultaneous notes, **Then** the violin plays back and the user is expected to play the piano notes.
+4. **Given** a score containing only piano parts (no violin), **When** the user starts a practice exercise, **Then** behaviour is identical to today — no accompaniment plays and no violin-related UI is shown.
+
+---
+
+### User Story 2 - Violin Accompaniment Volume Is Independently Adjustable (Priority: P2)
+
+A student finds the violin playback too loud relative to their piano playing and wants to lower it. They adjust a violin volume slider without affecting the piano playback volume. Alternatively, they silence the violin entirely to practice unaccompanied, then bring it back for the next round.
+
+**Why this priority**: Accompaniment balance is a core musical need. A single global volume knob would not allow the student to choose how prominent the violin is relative to their own playing feedback.
+
+**Independent Test**: Load a violin+piano score, start a practice exercise, adjust the violin accompaniment volume control, and confirm that the violin gets louder/quieter without affecting the piano note feedback volume.
+
+**Acceptance Scenarios**:
+
+1. **Given** a violin+piano exercise is active, **When** the user decreases the violin volume control, **Then** the violin accompaniment becomes quieter while piano note playback volume is unchanged.
+2. **Given** a violin+piano exercise is active, **When** the user sets the violin volume to zero (mute), **Then** the violin is completely silent for that and subsequent rounds until the volume is raised.
+3. **Given** the user has adjusted the violin volume, **When** they restart the exercise, **Then** the adjusted volume level is retained.
+
+---
+
+### User Story 3 - Violin Accompaniment Follows Practice Tempo (Priority: P2)
+
+A student is practicing a difficult passage at 60% of the score's original tempo using the tempo setting. The violin accompaniment plays back at the same reduced tempo, staying perfectly in sync with the slowed-down piano exercise.
+
+**Why this priority**: If the violin plays at full tempo while the piano practice is slowed down, the two are out of sync, making the accompaniment useless or distracting.
+
+**Independent Test**: Load a violin+piano score, set practice tempo to below 100%, start an exercise, and verify the violin playback is aligned with the adjusted tempo.
+
+**Acceptance Scenarios**:
+
+1. **Given** the practice tempo is set to a value less than 100%, **When** a violin+piano exercise starts, **Then** the violin plays back at the same tempo as the practice exercise.
+2. **Given** the user changes the tempo mid-session, **When** the next exercise round begins, **Then** the violin accompaniment starts at the newly selected tempo.
+
+---
+
+### User Story 4 - Violin Accompaniment Works With One-Hand Practice Mode (Priority: P3)
+
+A student practices only the right hand of the piano part while hearing the violin. They select "Right hand" in the Train plugin; only piano treble-staff notes are expected from the user, but the violin still plays back in full as accompaniment.
+
+**Why this priority**: One-hand mode (feature 084) is a sibling feature; both must coexist without conflict. A student isolating one piano hand still benefits from hearing the violin partner.
+
+**Independent Test**: Load a violin+piano score, select right-hand-only piano mode, start an exercise, and verify that the violin plays back while only right-hand piano notes are active in the exercise.
+
+**Acceptance Scenarios**:
+
+1. **Given** a violin+piano score is loaded and right-hand-only piano mode is selected, **When** the exercise runs, **Then** the violin accompaniment plays in full while only treble-staff piano notes are expected from the user.
+2. **Given** a violin+piano score is loaded and left-hand-only piano mode is selected, **When** the exercise runs, **Then** the violin plays and only bass-staff piano notes are expected.
+
+---
+
+### Edge Cases
+
+- What happens when the score has two violin parts and one piano part? All non-piano parts play back together as accompaniment; both violin parts are heard.
+- What happens when the score has violin but no piano part? The feature does not activate; the score is treated as a non-piano score and is not available for piano practice.
+- What happens if the violin part and piano part have different lengths? Violin playback follows the piano exercise measure range; if the violin has no notes in a given measure it is silent for that measure.
+- What happens during the lead-in / count-in before the exercise? The violin starts playback from the same point as the piano exercise, including any lead-in measures.
+- What happens when the user pauses or restarts mid-exercise? Violin playback pauses and restarts in lockstep with the piano exercise state.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When the loaded score contains at least one violin part and at least one piano part, the system MUST play back the violin part during piano practice exercises.
+- **FR-002**: Violin accompaniment playback MUST be synchronised with the piano exercise at all times — same tempo, same current measure, same start/stop events.
+- **FR-003**: The system MUST provide an independent volume control for the violin accompaniment, separate from the piano note feedback volume.
+- **FR-004**: The violin accompaniment volume control MUST support the full range from fully muted (silent) to fully audible, defaulting to a clearly audible but not dominant level.
+- **FR-005**: The violin accompaniment volume setting MUST persist across exercise rounds within the same session.
+- **FR-006**: Violin accompaniment MUST play back at whatever tempo the practice session is set to, matching the exercise tempo exactly.
+- **FR-007**: Violin accompaniment MUST coexist with one-hand piano practice mode: the violin plays in full regardless of which piano hand is selected.
+- **FR-008**: For scores with no violin part, no violin-related controls or behaviour MUST be visible or active.
+- **FR-009**: For scores with multiple non-piano instrument parts, all non-piano parts MUST play back together as accompaniment.
+- **FR-010**: Violin accompaniment MUST pause, resume, and restart in lockstep with the piano exercise playback state.
+
+### Key Entities
+
+- **Accompaniment Part**: One or more non-piano instrument parts from the loaded score that play back automatically during piano practice. For violin+piano scores, this is the violin part(s).
+- **Piano Part**: The part(s) in the score assigned to piano; this is the instrument the user practices and is detected via MIDI.
+- **Accompaniment Volume**: An independent gain setting (0–100%) for the accompaniment parts, distinct from piano feedback volume. Persists within a session.
+- **Practice Exercise**: A single run of the Train plugin from start to results screen; violin accompaniment is active for its full duration.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: When a violin+piano score is loaded, violin accompaniment plays back during 100% of exercise runs without any additional user setup required.
+- **SC-002**: The violin accompaniment and piano exercise remain in sync — no audible drift across any score at any supported tempo.
+- **SC-003**: Adjusting the violin volume takes no more than one user interaction (a single slider move or tap).
+- **SC-004**: Scores without a violin part show zero new UI elements — existing behaviour is fully preserved.
+- **SC-005**: One-hand piano practice exercises with violin accompaniment produce no regressions in note detection or scoring accuracy compared to one-hand exercises without accompaniment.
+
+## Assumptions
+
+- The system can identify which parts in a loaded MusicXML score are piano parts and which are violin (or other non-piano) parts, using instrument metadata already present in MusicXML.
+- The violin accompaniment is rendered from the score's notation data (same source as piano note scheduling), not from a separate audio file.
+- The accompaniment volume control is placed in the Train plugin's configuration panel, near the existing tempo and MIDI volume controls.
+- "Violin" in this context means any part tagged as a violin instrument in the MusicXML; the feature is generalised to "all non-piano parts" to avoid instrument-by-instrument special casing.
+- The feature applies to the Train plugin's score-preset mode; free-practice or scales modes are unaffected.
+- Accompaniment volume is stored in component or session state and does not need to survive full page reloads for the initial implementation.
+

--- a/specs/089-piano-violin-practice/tasks.md
+++ b/specs/089-piano-violin-practice/tasks.md
@@ -1,0 +1,197 @@
+# Tasks: Piano Practice with Violin Accompaniment Playback
+
+**Input**: Design documents from `/specs/089-piano-violin-practice/`
+**Prerequisites**: plan.md ✅ · spec.md ✅ · research.md ✅ · data-model.md ✅ · contracts/plugin-api-v11.ts ✅ · quickstart.md ✅
+
+**Principle V — Test-First (NON-NEGOTIABLE)**: In each phase, test tasks MUST be written and confirmed failing before their implementation tasks. No exceptions.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm development environment and no conflicting changes
+
+- [X] T001 Verify Feature 088 ToneAdapter.getChannel() is accessible from frontend/src/plugin-api/scorePlayerContext.ts and run `cd frontend && npx tsc --noEmit` to confirm clean baseline
+
+---
+
+## Phase 2: Foundational — Plugin API v11
+
+**Purpose**: Extend the Plugin API with instrument metadata and per-part volume control. Blocks ALL user story work — no US1/US2/US3/US4 task can begin until this phase is complete.
+
+**⚠️ CRITICAL**: US1 through US4 all depend on `getInstruments()` and `setPartVolume()` being available in `PluginScorePlayerContext`. Do not start Phase 3 until T006 passes.
+
+- [X] T002 Add `PluginInstrumentInfo` interface and update header comment to v11 in `frontend/src/plugin-api/types.ts`
+- [X] T003 Extend `PluginScorePlayerContext` interface with `getInstruments()` and `setPartVolume()` signatures in `frontend/src/plugin-api/types.ts`
+- [X] T004 Write failing contract tests for `getInstruments()` and `setPartVolume()` in `frontend/tests/integration/accompaniment.test.ts` (must be red — no implementation yet)
+- [X] T005 [P] Implement `getInstruments()` in `frontend/src/plugin-api/scorePlayerContext.ts` reading from `scoreRef.current.instruments` and applying `resolveInstrumentType()`
+- [X] T006 [P] Implement `setPartVolume(partIndex, volume)` in `frontend/src/plugin-api/scorePlayerContext.ts` using `ToneAdapter.getInstance().getChannel(partIndex)?.setVolume(Math.max(0, Math.min(1, volume)))`
+- [X] T007 Update `createNoOpScorePlayer()` stub and proxy delegation object in `frontend/src/plugin-api/scorePlayerContext.ts` to include `getInstruments: () => []` and `setPartVolume: () => {}`
+
+**Checkpoint**: `frontend/tests/integration/accompaniment.test.ts` contract tests (T004) now pass. TypeScript compiles clean. Phase 3 may begin.
+
+---
+
+## Phase 3: User Story 1 — Violin Plays Back Automatically During Piano Practice (Priority: P1) 🎯 MVP
+
+**Goal**: When a violin+piano score is loaded in the Practice plugin, the violin part plays at 70% volume automatically without any user action.
+
+**Independent Test**: Load a violin+piano score in the Practice plugin. Start playback. Confirm violin audio is audible (accompaniment active at 70% gain via ToneAdapter channel). Load a piano-only score. Confirm no new UI appears and playback is identical to today.
+
+- [X] T008 [US1] Write failing unit tests for `useAccompaniment` hook in `frontend/plugins/practice-view-plugin/useAccompaniment.test.ts` covering: detects accompaniment parts, derives `hasAccompaniment=true` for violin+piano score, derives `hasAccompaniment=false` for piano-only score, applies 70% default volume to all non-piano partIndexes on score load (must be red — hook does not exist yet)
+- [X] T009 [US1] Create `useAccompaniment.ts` in `frontend/plugins/practice-view-plugin/` — hook that calls `scorePlayer.getInstruments()`, derives `accompanimentParts` (non-piano parts) and `hasAccompaniment`, reads/writes `pageSessionVolume` module-level singleton (default 0.7), calls `scorePlayer.setPartVolume()` for each accompaniment part on score change and on volume change, returns `{ hasAccompaniment, volume, setVolume }`
+- [X] T010 [US1] Modify `PracticeViewPlugin.tsx` to call `useAccompaniment(context.scorePlayer)` and pass `{ hasAccompaniment, accompanimentVolume: volume, onAccompanimentVolumeChange: setVolume }` props to `PracticeToolbar`
+- [X] T011 [P] [US1] Write regression test in `frontend/plugins/practice-view-plugin/useAccompaniment.test.ts`: piano-only score (no non-piano parts) → `hasAccompaniment=false`, `setPartVolume` never called
+
+**Checkpoint**: US1 fully functional and independently testable. Load violin+piano score in Practice plugin → violin plays at 70%. Load piano-only score → identical to today's behaviour. All T008/T011 tests pass.
+
+---
+
+## Phase 4: User Story 2 — Violin Accompaniment Volume Is Independently Adjustable (Priority: P2)
+
+**Goal**: A volume slider appears in the Practice plugin toolbar (only for violin+piano scores) allowing the student to set accompaniment volume 0–100% without affecting piano note detection volume.
+
+**Independent Test**: Load violin+piano score. Drag accompaniment slider from 70% to 30%. Confirm violin quieter, piano feedback unchanged. Drag to 0%. Confirm violin silent. Stop and restart practice — confirm 30% is retained.
+
+- [X] T012 [US2] Write failing component tests for `AccompanimentVolumeSlider` in `frontend/plugins/practice-view-plugin/AccompanimentVolumeSlider.test.tsx` covering: renders slider with current volume value, fires `onVolumeChange` on input change, renders label "Accompaniment", is accessible (aria-label, aria-valuemin=0, aria-valuemax=100), does not render when `visible=false` (must be red — component does not exist yet)
+- [X] T013 [US2] Create `AccompanimentVolumeSlider.tsx` in `frontend/plugins/practice-view-plugin/` — renders an `<input type="range" min={0} max={100}>` slider with "Accompaniment" label, accepts `{ volume: number; onVolumeChange: (v: number) => void; visible: boolean }` props, handles tablet touch targets (min 44px), aria attributes
+- [X] T014 [US2] Modify `practiceToolbar.tsx` to accept `hasAccompaniment`, `accompanimentVolume`, and `onAccompanimentVolumeChange` props and render `<AccompanimentVolumeSlider visible={hasAccompaniment} volume={accompanimentVolume} onVolumeChange={onAccompanimentVolumeChange}>` after the tempo multiplier slider
+- [X] T015 [P] [US2] Write integration test in `frontend/plugins/practice-view-plugin/useAccompaniment.test.ts`: calling `setVolume(0.4)` updates `pageSessionVolume` to 0.4 and immediately calls `setPartVolume(partIndex, 0.4)` for each accompaniment part
+- [X] T016 [P] [US2] Write integration test in `frontend/plugins/practice-view-plugin/useAccompaniment.test.ts`: calling `setVolume(0)` (mute) calls `setPartVolume(partIndex, 0)` — confirms full mute path
+
+**Checkpoint**: US1 + US2 fully functional. Slider visible for violin+piano scores, hidden for piano-only scores. Volume persists across stop/restart within the session. All T012/T015/T016 tests pass.
+
+---
+
+## Phase 5: User Story 3 — Violin Accompaniment Follows Practice Tempo (Priority: P2)
+
+**Goal**: Verify that violin accompaniment stays in sync when the tempo multiplier is changed (no new implementation needed — already correct by ToneAdapter architecture; this phase produces the test that proves it).
+
+**Independent Test**: Load violin+piano score at 60% tempo. Confirm violin plays at the same scaled tempo as the piano practice.
+
+- [X] T017 [US3] Write integration test in `frontend/tests/integration/accompaniment.test.ts`: mock scorePlayer with `setTempoMultiplier`, confirm that changing tempo multiplier does not require any additional accompaniment-specific logic (verifies R-004 orthogonality: the ToneAdapter channels are all driven by the same transport clock)
+
+**Checkpoint**: US3 verified. Tempo sync is architecturally correct — a single test documents the guarantee.
+
+---
+
+## Phase 6: User Story 4 — Violin Accompaniment Works With One-Hand Practice Mode (Priority: P3)
+
+**Goal**: Verify that `setPlaybackStaffFilter` (Feature 084 staff dropdown) and accompaniment volume control are orthogonal — staff filter affects piano notes only; violin channel is unaffected.
+
+**Independent Test**: Load violin+piano score, select piano treble staff from dropdown, start practice. Confirm violin plays at full accompaniment volume while only right-hand piano notes are expected.
+
+- [X] T018 [US4] Write integration test in `frontend/tests/integration/accompaniment.test.ts`: mock scorePlayer with both `setPlaybackStaffFilter(0)` and `setPartVolume(violinPartIndex, 0.7)` active simultaneously — confirm `setPartVolume` was called for the violin channel (partIndex ≠ 0) and that the staff filter and accompaniment volume states are fully independent
+
+**Checkpoint**: US4 verified. Staff filter coexistence is architecturally guaranteed and documented by test.
+
+---
+
+## Final Phase: Polish & Cross-Cutting Concerns
+
+**Purpose**: Accessibility, styling, regression sweep, and final TypeScript type-check.
+
+- [X] T019 [P] Add tablet-optimized CSS for `AccompanimentVolumeSlider` in `frontend/plugins/practice-view-plugin/practiceToolbar.css` — slider width matching tempo multiplier slider, 44px minimum touch target height, label typography matching existing toolbar labels
+- [X] T020 [P] Add `aria-label="Accompaniment volume"`, `aria-valuemin={0}`, `aria-valuemax={100}`, `aria-valuenow={Math.round(volume * 100)}` to slider `<input>` in `frontend/plugins/practice-view-plugin/AccompanimentVolumeSlider.tsx`
+- [X] T021 Write regression test in `frontend/plugins/practice-view-plugin/PracticeViewPlugin.test.tsx`: piano-only score → AccompanimentVolumeSlider absent from rendered toolbar (SC-004 / FR-008)
+- [X] T022 Run `cd frontend && npx tsc --noEmit` and resolve any TypeScript type errors introduced by v11 Plugin API extension
+- [X] T023 Run `cd frontend && npm run test` (full Vitest suite) and confirm all tests pass with no regressions
+
+---
+
+## Dependencies
+
+### User Story Completion Order
+
+```
+Phase 2 (Plugin API v11)
+  ├── Phase 3 (US1 — automatic playback at 70%) — MVP
+  │     ├── Phase 4 (US2 — volume slider UI)
+  │     │     └── Final Phase (polish)
+  │     ├── Phase 5 (US3 — tempo sync test)  ← can run in parallel with Phase 4
+  │     └── Phase 6 (US4 — staff filter test)  ← can run in parallel with Phase 4
+  └── (no other dependencies)
+```
+
+### Task-Level Dependencies
+
+| Task | Depends On |
+|------|------------|
+| T002 | T001 |
+| T003 | T002 |
+| T004 | T002 (must fail before T005/T006) |
+| T005 | T002, T003 |
+| T006 | T002, T003 |
+| T007 | T005, T006 |
+| T008 | T007 (must fail before T009) |
+| T009 | T007, T008 |
+| T010 | T009 |
+| T011 | T009 |
+| T012 | T010, T011 (must fail before T013) |
+| T013 | T012 |
+| T014 | T013 |
+| T015 | T009 |
+| T016 | T009 |
+| T017 | T009 |
+| T018 | T009 |
+| T019 | T013, T014 |
+| T020 | T013 |
+| T021 | T010, T013 |
+| T022 | T007, T013 |
+| T023 | all prior tasks |
+
+---
+
+## Parallel Execution Examples
+
+### Phase 2 — after T004 is written
+```
+T005 (getInstruments impl)  ←── parallel ──→  T006 (setPartVolume impl)
+     ↓
+T007 (stubs/proxy)
+```
+
+### Phase 3 — after T008 tests written
+```
+T009 (useAccompaniment hook)
+     ↓
+T010 (PracticeViewPlugin wiring)
+     ↓
+T011 (regression test) ←── parallel ──→ [start writing T012 AccompanimentVolumeSlider tests]
+```
+
+### After Phase 3 checkpoint
+```
+Phase 4 (US2 — slider)  ←── parallel ──→  Phase 5 (US3 test)  ←── parallel ──→  Phase 6 (US4 test)
+```
+
+### Final Phase — after T014
+```
+T019 (CSS)  ←── parallel ──→  T020 (aria attrs)  ←── parallel ──→  T021 (regression test)
+                                    ↓
+                               T022 (tsc)
+                                    ↓
+                               T023 (full test run)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP Scope: Phase 2 + Phase 3 (US1 only)
+
+The minimal working product that delivers value:
+
+1. Complete Phase 2 (Plugin API v11) — T001–T007
+2. Complete Phase 3 (US1 — automatic playback) — T008–T011
+
+**After MVP**: Violin plays at 70% automatically in violin+piano scores. No UI yet — volume is fixed at default. This is independently releasable and already satisfies FR-001, FR-002, FR-006, FR-010.
+
+### Incremental Delivery Order
+
+| Release | Tasks | User Value |
+|---------|-------|------------|
+| MVP | T001–T011 | Violin plays automatically in Practice plugin |
+| US2 | T012–T016 | Volume slider: student can balance accompaniment |
+| US3+US4 | T017–T018 | Tests documenting tempo and staff-filter guarantees |
+| Polish | T019–T023 | Accessibility, CSS, full regression sweep |


### PR DESCRIPTION
## Summary

Feature 089: violin (and other non-piano instruments) now sound correctly during step-by-step practice mode, in addition to normal Transport playback.

## Changes

### Plugin API v11 (host)
- Added `getInstruments()`, `setPartVolume()`, `getAccompanimentNotesAtTick()`, and `playAccompanimentAtTick()` to `PluginScorePlayerContext`
- `playAccompanimentAtTick` is implemented host-side in `scorePlayerContext.ts` using ToneAdapter — plugin code never touches ToneAdapter directly (API boundary enforcement)
- Accompaniment notes are pre-indexed on score load from repeat-expanded staves

### Practice plugin
- `useAccompaniment`: detects piano+violin scores; delegates audio to `scorePlayer.playAccompanimentAtTick()`
- `usePracticeMidi`: fires `onCorrectNote` callback after a correct note is detected
- `PracticeViewPlugin`: wires `onCorrectNote → playAccompanimentAtTick`
- Removed `AccompanimentVolumeSlider` (redundant — `InstrumentMixerOverlay` already owns violin volume/mute)
- Removed `setPartVolume` on mount — no longer overrides user-configured mute state

### Bug fixes
- Hands dropdown now visible for violin+piano scores
- Practice engine targets piano notes only (via `pianoStaffOffsetRef`)
- Violin sounds during normal Transport playback

## Test coverage
- 2125 tests passing, TypeScript clean, ESLint 0 errors
- 527 Rust tests passing