### PR TITLE
fix(072): practice max score always 100 regardless of tempo

### DIFF
--- a/frontend/src/plugin-api/computePracticeScore.test.ts
+++ b/frontend/src/plugin-api/computePracticeScore.test.ts
@@ -1,9 +1,8 @@
 /**
- * computePracticeScore.test.ts — Unit tests for tempo-weighted practice scoring.
- * Feature 072: Tempo Impact on Practice and Train Results
+ * computePracticeScore.test.ts — Unit tests for practice scoring.
  *
- * TDD: these tests are written BEFORE the implementation changes (T003).
- * They MUST fail until T004 is applied to computePracticeScore.ts.
+ * Score is based purely on accuracy. Tempo does not affect the max score —
+ * a perfect performance always earns 100 regardless of tempo multiplier.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -56,9 +55,9 @@ describe('computePracticeScore — tempoMultiplier 1.0', () => {
 // ─── tempoMultiplier = 0.5 (half speed) ──────────────────────────────────────
 
 describe('computePracticeScore — tempoMultiplier 0.5', () => {
-  it('returns score of 50 for all-correct notes at 0.5× (SC-001)', () => {
+  it('returns score of 100 for all-correct notes at 0.5× (max score unaffected by tempo)', () => {
     const result = computePracticeScore(allCorrect(10), 0.5);
-    expect(result?.score).toBe(50);
+    expect(result?.score).toBe(100);
   });
 
   it('stores tempoMultiplier 0.5 in the breakdown', () => {
@@ -66,15 +65,16 @@ describe('computePracticeScore — tempoMultiplier 0.5', () => {
     expect(result?.tempoMultiplier).toBe(0.5);
   });
 
-  it('halves the raw accuracy score at 0.5× (partial accuracy)', () => {
+  it('score at 0.5× equals score at 1.0× for the same accuracy', () => {
     // 8/10 correct = 80% raw, 2 wrong attempts → rawScore = round(80 - 4) = 76
-    // adjusted = round(76 * 0.5) = 38
     const notes = [
       ...allCorrect(8),
       ...allWrong(2),
     ];
-    const result = computePracticeScore(notes, 0.5);
-    expect(result?.score).toBe(38);
+    const at05x = computePracticeScore(notes, 0.5);
+    const at10x = computePracticeScore(notes, 1.0);
+    expect(at05x?.score).toBe(at10x?.score);
+    expect(at05x?.score).toBe(76);
   });
 });
 
@@ -96,7 +96,6 @@ describe('computePracticeScore — tempoMultiplier > 1.0', () => {
 
 describe('computePracticeScore — edge cases', () => {
   it('treats tempoMultiplier = 0 as 1.0 (guard for invalid legacy data)', () => {
-    // Should not score 0 — treat as neutral
     const result = computePracticeScore(allCorrect(10), 0);
     expect(result?.score).toBe(100);
   });
@@ -106,10 +105,10 @@ describe('computePracticeScore — edge cases', () => {
     expect(result?.score).toBe(100);
   });
 
-  it('score at 0.5× is strictly less than score at 1.0× for same accuracy (FR-001)', () => {
+  it('score at 0.5× equals score at 1.0× for same accuracy (tempo does not reduce score)', () => {
     const notes = allCorrect(10);
     const at1x = computePracticeScore(notes, 1.0)!.score;
     const atHalf = computePracticeScore(notes, 0.5)!.score;
-    expect(at1x).toBeGreaterThan(atHalf);
+    expect(at1x).toBe(atHalf);
   });
 });

--- a/frontend/src/plugin-api/computePracticeScore.ts
+++ b/frontend/src/plugin-api/computePracticeScore.ts
@@ -18,9 +18,9 @@ export interface PracticeScoreBreakdown {
   readonly lateCount: number;
   readonly earlyReleaseCount: number;
   readonly totalWrongAttempts: number;
-  /** 0–100, clamped. Reflects tempo weighting when tempoMultiplier < 1.0. */
+  /** 0–100, clamped. Based solely on accuracy — tempo does not affect max score. */
   readonly score: number;
-  /** The tempoMultiplier applied to produce `score`. 1.0 when not supplied. */
+  /** The tempoMultiplier recorded for informational purposes. 1.0 when not supplied. */
   readonly tempoMultiplier: number;
 }
 
@@ -28,10 +28,9 @@ export interface PracticeScoreBreakdown {
  * Compute the practice score from an array of note results.
  *
  * @param noteResults    Per-note outcomes and wrong-attempt counts.
- * @param tempoMultiplier  Optional tempo multiplier (0–∞). Values ≤ 0 or absent
- *                         default to 1.0. Values > 1.0 are clamped to 1.0 so a
- *                         perfect performance at any speed still earns 100.
- *                         Formula: `score = clamp(round(rawAccuracy × min(1.0, mult)), 0, 100)`
+ * @param tempoMultiplier  Optional tempo multiplier, recorded in the breakdown for
+ *                         informational purposes only. Does not affect the score —
+ *                         a perfect performance always earns 100 regardless of tempo.
  *
  * Returns `null` when the array is empty (no notes to score).
  */
@@ -55,11 +54,8 @@ export function computePracticeScore(
         )
       : 0;
 
-  // Feature 072: Apply multiplicative tempo weighting.
-  // Guard: treat absent, zero, or negative multipliers as neutral (1.0).
+  const score = Math.max(0, Math.min(100, rawScore));
   const safeMult = tempoMultiplier != null && tempoMultiplier > 0 ? tempoMultiplier : 1.0;
-  const effectiveMult = Math.min(1.0, safeMult);
-  const score = Math.max(0, Math.min(100, Math.round(rawScore * effectiveMult)));
 
-  return { totalNotes, correctCount, lateCount, earlyReleaseCount, totalWrongAttempts, score, tempoMultiplier: effectiveMult };
+  return { totalNotes, correctCount, lateCount, earlyReleaseCount, totalWrongAttempts, score, tempoMultiplier: safeMult };
 }


### PR DESCRIPTION
## Problem

When practicing with a tempo set below 100%, the max achievable score was capped at the tempo percentage:
- 50% tempo → max score **50**
- 70% tempo → max score **70**

A perfect performance should always yield **100** regardless of tempo.

## Root Cause

`computePracticeScore.ts` was multiplying `rawScore` by the `tempoMultiplier`:

```ts
// Before (buggy)
const score = Math.round(rawScore * effectiveMult);  // 100 * 0.5 = 50 ❌
```

## Fix

The `tempoMultiplier` is now stored in the breakdown for informational purposes only and no longer affects the score:

```ts
// After (fixed)
const score = Math.max(0, Math.min(100, rawScore));  // 100 ✅
```

## Changes

- `frontend/src/plugin-api/computePracticeScore.ts` — removed tempo weighting from score calculation
- `frontend/src/plugin-api/computePracticeScore.test.ts` — updated tests to assert correct behavior (max score 100 at any tempo for a perfect performance)