### PR TITLE
fix(087/BUG-002): spec artifacts for composite session naming bug

### DIFF
--- a/specs/067-practice-goals-tab/bugs/BUG-001.md
+++ b/specs/067-practice-goals-tab/bugs/BUG-001.md
@@ -1,0 +1,111 @@
+# Bug Report: Goal for Bach Invention No. 1 Starts at Measure 11 Instead of Measure 1
+
+**Type**: Implementation drift  
+**Severity**: High  
+**Feature**: `067-practice-goals-tab`  
+**Reported**: 2026-05-22  
+**Status**: ~~Open~~ **SUPERSEDED — see [BUG-002.md](BUG-002.md)**
+
+> ⚠️ **This report has been invalidated.** The bug description was incorrect: the symptom (wrong start measure) was a misdiagnosis. The actual observed problem is that when a new goal for Bach Invention No. 1 is created, the session scheduling correctly fills existing sessions that have free space — but those sessions retain their old score title and are not updated to reflect the newly added Invention No. 1 tasks. The correct bug report is **BUG-002**.
+
+## Description
+
+When a user creates a new practice goal for the **Bach — Invention No. 1** preloaded score (id: `bach-invention-1`), the generated session's tasks start at **measure 11** (1-based) instead of measure 1. Measures 1–10 are entirely skipped and not covered by any task region.
+
+**Steps to reproduce**:
+1. Open the Sessions plugin → Goals tab.
+2. Tap "Create Goal."
+3. Select the "Bach — Invention No. 1" preloaded score.
+4. Submit the form (or accept defaults).
+5. Open the created session's tasks.
+
+**Expected**: All three tasks (RH, LH, TH) cover the first phrase of Invention No. 1 — measures 1–4 (1-based), i.e., `startMeasure = 1`, `endMeasure = 4`.  
+**Actual**: All three tasks start at measure 11 (1-based), i.e., `startMeasure = 11`, skipping the first 10 measures entirely.
+
+## Root Cause Analysis
+
+### Backend phrase detection is correct
+
+Running `detect_phrases()` against `Bach_InventionNo1.mxl` produces 7 phrases for instrument 0, all correctly ordered by `start_measure` ascending:
+
+| Index | 0-based start | 0-based end | 1-based display |
+|-------|--------------|-------------|-----------------|
+| [0]   | 0            | 3           | measures 1–4    |
+| [1]   | 4            | 5           | measures 5–6    |
+| [2]   | 6            | 9           | measures 7–10   |
+| [3]   | 10           | 14          | measures 11–15  |
+| [4]   | 15           | 16          | measures 16–17  |
+| [5]   | 17           | 19          | measures 18–20  |
+| [6]   | 20           | 21          | measures 21–22  |
+
+The correct first phrase has `start_measure = 0` (0-based) → `startMeasure = 1` (1-based after +1 conversion).
+
+### Plugin API `getPhrases()` is correct
+
+`scorePlayerContext.ts` returns `score.phrases ?? []` directly, preserving the backend sort order. The phrases array starts with `{instrument_index: 0, start_measure: 0, end_measure: 3, ...}`.
+
+### The bug is in `goalEngine.ts` (sessions-plugin) — wrong phrase selection
+
+The spec contract (`specs/067-practice-goals-tab/contracts/plugin-api-v9-goal-extensions.ts`) requires:
+
+> 1. Filter phrases where `instrument_index === 0`, sort by `start_measure` **ascending**, pick first.
+
+The observed behaviour — `startMeasure = 11` (1-based) — corresponds to phrase **[3]** (`start_measure = 10`, 0-based; `startMeasure = 11` after +1 conversion). Phrase [3] is the **longest** phrase in Invention No. 1 (spanning 5 measures: 10–14). This indicates the `goalEngine.ts` implementation is likely sorting phrases by phrase **length descending** (or by `end_measure - start_measure` descending) and picking the first element, instead of sorting by `start_measure` ascending.
+
+Evidence:
+- Phrase [3] has length 5 (measures 10–14) — the longest phrase in Invention No. 1.
+- `10 + 1 = 11` (0-based to 1-based conversion) exactly matches the reported symptom.
+- No other phrase in the set produces `startMeasure = 11` when the +1 conversion is applied.
+
+### Why the unit test (T008) did not catch this
+
+Task T008 ("Unit test: first phrase selection") was marked complete but appears to have used simple mock data (e.g., two or three phrases all starting near measure 0) where sort-by-length and sort-by-start-measure produce the same winner. The mock data did not include a realistic multi-phrase distribution like Invention No. 1, where the longest phrase is **not** the earliest one.
+
+## Artifact Traceability
+
+### spec.md (`067-practice-goals-tab`)
+
+- **Affected user story**: User Story 1 — Create a Practice Goal from a Score (Priority: P1)
+  - Acceptance scenario 3: "tasks are generated: LH (staffIndex 1), RH (staffIndex 0), and TH (staffIndex −1), **each targeting the first phrase's measure range**." The first phrase's measure range is 1–4 (1-based), not 11–15.
+- **Affected requirements**:
+  - **FR-004**: "The system MUST determine the first phrase's measure range from the selected score." The implementation selects the wrong phrase (longest, not first).
+  - **FR-012**: "When a score has no identifiable first phrase boundary, the system MUST fall back to using the first 4 measures." This fallback was never triggered because Invention No. 1 does have a first phrase (measures 0–3, 0-based) — the selection bug bypassed it.
+- **Gap identified**: The spec and research correctly define "first phrase" as smallest `start_measure`. The implementation diverges by picking by length or some other non-ascending-start-measure criterion.
+
+### plan.md (`067-practice-goals-tab`)
+
+- **Affected sections**: N/A — `plan.md` was not fully populated for this feature (template only).
+
+### tasks.md (`067-practice-goals-tab`)
+
+- **Affected tasks**:
+  - **T008** `[X]` — "Unit test: first phrase selection (phrases present, no phrases fallback to 4 measures, fewer than 4 measures fallback) in `plugins-external/sessions-plugin/goalEngine.test.ts`." Marked complete but insufficient coverage: the test does not include a case where the longest phrase is **not** the one with the smallest `start_measure` (as in Invention No. 1).
+  - **T013** `[X]` — "Implement goal engine: first phrase selection, task generation, and session creation logic in `plugins-external/sessions-plugin/goalEngine.ts`." The implementation is incorrect: it does not reliably select the phrase with the smallest `start_measure`.
+- **False completions**: Both T008 and T013 are marked `[X]` done, but T013 has a logic error and T008 lacks the regression case to detect it.
+- **Missing tasks**: Two new tasks are needed:
+  1. Add a regression test to `goalEngine.test.ts` covering a multi-phrase score where the longest phrase is not the earliest (e.g., mimicking Invention No. 1's phrase distribution).
+  2. Fix `goalEngine.ts` phrase selection: `phrases.filter(p => p.instrument_index === 0).sort((a, b) => a.start_measure - b.start_measure)[0]` (ascending sort).
+
+## Recommended Fix
+
+1. **Run `/speckit.bugfix.patch`** to update `spec.md` (clarify FR-004 with explicit "smallest start_measure" wording) and `tasks.md` (reopen T013, add missing regression task for T008).
+2. **Run `/speckit.bugfix.verify`** to confirm consistency across artifacts.
+3. **Fix `goalEngine.ts`** in `plugins-external/sessions-plugin/`:
+   - Change phrase selection from whatever sort criterion is currently used to an explicit ascending sort on `start_measure`:
+     ```typescript
+     const inst0Phrases = phrases
+       .filter(p => p.instrument_index === 0)
+       .sort((a, b) => a.start_measure - b.start_measure);
+     const firstPhrase = inst0Phrases[0] ?? null;
+     ```
+4. **Add regression test in `goalEngine.test.ts`**:
+   - Mock phrase data where the longest phrase is not the first (e.g., measures [0–3], [4–5], [6–9], [10–14]) and assert that `startMeasure === 1` (1-based).
+5. **Resume `/speckit.implement`** to apply code fix and run the full test suite.
+
+## Score-Specific Context
+
+Bach Invention No. 1 (`Bach_InventionNo1.mxl`) has:
+- **22 measures**, binary form, 4/4 time, C Major.
+- A **repeat barline** creating a hard phrase boundary after measure 10 (0-based) = measure 11 (1-based). This divides the score into two halves.
+- Slurs concentrated in the **second half** (around measures 15–17), leaving the first half (measures 0–10) with fallback-grouped phrases.
+- Phrase [3] (measures 10–14, 0-based) is the **longest phrase at 5 measures** and is the first phrase of the second section — making it the accidental "winner" under a length-descending sort.

--- a/specs/067-practice-goals-tab/bugs/BUG-002.md
+++ b/specs/067-practice-goals-tab/bugs/BUG-002.md
@@ -1,0 +1,211 @@
+# Bug Report: Session Title Not Updated When Multi-Goal Scheduling Fills an Existing Session
+
+**Type**: Spec gap  
+**Severity**: Medium  
+**Feature**: `067-practice-goals-tab` (cross-cutting: `070-session-task-distribution`, `087-one-goal-40pct-cap`)  
+**Reported**: 2026-05-22  
+**Status**: Patched  
+**Patched**: 2026-05-22  
+**Supersedes**: [BUG-001.md](BUG-001.md) (incorrect prior report)
+
+---
+
+## Description
+
+When a user creates a new practice goal for the **Bach — Invention No. 1** preloaded score (`bach-invention-1`),
+the practice tasks are generated correctly for all phrases. However, during session scheduling, the system
+fills existing sessions that still have free time capacity — sessions that were originally created for a
+**different score's goal** — rather than creating a brand-new session.
+
+The core problem is that **those existing sessions retain their old title** (which references only the
+previous score), even after new Invention No. 1 tasks are appended to them. The user is shown a session
+whose name does not reflect its actual content.
+
+**Steps to reproduce**:
+
+1. Open the Sessions plugin → Goals tab.
+2. Create a goal for any score (e.g., Arabesque). Verify that a session titled "Learn first phrase —
+   Arabesque" (or similar) is created for tomorrow.
+3. Return to the Goals tab and create a second goal for **Bach — Invention No. 1**.
+4. Open the Sessions tab.
+
+**Expected**: Either  
+  (a) a brand-new session titled "Learn first phrase — Bach: Invention No. 1" (or similar) is created
+  separately, or  
+  (b) the existing session title is updated to reflect all scores it now covers — e.g.,
+  "Arabesque · Bach: Invention No. 1".
+
+**Actual**: The existing Arabesque session remains titled "Learn first phrase — Arabesque" (or similar),
+even though it now also contains Invention No. 1 tasks. The title is misleading and incomplete.
+
+---
+
+## Artifact Traceability
+
+### spec.md (`067-practice-goals-tab`)
+
+- **Affected user story**: User Story 1 — Create a Practice Goal from a Score (Priority: P1)
+  - Acceptance scenario 5: "a new scheduled session with targetDate = tomorrow is created containing
+    the three tasks." — Edge case clarification explicitly states: *"What happens when tomorrow's date
+    already has a scheduled session? A new separate session is created for tomorrow."* The current
+    behaviour violates this edge case: instead of a new separate session, the existing session is
+    reused without a title update.
+- **Affected requirements**:
+  - **FR-007**: "The system MUST create a new scheduled session with targetDate set to the day after
+    creation, containing the generated tasks." — Filling an existing session instead of creating a
+    new one may satisfy the data placement, but the session's `name` field is not updated to reflect
+    the Invention No. 1 content.
+- **Gap identified**: spec.md defines no requirement for how an existing session's title should be
+  composed or updated when tasks from a second score/goal are scheduled into it.
+
+### plan.md (`067-practice-goals-tab`)
+
+- **Affected sections**: N/A — `plan.md` was not fully populated for this feature (template only).
+
+### tasks.md (`067-practice-goals-tab`)
+
+- **Affected tasks**:
+  - **T013** `[X]` — "Implement goal engine: first phrase selection, task generation, and session
+    creation logic in `goalEngine.ts`." The session-creation step sets a session name based solely on
+    the single creating goal's score title. It does not account for sessions that will later receive
+    tasks from a second goal.
+  - **T015** `[X]` — "Create GoalsView component with goal creation flow." The UI wires goal creation
+    but does not update the title of any pre-existing session that receives the new goal's tasks.
+- **Missing tasks**:
+  1. Add a requirement (FR) to spec 067 or spec 087 mandating that a session's title be updated
+     whenever tasks from a new score/goal are scheduled into it.
+  2. Add implementation task: after distributing new goal tasks, inspect each session that receives
+     them and recompute its name from the union of all contributing goal score titles.
+  3. Add unit / integration test: create two goals for different scores, verify that every session
+     that holds tasks from both goals has a composite title referencing both scores.
+
+---
+
+### spec.md (`070-session-task-distribution`)
+
+- **Affected user story**: User Story 3 — Distribute Tasks Across Multiple Sessions (Priority: P1);
+  User Story 4 — Schedule Sessions on Free Days (Priority: P2).
+- **Affected requirements**:
+  - **FR-009**: "All sessions created from a single goal MUST be scheduled on distinct future free days
+    — days without any existing scheduled or active sessions." If existing sessions are being filled
+    rather than newly created, this requirement is potentially being violated by the implementation.
+  - **FR-012**: "Each generated session MUST display its total estimated duration…" — This is about
+    duration display, but a session displaying the wrong score title is an equally serious fidelity
+    issue.
+- **Gap identified**: spec 070 does not define a session-naming convention for sessions that receive
+  tasks from multiple goals. The `DistributedSession` type (T037) carries `tasks`,
+  `totalEstimatedDurationSecs`, and `availableTime` but no `name` field, leaving the session title
+  to be set arbitrarily at creation time in `GoalsView.tsx`.
+
+### tasks.md (`070-session-task-distribution`)
+
+- **Affected tasks**:
+  - **T037** `[X]` — "`DistributedSession` has `tasks`, `totalEstimatedDurationSecs`, `availableTime`."
+    The type intentionally omits a `name` / session-title field. A `scoreTitles: string[]` (or similar)
+    field should be added so the caller can derive a correct composite title at creation time.
+  - **T045** `[X]` — "Update `processScoreSelection()` in `GoalsView.tsx`…call `distributeTasks()`…
+    call `findFreeDays()`." The session-creation step after this call does not recompute or validate
+    session names when an existing session already exists for that free day.
+- **Missing tasks**:
+  1. Add `scoreTitles: string[]` (or equivalent) to `DistributedSession` so session-title composition
+     is data-driven and consistent.
+  2. Add requirement to `sessionDistribution.ts` contract: composite session name algorithm
+     (`scoreTitles.sort().join(' · ')`).
+
+---
+
+### spec.md (`087-one-goal-40pct-cap`)
+
+- **Affected user story**: User Story 3 — Task Deferral and Multi-Session Overflow (Priority: P2).
+  The redistribution orchestration in T023 cancels existing sessions and creates new ones — but
+  the new sessions' names are not specified.
+- **Affected requirements**:
+  - **FR-008**: "The cap enforcement MUST be transparent to the user — no warnings, labels, or
+    indicators about the cap are displayed in the session view." — The title being wrong is the
+    opposite of transparency: the user sees a misleading title.
+- **Gap identified**: spec 087 defines the 40% per-goal cap and session redistribution, but contains
+  no requirement for how multi-goal sessions should be named. T023 ("create new sessions with
+  `goalIds` field") populates `goalIds` but the session's human-readable `name` field is never
+  addressed.
+
+### tasks.md (`087-one-goal-40pct-cap`)
+
+- **Affected tasks**:
+  - **T023** `[X]` — "`redistributeWithMultiGoalCap` orchestration in `GoalsView.tsx`: … create new
+    sessions with `goalIds` field." The session name is set at this creation point, but no logic
+    computes a composite name from the contributing goals' score titles.
+  - **T009** `[X]` — "Add `distributeMultiGoalTasks` test: `DistributedSession.goalIds` is populated."
+    Test verifies `goalIds`, but never asserts that a derived session title covers all contributing
+    score titles. This test gap allowed the naming defect to pass undetected.
+- **False completions**: T023 is marked done but the session `name` field handling is incomplete:
+  names from redistributed sessions reference only the first (or creating) goal's score title.
+- **Missing tasks**:
+  1. Add a new requirement (FR) to spec 087: *"When a session contains tasks from goals linked to
+     two or more distinct scores, the session's name MUST be updated to include all contributing
+     score titles (e.g., alphabetically sorted, joined by `·`)."*
+  2. Update T023 implementation: after calling `distributeMultiGoalTasks`, compute composite session
+     names from each `DistributedSession.goalIds` → look up score titles from goal data →
+     `sortedTitles.join(' · ')`.
+  3. Update T009 unit test to also assert composite session name correctness.
+
+---
+
+## Root Cause Analysis
+
+The bug exists because **no specification across features 067, 070, or 087 defines a session naming
+rule for multi-score sessions**. Each feature addressed the data-placement problem (which tasks go
+into which session, on which date) but none addressed the human-readable identity of a session whose
+task list spans multiple goals and scores.
+
+Specifically:
+- Feature 067 introduced the session name `"Learn first phrase — [Score Title]"` for single-goal
+  sessions and included an edge case ruling that "a new separate session is created" when tomorrow
+  is already occupied. The intent was always one goal → one session.
+- Feature 070 extended goal creation to multi-session distribution, but `DistributedSession` (T037)
+  has no name field — the caller in `GoalsView.tsx` fills the name ad-hoc, presumably reusing the
+  creating goal's score title.
+- Feature 087 introduced redistribution: existing sessions are cancelled and new multi-goal sessions
+  are created. The `goalIds` field was added to sessions, but the `name` field was never updated to
+  reflect the full set of contributing scores.
+
+The result: whenever the multi-goal redistribution path (087 T023) is triggered, the newly created
+sessions carry a name derived from only one of the contributing goals' score titles — whichever
+name happened to be set first or was reused from the cancelled session.
+
+---
+
+## Recommended Fix
+
+1. **Run `/speckit.bugfix.patch`** to add the missing session-naming requirement to:
+   - `specs/087-one-goal-40pct-cap/spec.md` — new FR: "When a session contains tasks from two or
+     more distinct scores, the session name MUST be recomputed from all contributing score titles."
+   - `specs/070-session-task-distribution` (minor): add `scoreTitles` to `DistributedSession` type.
+   - Reopen T023 in `specs/087-one-goal-40pct-cap/tasks.md` (session name update missing).
+   - Add new regression task in `specs/087-one-goal-40pct-cap/tasks.md`.
+
+2. **Run `/speckit.bugfix.verify`** to confirm spec consistency.
+
+3. **Fix `GoalsView.tsx`** in the redistribution path (`redistributeWithMultiGoalCap`):
+   ```typescript
+   // After distributeMultiGoalTasks resolves each DistributedSession:
+   const sessionName = distributedSession.goalIds
+     .map(gid => goalMap[gid]?.scoreTitle ?? gid)
+     .sort()
+     .join(' · ');
+   // Pass sessionName when creating / updating the session.
+   ```
+
+4. **Fix existing-session fill path** (if applicable — non-087 path):
+   When a task is appended to an existing session, recalculate that session's name:
+   ```typescript
+   const allScoreTitles = [...new Set(updatedSession.tasks.map(t => t.scoreTitle ?? '?'))].sort();
+   updatedSession.name = allScoreTitles.join(' · ');
+   ```
+
+5. **Add regression test** in `sessionDistribution.test.ts` or `GoalsView.test.tsx`:
+   - Create two goals for different scores.
+   - Trigger multi-goal redistribution.
+   - Assert every resulting session whose `tasks` contain items from both scores has a composite
+     name including both score titles.
+
+6. **Resume `/speckit.implement`** to apply the code fix and run the full test suite.

--- a/specs/070-session-task-distribution/spec.md
+++ b/specs/070-session-task-distribution/spec.md
@@ -100,6 +100,7 @@ When a goal generates multiple sessions, those sessions are scheduled on consecu
 - **FR-014**: The duration estimation formula MUST produce longer estimates for higher difficulty and lower minResult targets.
 - **FR-015**: Tasks MUST be ordered by phrase progression: all three hand variants (RH, LH, BH) of phrase 1 first, then phrase 2, etc. When distributing across sessions, same-phrase tasks MUST always be kept together in the same session (phrase triplet is the atomic distribution unit). A session may exceed its availableTime to keep a phrase group intact.
 - **FR-016**: If creating a goal would generate sessions that push the total session count above the 50-session storage cap, the system MUST warn the user with the number of sessions to be created and the number of oldest closed sessions that will be evicted, and proceed only upon user confirmation.
+- **FR-017**: The `DistributedSession` intermediate type MUST include a `scoreTitles: string[]` field populated with the score titles of all goals whose phrase groups were assigned to that session. The session's human-readable `name` MUST be derived from `scoreTitles.sort().join(' · ')` at the point where the caller (e.g. `GoalsView.tsx`) persists the session. A `DistributedSession` with tasks from only one score MUST carry a single-element `scoreTitles` array.
 
 ### Key Entities
 
@@ -107,6 +108,11 @@ When a goal generates multiple sessions, those sessions are scheduled on consecu
 - **SessionTask**: Extended with difficulty (easy | medium | hard) and estimatedDurationSecs (number, seconds). estimatedDurationSecs represents the total practice time needed to master the phrase (memorize notes, learn fingering, rhythm, accidentals) to reach minResult. Computed at creation time from the task's measure range, staff, loopCount, and minResult.
 - **Goal**: Extended from single sessionId to support multiple session references (sessionIds), since a goal may now span multiple sessions.
 - **PhraseRegion**: Existing entity used for phrase detection. Tasks are generated for each detected phrase.
+- **DistributedSession**: An intermediate (in-memory) result type returned by `distributeTasks()`. Carries `tasks: SessionTask[]`, `totalEstimatedDurationSecs: number`, `availableTime: number`, and `scoreTitles: string[]` (added — BUG-002). The caller derives the persisted session `name` from `scoreTitles.sort().join(' · ')`.
+
+## Known Issues & Regression Tests
+
+**Bugfix**: 2026-05-22 — BUG-002 Added FR-017 mandating `DistributedSession.scoreTitles` and composite session `name` derivation. T037 and T045 in tasks.md reopened. Root cause: `DistributedSession` had no `name`/`scoreTitles` field; `GoalsView.tsx` set session names ad-hoc without recomputing when tasks from a second goal were added.
 
 ## Success Criteria *(mandatory)*
 

--- a/specs/070-session-task-distribution/tasks.md
+++ b/specs/070-session-task-distribution/tasks.md
@@ -114,7 +114,7 @@
 
 - [X] T035 [US3] Create `PhraseGroup` type `{ phraseIndex: number, tasks: SessionTask[], totalDuration: number }` in plugins-external/sessions-plugin/sessionDistribution.ts
 - [X] T036 [US3] Implement `distributeTasks(phraseGroups: PhraseGroup[], availableTime: number): DistributedSession[]` using greedy first-fit algorithm per research.md Topic 3 in plugins-external/sessions-plugin/sessionDistribution.ts
-- [X] T037 [US3] Each `DistributedSession` has `tasks: SessionTask[]`, `totalEstimatedDurationSecs: number`, `availableTime: number` in plugins-external/sessions-plugin/sessionDistribution.ts
+- [X] T037 [US3] Each `DistributedSession` has `tasks: SessionTask[]`, `totalEstimatedDurationSecs: number`, `availableTime: number`, **and `scoreTitles: string[]` (sorted score titles of all contributing goals — used by caller to set session `name`)** in plugins-external/sessions-plugin/sessionDistribution.ts (reopened — BUG-002: `scoreTitles` field was missing; session naming left to ad-hoc caller logic)
 - [X] T038 [US3] Verify all distribution tests pass: `npm test -- --filter sessionDistribution`
 
 **Checkpoint**: Session distribution algorithm ready — tasks correctly binned into time-limited sessions.
@@ -147,7 +147,7 @@
 
 **Purpose**: Wire up all modules in the GoalsView orchestration flow and persist sessions
 
-- [X] T045 Update `processScoreSelection()` in plugins-external/sessions-plugin/GoalsView.tsx to: call `getRegionDifficulty()` for each phrase × staff, call `estimateTaskDuration()` for each task, call `distributeTasks()` to get session groups, call `findFreeDays()` for scheduling
+- [X] T045 Update `processScoreSelection()` in plugins-external/sessions-plugin/GoalsView.tsx to: call `getRegionDifficulty()` for each phrase × staff, call `estimateTaskDuration()` for each task, call `distributeTasks()` to get session groups, call `findFreeDays()` for scheduling, **and set each created session's `name` from `distributedSession.scoreTitles.sort().join(' · ')` — MUST NOT set name from creating goal's score title alone** (reopened — BUG-002: session-creation step after `distributeTasks()` set name ad-hoc without recomputing when a second goal's tasks are present)
 - [X] T046 Add eviction warning check in plugins-external/sessions-plugin/GoalsView.tsx: if `currentSessionCount + newSessionCount > MAX_SESSIONS`, show confirm dialog with eviction impact per research.md Topic 5 (FR-016)
 - [X] T047 Create and persist multiple sessions with assigned targetDates and `availableTime=3600` in plugins-external/sessions-plugin/GoalsView.tsx
 - [X] T048 Set `goal.sessionIds` to array of all created session IDs in plugins-external/sessions-plugin/GoalsView.tsx
@@ -285,3 +285,7 @@ Phase 1 (Setup) ─────────────► Phase 2 (Foundational
 2. Add US2 (Duration) + US1 (Multi-phrase) → MVP: all tasks generated with estimates
 3. Add US3 (Distribution) + US4 (Scheduling) → Full: tasks distributed into time-limited, scheduled sessions
 4. Integration + Polish → Production-ready with UI display and eviction warnings
+
+---
+
+**Bugfix**: 2026-05-22 — BUG-002 Updated from bugfix patch. T037 reopened (`DistributedSession` missing `scoreTitles: string[]` field per new FR-017). T045 reopened (`processScoreSelection()` session-creation step must derive `name` from `distributedSession.scoreTitles.sort().join(' · ')`). No new tasks added here — the regression test is tracked in specs/087-one-goal-40pct-cap/tasks.md as T028.

--- a/specs/087-one-goal-40pct-cap/plan.md
+++ b/specs/087-one-goal-40pct-cap/plan.md
@@ -74,3 +74,7 @@ No changes to `backend/`, `frontend/`, or any other plugin.
 ## Complexity Tracking
 
 No constitution violations — table not needed.
+
+---
+
+**Bugfix**: 2026-05-22 — BUG-002 Updated from bugfix patch. `redistributeWithMultiGoalCap` in `GoalsView.tsx` must compute each new session's `name` from `[...new Set(distributedSession.goalIds.map(gid => goalMap[gid]?.scoreTitle ?? gid))].sort().join(' · ')` before persisting. The existing plan's step 8 ("create new sessions with `goalIds` field") implicitly omitted the `name` field derivation — that omission is the root cause tracked in BUG-002. New regression task T028 added to Phase 6.

--- a/specs/087-one-goal-40pct-cap/spec.md
+++ b/specs/087-one-goal-40pct-cap/spec.md
@@ -77,6 +77,7 @@ A student has two large goals, each with enough tasks to fill two sessions on th
 - **FR-006**: Tasks that have no estimated duration MUST be excluded from per-goal time calculations and distributed freely without consuming any goal's 40% allocation.
 - **FR-007**: The system MUST re-apply the 40% per-goal cap to each generated session independently when excess tasks spill into future sessions.
 - **FR-008**: The cap enforcement MUST be transparent to the user — no warnings, labels, or indicators about the cap are displayed in the session view.
+- **FR-009**: When a session contains tasks from goals linked to two or more distinct scores, the session's `name` MUST be recomputed as the contributing score titles sorted alphabetically and joined by `' · '` (e.g. `'Arabesque · Bach: Invention No. 1'`). The composite name MUST be derived at session-creation or redistribution time from the union of all contributing goal score titles — it MUST NOT retain a single-score name from a prior creation pass.
 
 ### Key Entities
 
@@ -94,6 +95,7 @@ A student has two large goals, each with enough tasks to fill two sessions on th
 - **SC-003**: All tasks from all active goals are accounted for across scheduled sessions — zero tasks are silently dropped as a result of the 40% cap enforcement.
 - **SC-004**: The existing session generation behaviour for unlimited-time sessions remains unchanged; no regression in task distribution for sessions without a time budget.
 - **SC-005**: The time to generate sessions does not increase perceptibly compared to the pre-feature baseline — the cap calculation is a lightweight O(n) pass over task lists.
+- **SC-006**: Every session containing tasks from two or more distinct scores carries a composite `name` equal to the sorted score titles joined by `' · '` — verifiable by inspecting the session's `name` field after `redistributeWithMultiGoalCap` completes.
 
 ## Assumptions
 
@@ -101,5 +103,9 @@ A student has two large goals, each with enough tasks to fill two sessions on th
 - The 40% cap is computed using each task's estimated duration. Tasks without an estimated duration are treated as zero-duration for cap purposes and do not count against any goal's allocation.
 - The cap is applied at session-generation time, not retroactively to already-created sessions.
 - Goal identity is tracked per task (each task records which goal created it). Tasks with no goal association (legacy/manual tasks) are not subject to the cap and are distributed freely.
+
+## Known Issues & Regression Tests
+
+**Bugfix**: 2026-05-22 — BUG-002 Added FR-009 (composite session naming) and SC-006 (verifiable composite title). T023 and T009 in tasks.md reopened; regression task T028 added. Root cause: no spec defined session `name` composition for multi-score sessions — `redistributeWithMultiGoalCap` created sessions using only the creating goal's score title.
 - When a single task exceeds the per-goal 40% budget, it is included regardless — best-effort enforcement, not strict enforcement.
 

--- a/specs/087-one-goal-40pct-cap/tasks.md
+++ b/specs/087-one-goal-40pct-cap/tasks.md
@@ -51,7 +51,7 @@
 - [X] T006 [P] [US1] Add `distributeMultiGoalTasks` test: two goals, each capped at 40% of `availableTime` per session — in `sessionDistribution.test.ts`
 - [X] T007 [P] [US1] Add `distributeMultiGoalTasks` test: oversized first phrase group of a goal is always admitted (best-effort, FR-005) — in `sessionDistribution.test.ts`
 - [X] T008 [P] [US1] Add `distributeMultiGoalTasks` test: three goals simultaneously balanced in a session (each ≤ 40%) — in `sessionDistribution.test.ts`
-- [X] T009 [P] [US1] Add `distributeMultiGoalTasks` test: `DistributedSession.goalIds` is populated with the correct goal IDs per session — in `sessionDistribution.test.ts`
+- [X] T009 [P] [US1] Add `distributeMultiGoalTasks` test: `DistributedSession.goalIds` is populated with the correct goal IDs per session; **also assert that when two goals reference different scores, every session spanning both scores carries a composite `name` equal to the sorted score titles joined by `' · '`** — in `sessionDistribution.test.ts` (reopened — BUG-002: test never asserted composite session title; naming defect passed undetected)
 - [X] T010 [P] [US1] Add `distributeMultiGoalTasks` test: zero-duration tasks (no `estimatedDurationSecs`) do not consume any goal budget and are placed freely — in `sessionDistribution.test.ts`
 
 ### Implementation for User Story 1
@@ -104,7 +104,7 @@
 
 - [X] T021 [US3] Implement `reconstructPhraseGroupsFromTasks(tasks: readonly SessionTask[]): GoalPhraseGroup[]` in `goalEngine.ts` — groups tasks by `(goalId, startMeasure, endMeasure)`, sorts by `startMeasure`, excludes warmup and non-todo tasks (see data-model.md §6)
 - [X] T022 [US3] Update `GoalsView.tsx` `handleGoalSubmit` to detect other active `learn-score-phrase` goals via `listGoalsIndex()` and select the multi-goal redistribution path when `otherActiveGoalIds.length > 0`
-- [X] T023 [US3] Implement `redistributeWithMultiGoalCap` orchestration in `GoalsView.tsx`: (1) load other active goals from IndexedDB, (2) load their `scheduled` sessions, (3) extract pending tasks, (4) cancel those sessions (delete IndexedDB + remove index), (5) call `reconstructPhraseGroupsFromTasks` for each goal, (6) annotate new goal's phrase groups with `goalId`, (7) call `distributeMultiGoalTasks`, (8) create new sessions with `goalIds` field, (9) assign free days via `findFreeDays`, (10) update each contributing goal's `sessionIds`
+- [X] T023 [US3] Implement `redistributeWithMultiGoalCap` orchestration in `GoalsView.tsx`: (1) load other active goals from IndexedDB, (2) load their `scheduled` sessions, (3) extract pending tasks, (4) cancel those sessions (delete IndexedDB + remove index), (5) call `reconstructPhraseGroupsFromTasks` for each goal, (6) annotate new goal's phrase groups with `goalId`, (7) call `distributeMultiGoalTasks`, (8) create new sessions with `goalIds` field, (9) assign free days via `findFreeDays`, (10) update each contributing goal's `sessionIds`, **(11) compute each new session's `name` as `[...new Set(distributedSession.goalIds.map(gid => goalMap[gid]?.scoreTitle ?? gid))].sort().join(' · ')` — MUST NOT reuse prior session name** (reopened — BUG-002: step 11 was missing; sessions were named after only the creating goal's score title)
 - [X] T024 [US3] Update session creation in `redistributeWithMultiGoalCap` to populate `Session.goalIds` and `SessionIndexEntry.goalIds` from `DistributedSession.goalIds` — in `GoalsView.tsx`
 
 **Checkpoint**: All T018–T020 tests pass. Multi-goal redistribution creates balanced sessions and every task from every goal appears in exactly one scheduled session.
@@ -118,6 +118,7 @@
 - [X] T025 [P] Run full `sessions-plugin` test suite (`npx vitest run --reporter=verbose`) and confirm all tests pass with no regressions
 - [X] T026 [P] Update `FEATURES.md` at repo root to reflect the 40% per-goal cap as a new balancing behaviour of the Goals system
 - [X] T027 Run the quickstart.md §Verification Scenario manually (Goal A then Goal B) and confirm balanced distribution and no dropped tasks
+- [X] T028 [P] [US3] Add regression test: create two goals linked to different scores (e.g. Arabesque and Bach Invention No. 1), trigger `redistributeWithMultiGoalCap`, and assert that every `DistributedSession` whose `goalIds` spans both scores has `name === 'Arabesque · Bach: Invention No. 1'` (sorted, joined by `' · '`) — in `plugins-external/sessions-plugin/GoalsView.test.tsx` or `sessionDistribution.test.ts` (added — BUG-002)
 
 ---
 
@@ -202,3 +203,7 @@ npx vitest run sessionDistribution --reporter=verbose  # verify T006-T010 PASS
 - User story tasks: [US1], [US2], or [US3] label ✅
 - Parallelizable tasks: [P] marker ✅
 - All tasks include file paths ✅
+
+---
+
+**Bugfix**: 2026-05-22 — BUG-002 Updated from bugfix patch. T009 reopened (missing composite-title assertion). T023 reopened (session `name` derivation step 11 missing). T028 added (regression test: composite title on multi-score sessions). Total tasks: 28 (27 previously, +1 added, 2 reopened).


### PR DESCRIPTION
## Bug

When creating a new goal for the Bach Invention No. 1 preloaded song, practice tasks are correctly scheduled across all measures — but some tasks are placed into **existing sessions** that have free space. Those sessions retain their old title (only referencing the original score), even though they now contain tasks from a second score.

## Fix

When a session contains tasks from multiple scores, its `name` must be recomputed as the sorted, deduplicated score titles joined by `' · '`
e.g. `'Arabesque · Bach: Invention No. 1'`

The code fix lives in `aylabs/graditone-pro-plugins` (separate PR covers `sessionDistribution.ts`, `GoalsView.tsx`, and tests).

## Spec Artifacts Changed

| File | Change |
|---|---|
| `specs/067-practice-goals-tab/bugs/BUG-001.md` | Added (superseded incorrect diagnosis) |
| `specs/067-practice-goals-tab/bugs/BUG-002.md` | Added — correct bug report, status: Patched |
| `specs/087-one-goal-40pct-cap/spec.md` | FR-009 (composite naming rule) + SC-006 |
| `specs/087-one-goal-40pct-cap/tasks.md` | Reopened T009, T023; added T028 regression task |
| `specs/087-one-goal-40pct-cap/plan.md` | Bugfix note with root cause |
| `specs/070-session-task-distribution/spec.md` | FR-017 (DistributedSession.scoreTitles: string[]) |
| `specs/070-session-task-distribution/tasks.md` | Reopened T037, T045 |