### PR TITLE
practice: fix Free Practice button regression and pre-commit worktree support

### DIFF
--- a/frontend/plugins/practice-view-plugin/ARCHITECTURE.md
+++ b/frontend/plugins/practice-view-plugin/ARCHITECTURE.md
@@ -161,9 +161,9 @@ File: `frontend/src/plugin-api/PluginStaffViewer.tsx`
 
 ## Build Constraints
 
-- `frontend/node_modules` does not exist in the worktree — must copy files to the main repo at `/Users/alvaro.delcastillo/devel/graditone` to build
-- Pre-commit hook fails in worktrees — always use `git commit --no-verify`
-- Files to copy for a build test: all new/modified `.tsx/.ts` files under `frontend/plugins/practice-view-plugin/` and `frontend/src/plugin-api/` + `frontend/src/services/savedPractice*.ts`
+- `frontend/node_modules` is not pre-installed in worktrees. The pre-commit hook auto-runs `npm install --prefer-offline` on first commit, so dependencies are installed automatically.
+- The backend (`cargo`) shares the main repo's `~/.cargo` registry and `backend/target/` — no extra setup needed.
+- Files changed in the worktree are committed directly; no manual copy to the main repo is required.
 
 ---
 


### PR DESCRIPTION
## What changed

### Fix: Free Practice button regression (`PracticeViewPlugin.tsx`)
The previous PR (#481) accidentally merged the old 1211-line pre-refactor version of `PracticeViewPlugin.tsx` (from the main repo snapshot), losing the DDD-refactored version that wires `useFreePractice` and passes `onFreePractice` to `<ScoreSelector>`. This PR restores the correct 963-line refactored orchestrator.

### Fix: Pre-commit hook in worktrees
The pre-commit hook used bare `cd backend` / `cd frontend` which resolved relative to the worktree root — where `node_modules/` doesn't exist. Two improvements:
- Added `REPO_ROOT=$(git rev-parse --show-toplevel)` at the top so all `cd` calls are explicit
- Added `npm install --prefer-offline` guard when `node_modules` is missing (uses npm cache, ~seconds)
- Made `cd ..` calls explicit (`cd "$REPO_ROOT"`) for safety

### Docs: Remove `--no-verify` workaround advice
`ARCHITECTURE.md` previously advised using `git commit --no-verify` in worktrees since the hook would fail. Now that the hook handles worktrees correctly, that advice is removed and replaced with accurate notes.

## Why
- Free Practice button was silently invisible after PR #481 merged
- Pre-commit was skipped in worktrees, allowing unformatted/linting errors to slip in
- `--no-verify` advice was actively harmful and inconsistent with a healthy CI workflow

## Testing
- Pre-commit hook runs and passes in the worktree (confirmed: `05fcd82` committed without `--no-verify`)
- Free Practice button visible in ScoreSelector when accessed via Practice plugin
